### PR TITLE
Feature/166 167 168 connection playercount

### DIFF
--- a/app/src/main/kotlin/at/aau/pulverfass/app/lobby/LobbyController.kt
+++ b/app/src/main/kotlin/at/aau/pulverfass/app/lobby/LobbyController.kt
@@ -15,6 +15,7 @@ import at.aau.pulverfass.shared.message.lobby.event.GameStartedEvent
 import at.aau.pulverfass.shared.message.lobby.event.GameStateDeltaEvent
 import at.aau.pulverfass.shared.message.lobby.event.GameStateSnapshotBroadcast
 import at.aau.pulverfass.shared.message.lobby.event.PhaseBoundaryEvent
+import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerJoinedLobbyEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerKickedLobbyEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerLeftLobbyEvent
@@ -953,6 +954,7 @@ class LobbyController(
                 _state.update { it.copy(errorText = payload.reason) }
             }
             is PlayerJoinedLobbyEvent -> handlePlayerJoined(payload)
+            is PlayerConnectionLostEvent -> handlePlayerConnectionLost(payload)
             is PlayerLeftLobbyEvent -> {
                 playersById.remove(payload.playerId.value)
                 publishPlayers()
@@ -1032,11 +1034,13 @@ class LobbyController(
     }
 
     private fun handlePlayerJoined(payload: PlayerJoinedLobbyEvent) {
+        val existingPlayer = playersById[payload.playerId.value]
         playersById[payload.playerId.value] =
             LobbyPlayerUi(
                 playerId = payload.playerId,
                 displayName = payload.playerDisplayName,
                 isHost = payload.isHost,
+                isDisconnected = existingPlayer?.isDisconnected ?: false,
             )
 
         _state.update { current ->
@@ -1045,6 +1049,13 @@ class LobbyController(
                     ?: payload.playerId.takeIf { payload.playerDisplayName == current.playerName }
             current.copy(ownPlayerId = ownPlayerId)
         }
+        publishPlayers()
+    }
+
+    private fun handlePlayerConnectionLost(payload: PlayerConnectionLostEvent) {
+        val existingPlayer = playersById[payload.playerId.value] ?: return
+        playersById[payload.playerId.value] =
+            existingPlayer.copy(isDisconnected = true)
         publishPlayers()
     }
 

--- a/app/src/main/kotlin/at/aau/pulverfass/app/lobby/LobbyPlayerUi.kt
+++ b/app/src/main/kotlin/at/aau/pulverfass/app/lobby/LobbyPlayerUi.kt
@@ -12,4 +12,5 @@ data class LobbyPlayerUi(
     val playerId: PlayerId,
     val displayName: String,
     val isHost: Boolean = false,
+    val isDisconnected: Boolean = false,
 )

--- a/app/src/main/kotlin/at/aau/pulverfass/app/ui/screens/WaitingRoomScreen.kt
+++ b/app/src/main/kotlin/at/aau/pulverfass/app/ui/screens/WaitingRoomScreen.kt
@@ -50,10 +50,19 @@ fun WaitingRoomScreen(
     val effectiveIsHost = state.isHost || isHost
     val players =
         if (state.players.isEmpty()) {
-            listOf(WaitingRoomPlayerUi(displayName = effectivePlayerName, isHost = effectiveIsHost))
+            listOf(
+                WaitingRoomPlayerUi(
+                    displayName = effectivePlayerName,
+                    isHost = effectiveIsHost,
+                ),
+            )
         } else {
             state.players.map {
-                WaitingRoomPlayerUi(displayName = it.displayName, isHost = it.isHost)
+                WaitingRoomPlayerUi(
+                    displayName = it.displayName,
+                    isHost = it.isHost,
+                    isDisconnected = it.isDisconnected,
+                )
             }
         }
 
@@ -110,6 +119,7 @@ fun WaitingRoomScreen(
 private data class WaitingRoomPlayerUi(
     val displayName: String,
     val isHost: Boolean,
+    val isDisconnected: Boolean = false,
 )
 
 @Composable
@@ -157,6 +167,7 @@ private fun PlayerListCard(
                     PlayerRow(
                         player = player.displayName,
                         isHostPlayer = player.isHost,
+                        isDisconnected = player.isDisconnected,
                     )
                 }
             }
@@ -168,6 +179,7 @@ private fun PlayerListCard(
 private fun PlayerRow(
     player: String,
     isHostPlayer: Boolean,
+    isDisconnected: Boolean,
 ) {
     Row(
         modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
@@ -180,6 +192,14 @@ private fun PlayerRow(
                 text = stringResource(id = R.string.host_tag),
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.secondary,
+            )
+        }
+        if (isDisconnected) {
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = stringResource(id = R.string.disconnected_tag),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.error,
             )
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="waiting_for_host">Warte auf Host zum Starten...</string>
     <string name="players">Spieler</string>
     <string name="host_tag">(Host)</string>
+    <string name="disconnected_tag">(Getrennt)</string>
     <string name="start_game">Spiel starten</string>
     <string name="need_players">Mindestens 3 Spieler benötigt</string>
     <string name="leave_lobby">Lobby verlassen</string>

--- a/app/src/test/kotlin/at/aau/pulverfass/app/lobby/LobbyControllerTest.kt
+++ b/app/src/test/kotlin/at/aau/pulverfass/app/lobby/LobbyControllerTest.kt
@@ -9,6 +9,8 @@ import at.aau.pulverfass.shared.message.connection.response.ConnectionResponse
 import at.aau.pulverfass.shared.message.connection.response.ReconnectErrorCode
 import at.aau.pulverfass.shared.message.connection.response.ReconnectResponse
 import at.aau.pulverfass.shared.message.lobby.event.GameStartedEvent
+import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostEvent
+import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostReason
 import at.aau.pulverfass.shared.message.lobby.event.PlayerJoinedLobbyEvent
 import at.aau.pulverfass.shared.message.lobby.request.CreateLobbyRequest
 import at.aau.pulverfass.shared.message.lobby.request.GameStateCatchUpRequest
@@ -282,6 +284,88 @@ class LobbyControllerTest {
                 waitUntil { seenPayloads.any { it is GameStateCatchUpRequest } }
 
                 assertTrue(controller.state.value.gameState.isCatchingUp)
+            } finally {
+                controller.close()
+                server.close()
+            }
+        }
+    }
+
+    @Test
+    fun `player connection lost event should mark lobby member as disconnected`() {
+        runBlocking {
+            val lobbyCode = LobbyCode("DL42")
+            val server =
+                startProtocolServer(
+                    onOpenPayload =
+                        ConnectionResponse(
+                            SessionToken("123e4567-e89b-12d3-a456-426614174240"),
+                        ),
+                ) { payload, outgoing ->
+                    if (payload is JoinLobbyRequest) {
+                        outgoing.send(
+                            Frame.Binary(
+                                true,
+                                MessageCodec.encode(JoinLobbyResponse(payload.lobbyCode)),
+                            ),
+                        )
+                        outgoing.send(
+                            Frame.Binary(
+                                true,
+                                MessageCodec.encode(
+                                    PlayerJoinedLobbyEvent(
+                                        lobbyCode = payload.lobbyCode,
+                                        playerId = PlayerId(1),
+                                        playerDisplayName = payload.playerDisplayName,
+                                        isHost = true,
+                                    ),
+                                ),
+                            ),
+                        )
+                        outgoing.send(
+                            Frame.Binary(
+                                true,
+                                MessageCodec.encode(
+                                    PlayerJoinedLobbyEvent(
+                                        lobbyCode = payload.lobbyCode,
+                                        playerId = PlayerId(2),
+                                        playerDisplayName = "Bob",
+                                    ),
+                                ),
+                            ),
+                        )
+                        outgoing.send(
+                            Frame.Binary(
+                                true,
+                                MessageCodec.encode(
+                                    PlayerConnectionLostEvent(
+                                        lobbyCode = payload.lobbyCode,
+                                        playerId = PlayerId(2),
+                                        reason = PlayerConnectionLostReason.SOCKET_CLOSED,
+                                    ),
+                                ),
+                            ),
+                        )
+                    }
+                }
+            val controller = createController()
+            try {
+                controller.updateServerUrl(server.url)
+                controller.updatePlayerName("Alice")
+                controller.updateLobbyCode(lobbyCode.value)
+
+                controller.joinLobby { }
+
+                waitUntil {
+                    controller.state.value.players.any { player ->
+                        player.playerId == PlayerId(2) && player.isDisconnected
+                    }
+                }
+
+                val disconnectedPlayer =
+                    controller.state.value.players.first { it.playerId == PlayerId(2) }
+                assertEquals("Bob", disconnectedPlayer.displayName)
+                assertTrue(disconnectedPlayer.isDisconnected)
             } finally {
                 controller.close()
                 server.close()

--- a/server/src/main/kotlin/at/aau/pulverfass/server/Application.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/Application.kt
@@ -203,11 +203,15 @@ private fun Application.installLobbyRuntime(network: ServerNetwork) {
                 }
 
                 is Network.Event.Disconnected<ConnectionId> -> {
-                    network.sessionManager
-                        .getByConnectionId(event.connectionId)
-                        ?.sessionToken
+                    event.sessionToken
                         ?.let(sessionContextRegistry::playerIdForSession)
-                        ?.let { playerId -> routingService.onPlayerDisconnected(playerId) }
+                        ?.let { playerId ->
+                            routingService.onPlayerDisconnected(
+                                connectionId = event.connectionId,
+                                playerId = playerId,
+                                reason = event.reason,
+                            )
+                        }
                 }
 
                 else -> Unit

--- a/server/src/main/kotlin/at/aau/pulverfass/server/ServerNetwork.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/ServerNetwork.kt
@@ -142,9 +142,15 @@ class ServerNetwork(
         connectionId: ConnectionId,
         reason: String?,
     ) {
-        sessionManager.detachConnection(connectionId)
+        val detachedSession = sessionManager.detachConnection(connectionId)
         transport.onDisconnected(connectionId, reason)
-        _events.emit(Network.Event.Disconnected(connectionId, reason))
+        _events.emit(
+            Network.Event.Disconnected(
+                connectionId = connectionId,
+                reason = reason,
+                sessionToken = detachedSession?.sessionToken,
+            ),
+        )
     }
 
     /**

--- a/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
@@ -31,6 +31,7 @@ import at.aau.pulverfass.shared.message.lobby.request.GameStatePrivateGetRequest
 import at.aau.pulverfass.shared.message.lobby.request.JoinLobbyRequest
 import at.aau.pulverfass.shared.message.lobby.request.KickPlayerRequest
 import at.aau.pulverfass.shared.message.lobby.request.LeaveLobbyRequest
+import at.aau.pulverfass.shared.message.lobby.request.LobbyPlayerCountRequest
 import at.aau.pulverfass.shared.message.lobby.request.MapGetRequest
 import at.aau.pulverfass.shared.message.lobby.request.StartGameRequest
 import at.aau.pulverfass.shared.message.lobby.request.StartPlayerSetRequest
@@ -42,6 +43,7 @@ import at.aau.pulverfass.shared.message.lobby.response.GameStatePrivateGetRespon
 import at.aau.pulverfass.shared.message.lobby.response.JoinLobbyResponse
 import at.aau.pulverfass.shared.message.lobby.response.KickPlayerResponse
 import at.aau.pulverfass.shared.message.lobby.response.LeaveLobbyResponse
+import at.aau.pulverfass.shared.message.lobby.response.LobbyPlayerCountResponse
 import at.aau.pulverfass.shared.message.lobby.response.MapGetResponse
 import at.aau.pulverfass.shared.message.lobby.response.StartGameResponse
 import at.aau.pulverfass.shared.message.lobby.response.StartPlayerSetResponse
@@ -54,6 +56,8 @@ import at.aau.pulverfass.shared.message.lobby.response.error.GameStatePrivateGet
 import at.aau.pulverfass.shared.message.lobby.response.error.GameStatePrivateGetErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.JoinLobbyErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.KickPlayerErrorResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.LobbyPlayerCountErrorCode
+import at.aau.pulverfass.shared.message.lobby.response.error.LobbyPlayerCountErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.MapGetErrorCode
 import at.aau.pulverfass.shared.message.lobby.response.error.MapGetErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.StartGameErrorResponse
@@ -141,6 +145,7 @@ class MainServerLobbyRoutingService(
                     payload = payload,
                 )
             is CreateLobbyRequest -> routeCreateLobbyRequest(packet)
+            is LobbyPlayerCountRequest -> routeLobbyPlayerCountRequest(request)
             is MapGetRequest -> routeMapGetRequest(request)
             is GameStateCatchUpRequest -> routeGameStateCatchUpRequest(request)
             is GameStatePrivateGetRequest -> routeGameStatePrivateGetRequest(request)
@@ -300,6 +305,32 @@ class MainServerLobbyRoutingService(
             hooks.onRouted(request.connectionId)
         }.onFailure { cause ->
             val error = mapGetErrorResponse(request, payload, cause)
+            network.send(request.connectionId, error)
+            hooks.onRoutingError(
+                request.connectionId,
+                LobbyRoutingError.InvalidRoutingData(
+                    reason = error.reason,
+                    context =
+                        LobbyRoutingContext(
+                            connectionId = request.connectionId,
+                            messageType = request.receivedPacket.header.type,
+                            lobbyCode = payload.lobbyCode,
+                        ),
+                    cause = cause,
+                ),
+            )
+        }
+    }
+
+    private suspend fun routeLobbyPlayerCountRequest(request: DecodedNetworkRequest) {
+        val payload = request.payload as LobbyPlayerCountRequest
+
+        runCatching {
+            val response = buildLobbyPlayerCountResponse(payload)
+            network.send(request.connectionId, response)
+            hooks.onRouted(request.connectionId)
+        }.onFailure { cause ->
+            val error = lobbyPlayerCountErrorResponse(payload, cause)
             network.send(request.connectionId, error)
             hooks.onRoutingError(
                 request.connectionId,
@@ -949,6 +980,25 @@ class MainServerLobbyRoutingService(
         }
     }
 
+    private fun buildLobbyPlayerCountResponse(
+        payload: LobbyPlayerCountRequest,
+    ): LobbyPlayerCountResponse {
+        val state =
+            lobbyManager.getLobby(payload.lobbyCode)?.currentState()
+                ?: throw IllegalStateException("LOBBY_NOT_FOUND")
+
+        return LobbyPlayerCountResponse(
+            lobbyCode = payload.lobbyCode,
+            playerCount = state.players.size,
+        ).also { response ->
+            logger.info(
+                "Lobby player count served: lobbyCode={} playerCount={}",
+                response.lobbyCode.value,
+                response.playerCount,
+            )
+        }
+    }
+
     private fun turnAdvanceErrorResponse(
         request: DecodedNetworkRequest,
         payload: TurnAdvanceRequest,
@@ -1069,6 +1119,29 @@ class MainServerLobbyRoutingService(
             }
 
         return TurnStateGetErrorResponse(code = code, reason = reason)
+    }
+
+    private fun lobbyPlayerCountErrorResponse(
+        payload: LobbyPlayerCountRequest,
+        cause: Throwable,
+    ): LobbyPlayerCountErrorResponse {
+        val code =
+            when (cause.message) {
+                "LOBBY_NOT_FOUND" -> LobbyPlayerCountErrorCode.LOBBY_NOT_FOUND
+                else -> LobbyPlayerCountErrorCode.LOBBY_NOT_FOUND
+            }
+
+        val reason =
+            when (code) {
+                LobbyPlayerCountErrorCode.LOBBY_NOT_FOUND ->
+                    "Lobby '${payload.lobbyCode.value}' wurde nicht gefunden."
+            }
+
+        return LobbyPlayerCountErrorResponse(
+            lobbyCode = payload.lobbyCode,
+            code = code,
+            reason = reason,
+        )
     }
 
     private suspend fun broadcastAcceptedLobbyEvent(

--- a/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
@@ -20,6 +20,8 @@ import at.aau.pulverfass.shared.lobby.state.TurnStateMachine
 import at.aau.pulverfass.shared.message.connection.request.ReconnectRequest
 import at.aau.pulverfass.shared.message.lobby.event.GameStartedEvent
 import at.aau.pulverfass.shared.message.lobby.event.PhaseBoundaryEvent
+import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostEvent
+import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostReason
 import at.aau.pulverfass.shared.message.lobby.event.PlayerJoinedLobbyEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerKickedLobbyEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerLeftLobbyEvent
@@ -210,8 +212,30 @@ class MainServerLobbyRoutingService(
         }
     }
 
-    suspend fun onPlayerDisconnected(playerId: PlayerId) {
+    suspend fun onPlayerDisconnected(
+        connectionId: ConnectionId,
+        playerId: PlayerId,
+        reason: String?,
+    ) {
+        val currentConnectionId = connectionIdResolver(playerId)
+        if (currentConnectionId != null && currentConnectionId != connectionId) {
+            logger.info(
+                "Ignoring stale disconnect after reconnect: playerId={} staleConnectionId={} " +
+                    "currentConnectionId={}",
+                playerId.value,
+                connectionId.value,
+                currentConnectionId.value,
+            )
+            return
+        }
+
         val lobbyCode = lobbyManager.findLobbyCodeByPlayer(playerId) ?: return
+        broadcastPlayerConnectionLost(
+            lobbyCode = lobbyCode,
+            playerId = playerId,
+            reason = connectionLostReason(reason),
+        )
+
         val previousTurnState = currentTurnState(lobbyCode)
         val currentState = lobbyManager.getLobby(lobbyCode)?.currentState() ?: return
         val currentTurnState = currentState.turnState ?: return
@@ -1237,6 +1261,48 @@ class MainServerLobbyRoutingService(
             pauseReason = TurnPauseReasons.WAITING_FOR_PLAYER,
             pausedPlayerId = pausedPlayerId,
         )
+
+    private suspend fun broadcastPlayerConnectionLost(
+        lobbyCode: LobbyCode,
+        playerId: PlayerId,
+        reason: PlayerConnectionLostReason,
+    ) {
+        val members = lobbyManager.getLobby(lobbyCode)?.currentState()?.players.orEmpty()
+        val event =
+            PlayerConnectionLostEvent(
+                lobbyCode = lobbyCode,
+                playerId = playerId,
+                reason = reason,
+            )
+
+        logger.info(
+            "Connection lost broadcast: lobbyCode={} playerId={} reason={}",
+            lobbyCode.value,
+            playerId.value,
+            reason.name,
+        )
+
+        members
+            .filter { memberId -> memberId != playerId }
+            .mapNotNull(connectionIdResolver)
+            .distinct()
+            .forEach { activeConnectionId ->
+                network.send(activeConnectionId, event)
+            }
+    }
+
+    private fun connectionLostReason(reason: String?): PlayerConnectionLostReason {
+        val normalizedReason = reason?.lowercase().orEmpty()
+        return if (
+            normalizedReason.contains("ping") ||
+            normalizedReason.contains("pong") ||
+            normalizedReason.contains("timeout")
+        ) {
+            PlayerConnectionLostReason.HEARTBEAT_TIMEOUT
+        } else {
+            PlayerConnectionLostReason.SOCKET_CLOSED
+        }
+    }
 
     private fun TurnState.toUpdatedEvent(
         lobbyCode: LobbyCode,

--- a/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
@@ -337,7 +337,7 @@ class MainServerLobbyRoutingService(
             network.send(request.connectionId, response)
             hooks.onRouted(request.connectionId)
         }.onFailure { cause ->
-            val error = lobbyPlayerCountErrorResponse(payload, cause)
+            val error = lobbyPlayerCountErrorResponse(payload)
             logger.warn(
                 "Routing failed messageType={} connectionId={} lobbyCode={} code={} reason={}",
                 MessageType.LOBBY_PLAYER_COUNT_ERROR_RESPONSE.name,
@@ -1141,7 +1141,6 @@ class MainServerLobbyRoutingService(
 
     private fun lobbyPlayerCountErrorResponse(
         payload: LobbyPlayerCountRequest,
-        cause: Throwable,
     ): LobbyPlayerCountErrorResponse {
         val code = LobbyPlayerCountErrorCode.LOBBY_NOT_FOUND
 

--- a/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
@@ -67,6 +67,7 @@ import at.aau.pulverfass.shared.message.lobby.response.error.TurnAdvanceErrorCod
 import at.aau.pulverfass.shared.message.lobby.response.error.TurnAdvanceErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.TurnStateGetErrorCode
 import at.aau.pulverfass.shared.message.lobby.response.error.TurnStateGetErrorResponse
+import at.aau.pulverfass.shared.message.protocol.MessageType
 import at.aau.pulverfass.shared.message.protocol.NetworkMessagePayload
 import at.aau.pulverfass.shared.network.codec.MessageCodec
 import at.aau.pulverfass.shared.network.receive.ReceivedPacket
@@ -324,13 +325,27 @@ class MainServerLobbyRoutingService(
 
     private suspend fun routeLobbyPlayerCountRequest(request: DecodedNetworkRequest) {
         val payload = request.payload as LobbyPlayerCountRequest
+        logger.info(
+            "Routing messageType={} connectionId={} lobbyCode={}",
+            request.receivedPacket.header.type.name,
+            request.connectionId.value,
+            payload.lobbyCode.value,
+        )
 
         runCatching {
-            val response = buildLobbyPlayerCountResponse(payload)
+            val response = buildLobbyPlayerCountResponse(request, payload)
             network.send(request.connectionId, response)
             hooks.onRouted(request.connectionId)
         }.onFailure { cause ->
             val error = lobbyPlayerCountErrorResponse(payload, cause)
+            logger.warn(
+                "Routing failed messageType={} connectionId={} lobbyCode={} code={} reason={}",
+                MessageType.LOBBY_PLAYER_COUNT_ERROR_RESPONSE.name,
+                request.connectionId.value,
+                payload.lobbyCode.value,
+                error.code.name,
+                error.reason,
+            )
             network.send(request.connectionId, error)
             hooks.onRoutingError(
                 request.connectionId,
@@ -981,6 +996,7 @@ class MainServerLobbyRoutingService(
     }
 
     private fun buildLobbyPlayerCountResponse(
+        request: DecodedNetworkRequest,
         payload: LobbyPlayerCountRequest,
     ): LobbyPlayerCountResponse {
         val state =
@@ -992,7 +1008,9 @@ class MainServerLobbyRoutingService(
             playerCount = state.players.size,
         ).also { response ->
             logger.info(
-                "Lobby player count served: lobbyCode={} playerCount={}",
+                "Sent messageType={} connectionId={} lobbyCode={} playerCount={}",
+                MessageType.LOBBY_PLAYER_COUNT_RESPONSE.name,
+                request.connectionId.value,
                 response.lobbyCode.value,
                 response.playerCount,
             )
@@ -1349,7 +1367,8 @@ class MainServerLobbyRoutingService(
             )
 
         logger.info(
-            "Connection lost broadcast: lobbyCode={} playerId={} reason={}",
+            "Broadcasting messageType={} lobbyCode={} playerId={} reason={}",
+            MessageType.LOBBY_PLAYER_CONNECTION_LOST_BROADCAST.name,
             lobbyCode.value,
             playerId.value,
             reason.name,

--- a/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
@@ -1143,11 +1143,7 @@ class MainServerLobbyRoutingService(
         payload: LobbyPlayerCountRequest,
         cause: Throwable,
     ): LobbyPlayerCountErrorResponse {
-        val code =
-            when (cause.message) {
-                "LOBBY_NOT_FOUND" -> LobbyPlayerCountErrorCode.LOBBY_NOT_FOUND
-                else -> LobbyPlayerCountErrorCode.LOBBY_NOT_FOUND
-            }
+        val code = LobbyPlayerCountErrorCode.LOBBY_NOT_FOUND
 
         val reason =
             when (code) {

--- a/server/src/test/kotlin/at/aau/pulverfass/server/LobbyPlayerCountIntegrationTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/LobbyPlayerCountIntegrationTest.kt
@@ -7,8 +7,15 @@ import at.aau.pulverfass.server.routing.MainServerLobbyRoutingServiceHooks
 import at.aau.pulverfass.server.routing.MainServerRouter
 import at.aau.pulverfass.shared.ids.LobbyCode
 import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.lobby.event.TurnStateUpdatedEvent
 import at.aau.pulverfass.shared.lobby.state.GameState
+import at.aau.pulverfass.shared.lobby.state.TurnPhase
+import at.aau.pulverfass.shared.message.lobby.event.PlayerJoinedLobbyEvent
+import at.aau.pulverfass.shared.message.lobby.request.CreateLobbyRequest
+import at.aau.pulverfass.shared.message.lobby.request.JoinLobbyRequest
 import at.aau.pulverfass.shared.message.lobby.request.LobbyPlayerCountRequest
+import at.aau.pulverfass.shared.message.lobby.response.CreateLobbyResponse
+import at.aau.pulverfass.shared.message.lobby.response.JoinLobbyResponse
 import at.aau.pulverfass.shared.message.lobby.response.LobbyPlayerCountResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.LobbyPlayerCountErrorCode
 import at.aau.pulverfass.shared.message.lobby.response.error.LobbyPlayerCountErrorResponse
@@ -26,6 +33,7 @@ import kotlinx.coroutines.coroutineScope
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
 
 class LobbyPlayerCountIntegrationTest {
     @Test
@@ -34,6 +42,8 @@ class LobbyPlayerCountIntegrationTest {
             val network = ServerNetwork()
             val serverScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
             val lobbyManager = LobbyManager(serverScope)
+            val routedPackets = AtomicInteger(0)
+            val routingErrors = AtomicInteger(0)
             val router =
                 MainServerRouter(
                     lobbyManager = lobbyManager,
@@ -45,7 +55,11 @@ class LobbyPlayerCountIntegrationTest {
                     router = router,
                     lobbyManager = lobbyManager,
                     playerIdResolver = { null },
-                    hooks = MainServerLobbyRoutingServiceHooks(),
+                    hooks =
+                        MainServerLobbyRoutingServiceHooks(
+                            onRouted = { routedPackets.incrementAndGet() },
+                            onRoutingError = { _, _ -> routingErrors.incrementAndGet() },
+                        ),
                 )
 
             application {
@@ -87,6 +101,12 @@ class LobbyPlayerCountIntegrationTest {
                         ),
                         receivePayload(requester.first),
                     )
+                    assertEquals(
+                        0,
+                        lobbyManager.getLobby(lobbyCode)?.currentState()?.processedEventCount,
+                    )
+                    assertEquals(1, routedPackets.get())
+                    assertEquals(0, routingErrors.get())
                     assertNull(receivePayloadOrNull(requester.first))
                     assertNull(receivePayloadOrNull(otherClient.first))
 
@@ -165,6 +185,123 @@ class LobbyPlayerCountIntegrationTest {
             }
         }
 
+    @Test
+    fun `player count request is wired through module with lobby runtime`() =
+        testApplication {
+            val network = ServerNetwork()
+
+            application {
+                moduleWithLobbyRuntime(network)
+            }
+
+            val client =
+                createClient {
+                    install(WebSockets)
+                }
+
+            coroutineScope {
+                val hostSession = client.webSocketSession("/ws")
+                receiveTestConnectionToken(hostSession)
+
+                hostSession.send(
+                    Frame.Binary(
+                        fin = true,
+                        data = MessageCodec.encode(CreateLobbyRequest),
+                    ),
+                )
+                val lobbyCode =
+                    (receivePayload(hostSession) as CreateLobbyResponse).lobbyCode
+
+                hostSession.send(
+                    Frame.Binary(
+                        fin = true,
+                        data = MessageCodec.encode(JoinLobbyRequest(lobbyCode, "Alice")),
+                    ),
+                )
+                assertEquals(
+                    JoinLobbyResponse(lobbyCode),
+                    receivePayloadOfType<JoinLobbyResponse>(hostSession),
+                )
+                assertEquals(
+                    PlayerJoinedLobbyEvent(
+                        lobbyCode = lobbyCode,
+                        playerId = PlayerId(1),
+                        playerDisplayName = "Alice",
+                        isHost = true,
+                    ),
+                    receivePayloadOfType<PlayerJoinedLobbyEvent>(hostSession),
+                )
+                assertEquals(
+                    TurnStateUpdatedEvent(
+                        lobbyCode = lobbyCode,
+                        activePlayerId = PlayerId(1),
+                        turnPhase = TurnPhase.REINFORCEMENTS,
+                        turnCount = 1,
+                        startPlayerId = PlayerId(1),
+                    ),
+                    receivePayloadOfType<TurnStateUpdatedEvent>(hostSession),
+                )
+
+                val joinerSession = client.webSocketSession("/ws")
+                receiveTestConnectionToken(joinerSession)
+                joinerSession.send(
+                    Frame.Binary(
+                        fin = true,
+                        data = MessageCodec.encode(JoinLobbyRequest(lobbyCode, "Bob")),
+                    ),
+                )
+                assertEquals(
+                    JoinLobbyResponse(lobbyCode),
+                    receivePayloadOfType<JoinLobbyResponse>(joinerSession),
+                )
+                assertEquals(
+                    PlayerJoinedLobbyEvent(
+                        lobbyCode = lobbyCode,
+                        playerId = PlayerId(1),
+                        playerDisplayName = "Alice",
+                        isHost = true,
+                    ),
+                    receivePayloadOfType<PlayerJoinedLobbyEvent>(joinerSession),
+                )
+                assertEquals(
+                    PlayerJoinedLobbyEvent(
+                        lobbyCode = lobbyCode,
+                        playerId = PlayerId(2),
+                        playerDisplayName = "Bob",
+                    ),
+                    receivePayloadOfType<PlayerJoinedLobbyEvent>(joinerSession),
+                )
+                assertEquals(
+                    PlayerJoinedLobbyEvent(
+                        lobbyCode = lobbyCode,
+                        playerId = PlayerId(2),
+                        playerDisplayName = "Bob",
+                    ),
+                    receivePayloadOfType<PlayerJoinedLobbyEvent>(hostSession),
+                )
+
+                hostSession.send(
+                    Frame.Binary(
+                        fin = true,
+                        data = MessageCodec.encode(LobbyPlayerCountRequest(lobbyCode)),
+                    ),
+                )
+
+                assertEquals(
+                    LobbyPlayerCountResponse(
+                        lobbyCode = lobbyCode,
+                        playerCount = 2,
+                    ),
+                    receivePayload(hostSession),
+                )
+                assertNull(receivePayloadOrNull(hostSession))
+                assertNull(receivePayloadOrNull(joinerSession))
+
+                hostSession.close()
+                joinerSession.close()
+            }
+        }
+
     private fun lobbyState(
         lobbyCode: LobbyCode,
         players: List<PlayerId>,
@@ -193,4 +330,20 @@ class LobbyPlayerCountIntegrationTest {
     private suspend fun receivePayloadOrNull(
         session: io.ktor.client.plugins.websocket.DefaultClientWebSocketSession,
     ): Any? = receiveRelevantTestPayloadOrNull(session = session, timeoutMillis = 500)
+
+    private suspend inline fun <reified T> receivePayloadOfType(
+        session: io.ktor.client.plugins.websocket.DefaultClientWebSocketSession,
+        maxMessages: Int = 6,
+    ): T {
+        repeat(maxMessages) {
+            val payload = receivePayload(session)
+            if (payload is T) {
+                return payload
+            }
+        }
+
+        throw AssertionError(
+            "Expected payload of type ${T::class.java.simpleName} within $maxMessages messages.",
+        )
+    }
 }

--- a/server/src/test/kotlin/at/aau/pulverfass/server/LobbyPlayerCountIntegrationTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/LobbyPlayerCountIntegrationTest.kt
@@ -1,0 +1,196 @@
+package at.aau.pulverfass.server
+
+import at.aau.pulverfass.server.lobby.mapping.DefaultNetworkToLobbyEventMapper
+import at.aau.pulverfass.server.lobby.runtime.LobbyManager
+import at.aau.pulverfass.server.routing.MainServerLobbyRoutingService
+import at.aau.pulverfass.server.routing.MainServerLobbyRoutingServiceHooks
+import at.aau.pulverfass.server.routing.MainServerRouter
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.lobby.state.GameState
+import at.aau.pulverfass.shared.message.lobby.request.LobbyPlayerCountRequest
+import at.aau.pulverfass.shared.message.lobby.response.LobbyPlayerCountResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.LobbyPlayerCountErrorCode
+import at.aau.pulverfass.shared.message.lobby.response.error.LobbyPlayerCountErrorResponse
+import at.aau.pulverfass.shared.network.codec.MessageCodec
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.client.plugins.websocket.webSocketSession
+import io.ktor.server.testing.testApplication
+import io.ktor.websocket.Frame
+import io.ktor.websocket.close
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class LobbyPlayerCountIntegrationTest {
+    @Test
+    fun `player count request replies only to requesting client`() =
+        testApplication {
+            val network = ServerNetwork()
+            val serverScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            val lobbyManager = LobbyManager(serverScope)
+            val router =
+                MainServerRouter(
+                    lobbyManager = lobbyManager,
+                    mapper = DefaultNetworkToLobbyEventMapper(),
+                )
+            val routingService =
+                MainServerLobbyRoutingService(
+                    network = network,
+                    router = router,
+                    lobbyManager = lobbyManager,
+                    playerIdResolver = { null },
+                    hooks = MainServerLobbyRoutingServiceHooks(),
+                )
+
+            application {
+                module(network)
+            }
+
+            val lobbyCode = LobbyCode("PC01")
+            lobbyManager.createLobby(
+                lobbyCode = lobbyCode,
+                initialState =
+                    lobbyState(
+                        lobbyCode = lobbyCode,
+                        players = listOf(PlayerId(1), PlayerId(2), PlayerId(3)),
+                    ),
+            )
+            routingService.start(serverScope)
+
+            val client =
+                createClient {
+                    install(WebSockets)
+                }
+
+            try {
+                coroutineScope {
+                    val requester = connectSession(client, network)
+                    val otherClient = connectSession(client, network)
+
+                    requester.first.send(
+                        Frame.Binary(
+                            fin = true,
+                            data = MessageCodec.encode(LobbyPlayerCountRequest(lobbyCode)),
+                        ),
+                    )
+
+                    assertEquals(
+                        LobbyPlayerCountResponse(
+                            lobbyCode = lobbyCode,
+                            playerCount = 3,
+                        ),
+                        receivePayload(requester.first),
+                    )
+                    assertNull(receivePayloadOrNull(requester.first))
+                    assertNull(receivePayloadOrNull(otherClient.first))
+
+                    requester.first.close()
+                    otherClient.first.close()
+                }
+            } finally {
+                routingService.stop()
+                lobbyManager.shutdownAll()
+                serverScope.cancel()
+            }
+        }
+
+    @Test
+    fun `player count request returns deterministic error for unknown lobby`() =
+        testApplication {
+            val network = ServerNetwork()
+            val serverScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            val lobbyManager = LobbyManager(serverScope)
+            val router =
+                MainServerRouter(
+                    lobbyManager = lobbyManager,
+                    mapper = DefaultNetworkToLobbyEventMapper(),
+                )
+            val routingService =
+                MainServerLobbyRoutingService(
+                    network = network,
+                    router = router,
+                    lobbyManager = lobbyManager,
+                    playerIdResolver = { null },
+                    hooks = MainServerLobbyRoutingServiceHooks(),
+                )
+
+            application {
+                module(network)
+            }
+
+            routingService.start(serverScope)
+
+            val client =
+                createClient {
+                    install(WebSockets)
+                }
+
+            try {
+                coroutineScope {
+                    val requester = connectSession(client, network)
+                    val unknownLobbyCode = LobbyCode("PC99")
+
+                    requester.first.send(
+                        Frame.Binary(
+                            fin = true,
+                            data =
+                                MessageCodec.encode(
+                                    LobbyPlayerCountRequest(unknownLobbyCode),
+                                ),
+                        ),
+                    )
+
+                    assertEquals(
+                        LobbyPlayerCountErrorResponse(
+                            lobbyCode = unknownLobbyCode,
+                            code = LobbyPlayerCountErrorCode.LOBBY_NOT_FOUND,
+                            reason = "Lobby 'PC99' wurde nicht gefunden.",
+                        ),
+                        receivePayload(requester.first),
+                    )
+                    assertNull(receivePayloadOrNull(requester.first))
+
+                    requester.first.close()
+                }
+            } finally {
+                routingService.stop()
+                lobbyManager.shutdownAll()
+                serverScope.cancel()
+            }
+        }
+
+    private fun lobbyState(
+        lobbyCode: LobbyCode,
+        players: List<PlayerId>,
+    ): GameState =
+        GameState(
+            lobbyCode = lobbyCode,
+            lobbyOwner = players.firstOrNull(),
+            players = players,
+            playerDisplayNames = players.associateWith { "Player ${it.value}" },
+            turnOrder = players,
+        )
+
+    private suspend fun connectSession(
+        client: io.ktor.client.HttpClient,
+        network: ServerNetwork,
+    ) = coroutineScope {
+        val session = client.webSocketSession("/ws")
+        val sessionToken = receiveTestConnectionToken(session)
+        session to awaitTestConnectionId(network, sessionToken)
+    }
+
+    private suspend fun receivePayload(
+        session: io.ktor.client.plugins.websocket.DefaultClientWebSocketSession,
+    ): Any = receiveRelevantTestPayload(session)
+
+    private suspend fun receivePayloadOrNull(
+        session: io.ktor.client.plugins.websocket.DefaultClientWebSocketSession,
+    ): Any? = receiveRelevantTestPayloadOrNull(session = session, timeoutMillis = 500)
+}

--- a/server/src/test/kotlin/at/aau/pulverfass/server/MainServerLobbyRoutingIntegrationTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/MainServerLobbyRoutingIntegrationTest.kt
@@ -25,6 +25,8 @@ import at.aau.pulverfass.shared.message.connection.response.ConnectionResponse
 import at.aau.pulverfass.shared.message.connection.response.ReconnectResponse
 import at.aau.pulverfass.shared.message.lobby.event.GameStartedEvent
 import at.aau.pulverfass.shared.message.lobby.event.GameStateDeltaEvent
+import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostEvent
+import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostReason
 import at.aau.pulverfass.shared.message.lobby.event.PlayerJoinedLobbyEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerKickedLobbyEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerLeftLobbyEvent
@@ -1716,6 +1718,109 @@ class MainServerLobbyRoutingIntegrationTest {
                 routingService.stop()
                 lobbyManager.shutdownAll()
                 serverScope.cancel()
+            }
+        }
+
+    @Test
+    fun `disconnect broadcasts player connection lost event only to affected lobby`() =
+        testApplication {
+            val network = ServerNetwork()
+
+            application {
+                moduleWithLobbyRuntime(network)
+            }
+
+            val client =
+                createClient {
+                    install(WebSockets)
+                }
+
+            coroutineScope {
+                val aliceSession = client.webSocketSession("/ws")
+                discardConnectionHandshake(aliceSession)
+                aliceSession.send(
+                    Frame.Binary(
+                        fin = true,
+                        data = MessageCodec.encode(CreateLobbyRequest),
+                    ),
+                )
+                val lobbyA =
+                    assertIs<CreateLobbyResponse>(
+                        receivePayload(aliceSession),
+                    ).lobbyCode
+                aliceSession.send(
+                    Frame.Binary(
+                        fin = true,
+                        data = MessageCodec.encode(JoinLobbyRequest(lobbyA, "Alice")),
+                    ),
+                )
+                assertEquals(JoinLobbyResponse(lobbyA), receivePayload(aliceSession))
+                assertEquals(
+                    PlayerJoinedLobbyEvent(lobbyA, PlayerId(1), "Alice", isHost = true),
+                    receivePayloadOfType<PlayerJoinedLobbyEvent>(aliceSession),
+                )
+
+                val bobSession = client.webSocketSession("/ws")
+                discardConnectionHandshake(bobSession)
+                bobSession.send(
+                    Frame.Binary(
+                        fin = true,
+                        data = MessageCodec.encode(JoinLobbyRequest(lobbyA, "Bob")),
+                    ),
+                )
+                assertEquals(JoinLobbyResponse(lobbyA), receivePayload(bobSession))
+                assertEquals(
+                    PlayerJoinedLobbyEvent(lobbyA, PlayerId(1), "Alice", isHost = true),
+                    receivePayload(bobSession),
+                )
+                assertEquals(
+                    PlayerJoinedLobbyEvent(lobbyA, PlayerId(2), "Bob"),
+                    receivePayloadOfType<PlayerJoinedLobbyEvent>(bobSession),
+                )
+                assertEquals(
+                    PlayerJoinedLobbyEvent(lobbyA, PlayerId(2), "Bob"),
+                    receivePayloadOfType<PlayerJoinedLobbyEvent>(aliceSession),
+                )
+
+                val carolSession = client.webSocketSession("/ws")
+                discardConnectionHandshake(carolSession)
+                carolSession.send(
+                    Frame.Binary(
+                        fin = true,
+                        data = MessageCodec.encode(CreateLobbyRequest),
+                    ),
+                )
+                val lobbyB =
+                    assertIs<CreateLobbyResponse>(
+                        receivePayload(carolSession),
+                    ).lobbyCode
+                carolSession.send(
+                    Frame.Binary(
+                        fin = true,
+                        data = MessageCodec.encode(JoinLobbyRequest(lobbyB, "Carol")),
+                    ),
+                )
+                assertEquals(JoinLobbyResponse(lobbyB), receivePayload(carolSession))
+                assertEquals(
+                    PlayerJoinedLobbyEvent(lobbyB, PlayerId(3), "Carol", isHost = true),
+                    receivePayloadOfType<PlayerJoinedLobbyEvent>(carolSession),
+                )
+                receivePayloadOfType<TurnStateUpdatedEvent>(carolSession)
+
+                bobSession.close()
+
+                assertEquals(
+                    PlayerConnectionLostEvent(
+                        lobbyCode = lobbyA,
+                        playerId = PlayerId(2),
+                        reason = PlayerConnectionLostReason.SOCKET_CLOSED,
+                    ),
+                    receivePayloadOfType<PlayerConnectionLostEvent>(aliceSession),
+                )
+                assertNull(receivePayloadOrNull(carolSession))
+
+                aliceSession.close()
+                carolSession.close()
             }
         }
 

--- a/server/src/test/kotlin/at/aau/pulverfass/server/ServerNetworkIntegrationTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/ServerNetworkIntegrationTest.kt
@@ -94,6 +94,41 @@ class ServerNetworkIntegrationTest {
         }
 
     @Test
+    fun `server network emits disconnected event with detached session token`() =
+        testApplication {
+            val network = ServerNetwork()
+
+            application {
+                module(network)
+            }
+
+            val client =
+                createClient {
+                    install(WebSockets)
+                }
+
+            coroutineScope {
+                val disconnectedDeferred =
+                    async(start = CoroutineStart.UNDISPATCHED) {
+                        withTimeout(5_000) {
+                            network.events
+                                .filterIsInstance<Network.Event.Disconnected<ConnectionId>>()
+                                .first()
+                        }
+                    }
+
+                val session = client.webSocketSession("/ws")
+                val response = receiveConnectionResponse(session)
+
+                session.close()
+
+                val event = disconnectedDeferred.await()
+
+                assertEquals(response.sessionToken, event.sessionToken)
+            }
+        }
+
+    @Test
     fun `server network send wraps payload into binary frame for connected client`() =
         testApplication {
             val network = ServerNetwork()

--- a/server/src/test/kotlin/at/aau/pulverfass/server/TurnAdvanceIntegrationTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/TurnAdvanceIntegrationTest.kt
@@ -17,6 +17,8 @@ import at.aau.pulverfass.shared.lobby.state.TurnState
 import at.aau.pulverfass.shared.message.lobby.event.GameStateDeltaEvent
 import at.aau.pulverfass.shared.message.lobby.event.GameStateSnapshotBroadcast
 import at.aau.pulverfass.shared.message.lobby.event.PhaseBoundaryEvent
+import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostEvent
+import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostReason
 import at.aau.pulverfass.shared.message.lobby.request.TurnAdvanceRequest
 import at.aau.pulverfass.shared.message.lobby.response.TurnAdvanceResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.TurnAdvanceErrorCode
@@ -681,7 +683,14 @@ class TurnAdvanceIntegrationTest {
                         routingService = routingService,
                     )
 
-                    assertNull(receivePayloadOrNull(playerOneSession.first))
+                    assertEquals(
+                        PlayerConnectionLostEvent(
+                            lobbyCode = lobbyCode,
+                            playerId = playerTwo,
+                            reason = PlayerConnectionLostReason.SOCKET_CLOSED,
+                        ),
+                        receivePayload(playerOneSession.first),
+                    )
                     val snapshot =
                         lobbyManager.getLobby(lobbyCode)?.currentState()
                             ?: error("snapshot missing")
@@ -770,6 +779,14 @@ class TurnAdvanceIntegrationTest {
                         playersByConnection = playersByConnection,
                         connectionsByPlayer = connectionsByPlayer,
                         routingService = routingService,
+                    )
+                    assertEquals(
+                        PlayerConnectionLostEvent(
+                            lobbyCode = lobbyCode,
+                            playerId = playerTwo,
+                            reason = PlayerConnectionLostReason.SOCKET_CLOSED,
+                        ),
+                        receivePayload(playerOneSession.first),
                     )
 
                     playerOneSession.first.send(
@@ -1051,7 +1068,11 @@ class TurnAdvanceIntegrationTest {
     ) {
         playersByConnection.remove(connectionId)
         connectionsByPlayer.remove(playerId)
-        routingService.onPlayerDisconnected(playerId)
+        routingService.onPlayerDisconnected(
+            connectionId = connectionId,
+            playerId = playerId,
+            reason = "socket closed",
+        )
         session.close()
     }
 

--- a/server/src/test/kotlin/at/aau/pulverfass/server/TurnSystemIntegrationTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/TurnSystemIntegrationTest.kt
@@ -16,6 +16,8 @@ import at.aau.pulverfass.shared.lobby.state.TurnPhase
 import at.aau.pulverfass.shared.map.config.MapConfigLoader
 import at.aau.pulverfass.shared.message.lobby.event.GameStartedEvent
 import at.aau.pulverfass.shared.message.lobby.event.PhaseBoundaryEvent
+import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostEvent
+import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostReason
 import at.aau.pulverfass.shared.message.lobby.request.StartGameRequest
 import at.aau.pulverfass.shared.message.lobby.request.StartPlayerSetRequest
 import at.aau.pulverfass.shared.message.lobby.request.TurnAdvanceRequest
@@ -420,6 +422,22 @@ class TurnSystemIntegrationTest {
                         connectionsByPlayer = connectionsByPlayer,
                         routingService = routingService,
                     )
+                    assertEquals(
+                        PlayerConnectionLostEvent(
+                            lobbyCode = lobbyCode,
+                            playerId = disconnectedNextPlayer,
+                            reason = PlayerConnectionLostReason.SOCKET_CLOSED,
+                        ),
+                        receivePayload(hostSession.first),
+                    )
+                    assertEquals(
+                        PlayerConnectionLostEvent(
+                            lobbyCode = lobbyCode,
+                            playerId = disconnectedNextPlayer,
+                            reason = PlayerConnectionLostReason.SOCKET_CLOSED,
+                        ),
+                        receivePayload(connectedWatcherSession),
+                    )
 
                     advanceAndAssertBroadcast(
                         actor = hostSession.first,
@@ -685,7 +703,11 @@ class TurnSystemIntegrationTest {
     ) {
         playersByConnection.remove(connectionId)
         connectionsByPlayer.remove(playerId)
-        routingService.onPlayerDisconnected(playerId)
+        routingService.onPlayerDisconnected(
+            connectionId = connectionId,
+            playerId = playerId,
+            reason = "socket closed",
+        )
         session.close()
     }
 

--- a/server/src/test/kotlin/at/aau/pulverfass/server/transport/ServerWebSocketTransportIntegrationTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/transport/ServerWebSocketTransportIntegrationTest.kt
@@ -14,6 +14,7 @@ import io.ktor.websocket.CloseReason
 import io.ktor.websocket.Frame
 import io.ktor.websocket.close
 import io.ktor.websocket.readBytes
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.filterIsInstance
@@ -44,7 +45,7 @@ class ServerWebSocketTransportIntegrationTest {
 
             coroutineScope {
                 val connectedEvent =
-                    async {
+                    async(start = CoroutineStart.UNDISPATCHED) {
                         withTimeout(5_000) {
                             transport.events.filterIsInstance<Connected>().first()
                         }

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/codec/NetworkPayloadRegistry.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/codec/NetworkPayloadRegistry.kt
@@ -20,6 +20,7 @@ import at.aau.pulverfass.shared.message.lobby.request.GameStatePrivateGetRequest
 import at.aau.pulverfass.shared.message.lobby.request.JoinLobbyRequest
 import at.aau.pulverfass.shared.message.lobby.request.KickPlayerRequest
 import at.aau.pulverfass.shared.message.lobby.request.LeaveLobbyRequest
+import at.aau.pulverfass.shared.message.lobby.request.LobbyPlayerCountRequest
 import at.aau.pulverfass.shared.message.lobby.request.MapGetRequest
 import at.aau.pulverfass.shared.message.lobby.request.StartGameRequest
 import at.aau.pulverfass.shared.message.lobby.request.StartPlayerSetRequest
@@ -31,6 +32,7 @@ import at.aau.pulverfass.shared.message.lobby.response.GameStatePrivateGetRespon
 import at.aau.pulverfass.shared.message.lobby.response.JoinLobbyResponse
 import at.aau.pulverfass.shared.message.lobby.response.KickPlayerResponse
 import at.aau.pulverfass.shared.message.lobby.response.LeaveLobbyResponse
+import at.aau.pulverfass.shared.message.lobby.response.LobbyPlayerCountResponse
 import at.aau.pulverfass.shared.message.lobby.response.MapGetResponse
 import at.aau.pulverfass.shared.message.lobby.response.StartGameResponse
 import at.aau.pulverfass.shared.message.lobby.response.StartPlayerSetResponse
@@ -41,6 +43,7 @@ import at.aau.pulverfass.shared.message.lobby.response.error.GameStateCatchUpErr
 import at.aau.pulverfass.shared.message.lobby.response.error.GameStatePrivateGetErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.JoinLobbyErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.KickPlayerErrorResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.LobbyPlayerCountErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.MapGetErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.StartGameErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.StartPlayerSetErrorResponse
@@ -72,6 +75,10 @@ internal object NetworkPayloadRegistry {
             PlayerJoinedLobbyEvent::class.java to MessageType.LOBBY_PLAYER_JOINED_BROADCAST,
             PlayerConnectionLostEvent::class.java to
                 MessageType.LOBBY_PLAYER_CONNECTION_LOST_BROADCAST,
+            LobbyPlayerCountRequest::class.java to MessageType.LOBBY_PLAYER_COUNT_REQUEST,
+            LobbyPlayerCountResponse::class.java to MessageType.LOBBY_PLAYER_COUNT_RESPONSE,
+            LobbyPlayerCountErrorResponse::class.java to
+                MessageType.LOBBY_PLAYER_COUNT_ERROR_RESPONSE,
             LeaveLobbyRequest::class.java to MessageType.LOBBY_LEAVE_REQUEST,
             LeaveLobbyResponse::class.java to MessageType.LOBBY_LEAVE_RESPONSE,
             PlayerLeftLobbyEvent::class.java to MessageType.LOBBY_PLAYER_LEFT_BROADCAST,
@@ -140,6 +147,12 @@ internal object NetworkPayloadRegistry {
             PlayerJoinedLobbyEvent::class.java to encodeWith(PlayerJoinedLobbyEvent.serializer()),
             PlayerConnectionLostEvent::class.java to
                 encodeWith(PlayerConnectionLostEvent.serializer()),
+            LobbyPlayerCountRequest::class.java to
+                encodeWith(LobbyPlayerCountRequest.serializer()),
+            LobbyPlayerCountResponse::class.java to
+                encodeWith(LobbyPlayerCountResponse.serializer()),
+            LobbyPlayerCountErrorResponse::class.java to
+                encodeWith(LobbyPlayerCountErrorResponse.serializer()),
             LeaveLobbyRequest::class.java to encodeWith(LeaveLobbyRequest.serializer()),
             LeaveLobbyResponse::class.java to encodeWith(LeaveLobbyResponse.serializer()),
             PlayerLeftLobbyEvent::class.java to encodeWith(PlayerLeftLobbyEvent.serializer()),
@@ -208,6 +221,12 @@ internal object NetworkPayloadRegistry {
                 decodeWith(PlayerJoinedLobbyEvent.serializer()),
             MessageType.LOBBY_PLAYER_CONNECTION_LOST_BROADCAST to
                 decodeWith(PlayerConnectionLostEvent.serializer()),
+            MessageType.LOBBY_PLAYER_COUNT_REQUEST to
+                decodeWith(LobbyPlayerCountRequest.serializer()),
+            MessageType.LOBBY_PLAYER_COUNT_RESPONSE to
+                decodeWith(LobbyPlayerCountResponse.serializer()),
+            MessageType.LOBBY_PLAYER_COUNT_ERROR_RESPONSE to
+                decodeWith(LobbyPlayerCountErrorResponse.serializer()),
             MessageType.LOBBY_LEAVE_REQUEST to decodeWith(LeaveLobbyRequest.serializer()),
             MessageType.LOBBY_LEAVE_RESPONSE to decodeWith(LeaveLobbyResponse.serializer()),
             MessageType.LOBBY_PLAYER_LEFT_BROADCAST to

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/codec/NetworkPayloadRegistry.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/codec/NetworkPayloadRegistry.kt
@@ -10,6 +10,7 @@ import at.aau.pulverfass.shared.message.lobby.event.GameStartedEvent
 import at.aau.pulverfass.shared.message.lobby.event.GameStateDeltaEvent
 import at.aau.pulverfass.shared.message.lobby.event.GameStateSnapshotBroadcast
 import at.aau.pulverfass.shared.message.lobby.event.PhaseBoundaryEvent
+import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerJoinedLobbyEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerKickedLobbyEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerLeftLobbyEvent
@@ -69,6 +70,8 @@ internal object NetworkPayloadRegistry {
             JoinLobbyErrorResponse::class.java to MessageType.LOBBY_JOIN_ERROR_RESPONSE,
             JoinLobbyResponse::class.java to MessageType.LOBBY_JOIN_RESPONSE,
             PlayerJoinedLobbyEvent::class.java to MessageType.LOBBY_PLAYER_JOINED_BROADCAST,
+            PlayerConnectionLostEvent::class.java to
+                MessageType.LOBBY_PLAYER_CONNECTION_LOST_BROADCAST,
             LeaveLobbyRequest::class.java to MessageType.LOBBY_LEAVE_REQUEST,
             LeaveLobbyResponse::class.java to MessageType.LOBBY_LEAVE_RESPONSE,
             PlayerLeftLobbyEvent::class.java to MessageType.LOBBY_PLAYER_LEFT_BROADCAST,
@@ -135,6 +138,8 @@ internal object NetworkPayloadRegistry {
                 encodeWith(JoinLobbyErrorResponse.serializer()),
             JoinLobbyResponse::class.java to encodeWith(JoinLobbyResponse.serializer()),
             PlayerJoinedLobbyEvent::class.java to encodeWith(PlayerJoinedLobbyEvent.serializer()),
+            PlayerConnectionLostEvent::class.java to
+                encodeWith(PlayerConnectionLostEvent.serializer()),
             LeaveLobbyRequest::class.java to encodeWith(LeaveLobbyRequest.serializer()),
             LeaveLobbyResponse::class.java to encodeWith(LeaveLobbyResponse.serializer()),
             PlayerLeftLobbyEvent::class.java to encodeWith(PlayerLeftLobbyEvent.serializer()),
@@ -201,6 +206,8 @@ internal object NetworkPayloadRegistry {
             MessageType.LOBBY_JOIN_RESPONSE to decodeWith(JoinLobbyResponse.serializer()),
             MessageType.LOBBY_PLAYER_JOINED_BROADCAST to
                 decodeWith(PlayerJoinedLobbyEvent.serializer()),
+            MessageType.LOBBY_PLAYER_CONNECTION_LOST_BROADCAST to
+                decodeWith(PlayerConnectionLostEvent.serializer()),
             MessageType.LOBBY_LEAVE_REQUEST to decodeWith(LeaveLobbyRequest.serializer()),
             MessageType.LOBBY_LEAVE_RESPONSE to decodeWith(LeaveLobbyResponse.serializer()),
             MessageType.LOBBY_PLAYER_LEFT_BROADCAST to

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/event/PlayerConnectionLostEvent.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/event/PlayerConnectionLostEvent.kt
@@ -1,0 +1,120 @@
+package at.aau.pulverfass.shared.message.lobby.event
+
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.message.protocol.NetworkMessagePayload
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.MissingFieldException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * Stabile Gründe für einen im Lobby-Scope beobachteten Verbindungsverlust.
+ */
+@Serializable
+enum class PlayerConnectionLostReason {
+    SOCKET_CLOSED,
+    HEARTBEAT_TIMEOUT,
+}
+
+/**
+ * Lobby-Scoped Broadcast des Servers, wenn ein Spieler die Verbindung verliert.
+ *
+ * @property lobbyCode betroffene Lobby
+ * @property playerId Spieler mit verlorener Verbindung
+ * @property reason stabiler technischer Grund für den Verbindungsverlust
+ */
+@Serializable(with = PlayerConnectionLostEventSerializer::class)
+data class PlayerConnectionLostEvent(
+    val lobbyCode: LobbyCode,
+    val playerId: PlayerId,
+    val reason: PlayerConnectionLostReason,
+) : NetworkMessagePayload
+
+/**
+ * Technischer Serializer für [PlayerConnectionLostEvent].
+ */
+@OptIn(ExperimentalSerializationApi::class)
+object PlayerConnectionLostEventSerializer : KSerializer<PlayerConnectionLostEvent> {
+    override val descriptor =
+        buildClassSerialDescriptor(
+            "at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostEvent",
+        ) {
+            element("lobbyCode", LobbyCode.serializer().descriptor)
+            element("playerId", PlayerId.serializer().descriptor)
+            element("reason", PlayerConnectionLostReason.serializer().descriptor)
+        }
+
+    override fun serialize(
+        encoder: Encoder,
+        value: PlayerConnectionLostEvent,
+    ) {
+        val composite = encoder.beginStructure(descriptor)
+        composite.encodeSerializableElement(
+            descriptor = descriptor,
+            index = 0,
+            serializer = LobbyCode.serializer(),
+            value = value.lobbyCode,
+        )
+        composite.encodeSerializableElement(
+            descriptor = descriptor,
+            index = 1,
+            serializer = PlayerId.serializer(),
+            value = value.playerId,
+        )
+        composite.encodeSerializableElement(
+            descriptor = descriptor,
+            index = 2,
+            serializer = PlayerConnectionLostReason.serializer(),
+            value = value.reason,
+        )
+        composite.endStructure(descriptor)
+    }
+
+    override fun deserialize(decoder: Decoder): PlayerConnectionLostEvent {
+        val composite = decoder.beginStructure(descriptor)
+        val serialName = descriptor.serialName
+        var lobbyCode: LobbyCode? = null
+        var playerId: PlayerId? = null
+        var reason: PlayerConnectionLostReason? = null
+
+        loop@ while (true) {
+            when (val index = composite.decodeElementIndex(descriptor)) {
+                0 ->
+                    lobbyCode =
+                        composite.decodeSerializableElement(
+                            descriptor,
+                            0,
+                            LobbyCode.serializer(),
+                        )
+                1 ->
+                    playerId =
+                        composite.decodeSerializableElement(
+                            descriptor,
+                            1,
+                            PlayerId.serializer(),
+                        )
+                2 ->
+                    reason =
+                        composite.decodeSerializableElement(
+                            descriptor,
+                            2,
+                            PlayerConnectionLostReason.serializer(),
+                        )
+                CompositeDecoder.DECODE_DONE -> break@loop
+                else -> throw IllegalArgumentException("Unexpected index $index")
+            }
+        }
+
+        composite.endStructure(descriptor)
+        return PlayerConnectionLostEvent(
+            lobbyCode = lobbyCode ?: throw MissingFieldException("lobbyCode", serialName),
+            playerId = playerId ?: throw MissingFieldException("playerId", serialName),
+            reason = reason ?: throw MissingFieldException("reason", serialName),
+        )
+    }
+}

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/request/LobbyPlayerCountRequest.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/request/LobbyPlayerCountRequest.kt
@@ -1,0 +1,70 @@
+package at.aau.pulverfass.shared.message.lobby.request
+
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.message.protocol.NetworkMessagePayload
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.MissingFieldException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * Anfrage eines Clients, den aktuellen autoritativen Spielerstand einer Lobby
+ * direkt vom Server abzurufen.
+ *
+ * @property lobbyCode betroffene Lobby
+ */
+@Serializable(with = LobbyPlayerCountRequestSerializer::class)
+data class LobbyPlayerCountRequest(
+    val lobbyCode: LobbyCode,
+) : NetworkMessagePayload
+
+/**
+ * Technischer Serializer für [LobbyPlayerCountRequest].
+ */
+object LobbyPlayerCountRequestSerializer : KSerializer<LobbyPlayerCountRequest> {
+    override val descriptor =
+        buildClassSerialDescriptor(
+            "at.aau.pulverfass.shared.network.message.LobbyPlayerCountRequest",
+        ) {
+            element("lobbyCode", LobbyCode.serializer().descriptor)
+        }
+
+    override fun serialize(
+        encoder: Encoder,
+        value: LobbyPlayerCountRequest,
+    ) {
+        val composite = encoder.beginStructure(descriptor)
+        composite.encodeSerializableElement(descriptor, 0, LobbyCode.serializer(), value.lobbyCode)
+        composite.endStructure(descriptor)
+    }
+
+    override fun deserialize(decoder: Decoder): LobbyPlayerCountRequest {
+        val composite = decoder.beginStructure(descriptor)
+        var lobbyCode: LobbyCode? = null
+
+        loop@ while (true) {
+            when (val index = composite.decodeElementIndex(descriptor)) {
+                0 ->
+                    lobbyCode =
+                        composite.decodeSerializableElement(
+                            descriptor,
+                            0,
+                            LobbyCode.serializer(),
+                        )
+                CompositeDecoder.DECODE_DONE -> break@loop
+                else -> throw IllegalArgumentException("Unexpected index $index")
+            }
+        }
+
+        composite.endStructure(descriptor)
+        return LobbyPlayerCountRequest(
+            lobbyCode =
+                lobbyCode
+                    ?: throw MissingFieldException("lobbyCode", descriptor.serialName),
+        )
+    }
+}

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/LobbyPlayerCountResponse.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/LobbyPlayerCountResponse.kt
@@ -1,0 +1,78 @@
+package at.aau.pulverfass.shared.message.lobby.response
+
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.message.protocol.NetworkMessagePayload
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.MissingFieldException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * Erfolgsantwort des Servers mit der aktuellen Anzahl an Spielern in einer Lobby.
+ *
+ * @property lobbyCode betroffene Lobby
+ * @property playerCount aktuell autoritativ ermittelte Spieleranzahl
+ */
+@Serializable(with = LobbyPlayerCountResponseSerializer::class)
+data class LobbyPlayerCountResponse(
+    val lobbyCode: LobbyCode,
+    val playerCount: Int,
+) : NetworkMessagePayload
+
+/**
+ * Technischer Serializer für [LobbyPlayerCountResponse].
+ */
+object LobbyPlayerCountResponseSerializer : KSerializer<LobbyPlayerCountResponse> {
+    override val descriptor =
+        buildClassSerialDescriptor(
+            "at.aau.pulverfass.shared.network.message.LobbyPlayerCountResponse",
+        ) {
+            element("lobbyCode", LobbyCode.serializer().descriptor)
+            element<Int>("playerCount")
+        }
+
+    override fun serialize(
+        encoder: Encoder,
+        value: LobbyPlayerCountResponse,
+    ) {
+        val composite = encoder.beginStructure(descriptor)
+        composite.encodeSerializableElement(descriptor, 0, LobbyCode.serializer(), value.lobbyCode)
+        composite.encodeIntElement(descriptor, 1, value.playerCount)
+        composite.endStructure(descriptor)
+    }
+
+    override fun deserialize(decoder: Decoder): LobbyPlayerCountResponse {
+        val composite = decoder.beginStructure(descriptor)
+        var lobbyCode: LobbyCode? = null
+        var playerCount: Int? = null
+
+        loop@ while (true) {
+            when (val index = composite.decodeElementIndex(descriptor)) {
+                0 ->
+                    lobbyCode =
+                        composite.decodeSerializableElement(
+                            descriptor,
+                            0,
+                            LobbyCode.serializer(),
+                        )
+                1 -> playerCount = composite.decodeIntElement(descriptor, 1)
+                CompositeDecoder.DECODE_DONE -> break@loop
+                else -> throw IllegalArgumentException("Unexpected index $index")
+            }
+        }
+
+        composite.endStructure(descriptor)
+        return LobbyPlayerCountResponse(
+            lobbyCode =
+                lobbyCode
+                    ?: throw MissingFieldException("lobbyCode", descriptor.serialName),
+            playerCount =
+                playerCount
+                    ?: throw MissingFieldException("playerCount", descriptor.serialName),
+        )
+    }
+}

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/error/LobbyPlayerCountErrorResponse.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/error/LobbyPlayerCountErrorResponse.kt
@@ -1,0 +1,102 @@
+package at.aau.pulverfass.shared.message.lobby.response.error
+
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.message.protocol.NetworkMessagePayload
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.MissingFieldException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * Typisierte Fehlercodes für fehlgeschlagene PlayerCount-Anfragen.
+ */
+@Serializable
+enum class LobbyPlayerCountErrorCode {
+    LOBBY_NOT_FOUND,
+}
+
+/**
+ * Fehlantwort des Servers auf eine nicht erfolgreiche PlayerCount-Anfrage.
+ *
+ * @property lobbyCode betroffene Lobby
+ * @property code fachlicher Fehlercode
+ * @property reason lesbare Fehlerbeschreibung
+ */
+@Serializable(with = LobbyPlayerCountErrorResponseSerializer::class)
+data class LobbyPlayerCountErrorResponse(
+    val lobbyCode: LobbyCode,
+    val code: LobbyPlayerCountErrorCode,
+    val reason: String,
+) : NetworkMessagePayload
+
+/**
+ * Technischer Serializer für [LobbyPlayerCountErrorResponse].
+ */
+object LobbyPlayerCountErrorResponseSerializer : KSerializer<LobbyPlayerCountErrorResponse> {
+    override val descriptor =
+        buildClassSerialDescriptor(
+            "at.aau.pulverfass.shared.network.message.LobbyPlayerCountErrorResponse",
+        ) {
+            element("lobbyCode", LobbyCode.serializer().descriptor)
+            element("code", LobbyPlayerCountErrorCode.serializer().descriptor)
+            element<String>("reason")
+        }
+
+    override fun serialize(
+        encoder: Encoder,
+        value: LobbyPlayerCountErrorResponse,
+    ) {
+        val composite = encoder.beginStructure(descriptor)
+        composite.encodeSerializableElement(descriptor, 0, LobbyCode.serializer(), value.lobbyCode)
+        composite.encodeSerializableElement(
+            descriptor,
+            1,
+            LobbyPlayerCountErrorCode.serializer(),
+            value.code,
+        )
+        composite.encodeStringElement(descriptor, 2, value.reason)
+        composite.endStructure(descriptor)
+    }
+
+    override fun deserialize(decoder: Decoder): LobbyPlayerCountErrorResponse {
+        val composite = decoder.beginStructure(descriptor)
+        var lobbyCode: LobbyCode? = null
+        var code: LobbyPlayerCountErrorCode? = null
+        var reason: String? = null
+
+        loop@ while (true) {
+            when (val index = composite.decodeElementIndex(descriptor)) {
+                0 ->
+                    lobbyCode =
+                        composite.decodeSerializableElement(
+                            descriptor,
+                            0,
+                            LobbyCode.serializer(),
+                        )
+                1 ->
+                    code =
+                        composite.decodeSerializableElement(
+                            descriptor,
+                            1,
+                            LobbyPlayerCountErrorCode.serializer(),
+                        )
+                2 -> reason = composite.decodeStringElement(descriptor, 2)
+                CompositeDecoder.DECODE_DONE -> break@loop
+                else -> throw IllegalArgumentException("Unexpected index $index")
+            }
+        }
+
+        composite.endStructure(descriptor)
+        return LobbyPlayerCountErrorResponse(
+            lobbyCode =
+                lobbyCode
+                    ?: throw MissingFieldException("lobbyCode", descriptor.serialName),
+            code = code ?: throw MissingFieldException("code", descriptor.serialName),
+            reason = reason ?: throw MissingFieldException("reason", descriptor.serialName),
+        )
+    }
+}

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/protocol/MessageType.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/protocol/MessageType.kt
@@ -25,6 +25,9 @@ enum class MessageType(val id: Int) {
     /** Antwort des Servers auf einen Reconnect-Versuch. */
     CONNECTION_RECONNECT_RESPONSE(51),
 
+    /** Broadcast, dass ein Lobby-Spieler technisch die Verbindung verloren hat. */
+    LOBBY_PLAYER_CONNECTION_LOST_BROADCAST(52),
+
     /** Logout-Anfrage eines Clients. */
     LOGOUT_REQUEST(3),
 

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/protocol/MessageType.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/protocol/MessageType.kt
@@ -28,6 +28,15 @@ enum class MessageType(val id: Int) {
     /** Broadcast, dass ein Lobby-Spieler technisch die Verbindung verloren hat. */
     LOBBY_PLAYER_CONNECTION_LOST_BROADCAST(52),
 
+    /** Anfrage nach der aktuellen Spieleranzahl einer Lobby. */
+    LOBBY_PLAYER_COUNT_REQUEST(53),
+
+    /** Erfolgsantwort mit der aktuellen Spieleranzahl einer Lobby. */
+    LOBBY_PLAYER_COUNT_RESPONSE(54),
+
+    /** Fehlantwort auf eine PlayerCount-Anfrage. */
+    LOBBY_PLAYER_COUNT_ERROR_RESPONSE(55),
+
     /** Logout-Anfrage eines Clients. */
     LOGOUT_REQUEST(3),
 

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/network/Network.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/network/Network.kt
@@ -1,5 +1,6 @@
 package at.aau.pulverfass.shared.network
 
+import at.aau.pulverfass.shared.ids.SessionToken
 import at.aau.pulverfass.shared.message.protocol.NetworkMessagePayload
 import kotlinx.coroutines.flow.SharedFlow
 
@@ -58,10 +59,12 @@ interface Network<ConnectionT> {
          *
          * @property connectionId beendete Verbindung
          * @property reason optionaler technischer Close-Reason des Transports
+         * @property sessionToken zuletzt an die Verbindung gebundene Session, falls bekannt
          */
         data class Disconnected<ConnectionT>(
             val connectionId: ConnectionT,
             val reason: String?,
+            val sessionToken: SessionToken? = null,
         ) : Event<ConnectionT>
 
         /**

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/network/NetworkTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/network/NetworkTest.kt
@@ -2,6 +2,7 @@ package at.aau.pulverfass.shared.network
 
 import at.aau.pulverfass.shared.ids.ConnectionId
 import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.ids.SessionToken
 import at.aau.pulverfass.shared.message.lobby.request.JoinLobbyRequest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
@@ -27,10 +28,16 @@ class NetworkTest {
 
     @Test
     fun `should expose disconnected event data`() {
-        val event = Network.Event.Disconnected(ConnectionId(3), reason = "closed")
+        val event =
+            Network.Event.Disconnected(
+                connectionId = ConnectionId(3),
+                reason = "closed",
+                sessionToken = SessionToken("123e4567-e89b-12d3-a456-426614174299"),
+            )
 
         assertEquals(ConnectionId(3), event.connectionId)
         assertEquals("closed", event.reason)
+        assertEquals(SessionToken("123e4567-e89b-12d3-a456-426614174299"), event.sessionToken)
     }
 
     @Test

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/network/codec/MessageCodecTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/network/codec/MessageCodecTest.kt
@@ -16,6 +16,7 @@ import at.aau.pulverfass.shared.message.lobby.event.PlayerLeftLobbyEvent
 import at.aau.pulverfass.shared.message.lobby.request.CreateLobbyRequest
 import at.aau.pulverfass.shared.message.lobby.request.JoinLobbyRequest
 import at.aau.pulverfass.shared.message.lobby.request.LeaveLobbyRequest
+import at.aau.pulverfass.shared.message.lobby.request.LobbyPlayerCountRequest
 import at.aau.pulverfass.shared.message.lobby.request.MapGetRequest
 import at.aau.pulverfass.shared.message.lobby.request.StartPlayerSetRequest
 import at.aau.pulverfass.shared.message.lobby.request.TurnAdvanceRequest
@@ -23,6 +24,7 @@ import at.aau.pulverfass.shared.message.lobby.request.TurnStateGetRequest
 import at.aau.pulverfass.shared.message.lobby.response.CreateLobbyResponse
 import at.aau.pulverfass.shared.message.lobby.response.JoinLobbyResponse
 import at.aau.pulverfass.shared.message.lobby.response.LeaveLobbyResponse
+import at.aau.pulverfass.shared.message.lobby.response.LobbyPlayerCountResponse
 import at.aau.pulverfass.shared.message.lobby.response.MapDefinitionSnapshot
 import at.aau.pulverfass.shared.message.lobby.response.MapGetResponse
 import at.aau.pulverfass.shared.message.lobby.response.MapTerritoryDefinitionSnapshot
@@ -35,6 +37,8 @@ import at.aau.pulverfass.shared.message.lobby.response.TurnAdvanceResponse
 import at.aau.pulverfass.shared.message.lobby.response.TurnStateGetResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.CreateLobbyErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.JoinLobbyErrorResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.LobbyPlayerCountErrorCode
+import at.aau.pulverfass.shared.message.lobby.response.error.LobbyPlayerCountErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.StartPlayerSetErrorCode
 import at.aau.pulverfass.shared.message.lobby.response.error.StartPlayerSetErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.TurnAdvanceErrorCode
@@ -156,6 +160,41 @@ class MessageCodecTest {
                 lobbyCode = LobbyCode("EF57"),
                 playerId = PlayerId(15),
                 reason = PlayerConnectionLostReason.HEARTBEAT_TIMEOUT,
+            )
+
+        val bytes = MessageCodec.encode(payload)
+        val result = MessageCodec.decodePayload(bytes)
+
+        assertEquals(payload, result)
+    }
+
+    @Test
+    fun `should encode and decode lobby player count request payload directly`() {
+        val payload = LobbyPlayerCountRequest(LobbyCode("PC12"))
+
+        val bytes = MessageCodec.encode(payload)
+        val result = MessageCodec.decodePayload(bytes)
+
+        assertEquals(payload, result)
+    }
+
+    @Test
+    fun `should encode and decode lobby player count response payload directly`() {
+        val payload = LobbyPlayerCountResponse(lobbyCode = LobbyCode("PC34"), playerCount = 6)
+
+        val bytes = MessageCodec.encode(payload)
+        val result = MessageCodec.decodePayload(bytes)
+
+        assertEquals(payload, result)
+    }
+
+    @Test
+    fun `should encode and decode lobby player count error payload directly`() {
+        val payload =
+            LobbyPlayerCountErrorResponse(
+                lobbyCode = LobbyCode("PC99"),
+                code = LobbyPlayerCountErrorCode.LOBBY_NOT_FOUND,
+                reason = "Lobby 'PC99' wurde nicht gefunden.",
             )
 
         val bytes = MessageCodec.encode(payload)

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/network/codec/MessageCodecTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/network/codec/MessageCodecTest.kt
@@ -9,6 +9,8 @@ import at.aau.pulverfass.shared.lobby.event.TurnStateUpdatedEvent
 import at.aau.pulverfass.shared.lobby.state.TurnPhase
 import at.aau.pulverfass.shared.message.lobby.event.GameStateSnapshotBroadcast
 import at.aau.pulverfass.shared.message.lobby.event.PhaseBoundaryEvent
+import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostEvent
+import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostReason
 import at.aau.pulverfass.shared.message.lobby.event.PlayerJoinedLobbyEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerLeftLobbyEvent
 import at.aau.pulverfass.shared.message.lobby.request.CreateLobbyRequest
@@ -139,6 +141,21 @@ class MessageCodecTest {
                 lobbyCode = LobbyCode("EF56"),
                 playerId = PlayerId(7),
                 playerDisplayName = "Carol",
+            )
+
+        val bytes = MessageCodec.encode(payload)
+        val result = MessageCodec.decodePayload(bytes)
+
+        assertEquals(payload, result)
+    }
+
+    @Test
+    fun `should encode and decode player connection lost event payload directly`() {
+        val payload =
+            PlayerConnectionLostEvent(
+                lobbyCode = LobbyCode("EF57"),
+                playerId = PlayerId(15),
+                reason = PlayerConnectionLostReason.HEARTBEAT_TIMEOUT,
             )
 
         val bytes = MessageCodec.encode(payload)

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/LobbyPlayerCountMessageTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/LobbyPlayerCountMessageTest.kt
@@ -1,0 +1,65 @@
+package at.aau.pulverfass.shared.network.message
+
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.message.lobby.request.LobbyPlayerCountRequest
+import at.aau.pulverfass.shared.message.lobby.response.LobbyPlayerCountResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.LobbyPlayerCountErrorCode
+import at.aau.pulverfass.shared.message.lobby.response.error.LobbyPlayerCountErrorResponse
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class LobbyPlayerCountMessageTest {
+    private val json = Json
+
+    @Test
+    fun `serializer roundtrip request`() {
+        val request = LobbyPlayerCountRequest(lobbyCode = LobbyCode("AB12"))
+
+        val serialized = json.encodeToString(LobbyPlayerCountRequest.serializer(), request)
+        val deserialized =
+            json.decodeFromString(LobbyPlayerCountRequest.serializer(), serialized)
+
+        assertEquals("""{"lobbyCode":"AB12"}""", serialized)
+        assertEquals(request, deserialized)
+    }
+
+    @Test
+    fun `serializer roundtrip response`() {
+        val response =
+            LobbyPlayerCountResponse(
+                lobbyCode = LobbyCode("CD34"),
+                playerCount = 4,
+            )
+
+        val serialized = json.encodeToString(LobbyPlayerCountResponse.serializer(), response)
+        val deserialized =
+            json.decodeFromString(LobbyPlayerCountResponse.serializer(), serialized)
+
+        assertEquals("""{"lobbyCode":"CD34","playerCount":4}""", serialized)
+        assertEquals(response, deserialized)
+    }
+
+    @Test
+    fun `serializer roundtrip error response`() {
+        val response =
+            LobbyPlayerCountErrorResponse(
+                lobbyCode = LobbyCode("ZZ99"),
+                code = LobbyPlayerCountErrorCode.LOBBY_NOT_FOUND,
+                reason = "Lobby 'ZZ99' wurde nicht gefunden.",
+            )
+
+        val serialized =
+            json.encodeToString(LobbyPlayerCountErrorResponse.serializer(), response)
+        val deserialized =
+            json.decodeFromString(LobbyPlayerCountErrorResponse.serializer(), serialized)
+
+        assertEquals(
+            """
+            {"lobbyCode":"ZZ99","code":"LOBBY_NOT_FOUND","reason":"Lobby 'ZZ99' wurde nicht gefunden."}
+            """.trimIndent(),
+            serialized,
+        )
+        assertEquals(response, deserialized)
+    }
+}

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/MessageTypeTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/MessageTypeTest.kt
@@ -59,6 +59,9 @@ class MessageTypeTest {
         assertTrue(MessageType.entries.contains(MessageType.LOBBY_JOIN_ERROR_RESPONSE))
         assertTrue(MessageType.entries.contains(MessageType.LOBBY_LEAVE_REQUEST))
         assertTrue(MessageType.entries.contains(MessageType.LOBBY_LEAVE_RESPONSE))
+        assertTrue(
+            MessageType.entries.contains(MessageType.LOBBY_PLAYER_CONNECTION_LOST_BROADCAST),
+        )
         assertTrue(MessageType.entries.contains(MessageType.LOBBY_PLAYER_LEFT_BROADCAST))
         assertTrue(MessageType.entries.contains(MessageType.LOBBY_MAP_GET_REQUEST))
         assertTrue(MessageType.entries.contains(MessageType.LOBBY_MAP_GET_RESPONSE))

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/MessageTypeTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/MessageTypeTest.kt
@@ -62,6 +62,9 @@ class MessageTypeTest {
         assertTrue(
             MessageType.entries.contains(MessageType.LOBBY_PLAYER_CONNECTION_LOST_BROADCAST),
         )
+        assertTrue(MessageType.entries.contains(MessageType.LOBBY_PLAYER_COUNT_REQUEST))
+        assertTrue(MessageType.entries.contains(MessageType.LOBBY_PLAYER_COUNT_RESPONSE))
+        assertTrue(MessageType.entries.contains(MessageType.LOBBY_PLAYER_COUNT_ERROR_RESPONSE))
         assertTrue(MessageType.entries.contains(MessageType.LOBBY_PLAYER_LEFT_BROADCAST))
         assertTrue(MessageType.entries.contains(MessageType.LOBBY_MAP_GET_REQUEST))
         assertTrue(MessageType.entries.contains(MessageType.LOBBY_MAP_GET_RESPONSE))

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/NetworkMessageSerializerTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/NetworkMessageSerializerTest.kt
@@ -13,6 +13,8 @@ import at.aau.pulverfass.shared.message.connection.request.ReconnectRequest
 import at.aau.pulverfass.shared.message.connection.response.ConnectionResponse
 import at.aau.pulverfass.shared.message.connection.response.ReconnectErrorCode
 import at.aau.pulverfass.shared.message.connection.response.ReconnectResponse
+import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostEvent
+import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostReason
 import at.aau.pulverfass.shared.message.lobby.event.PlayerJoinedLobbyEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerLeftLobbyEvent
 import at.aau.pulverfass.shared.message.lobby.request.CreateLobbyRequest
@@ -278,6 +280,25 @@ class NetworkMessageSerializerTest {
         val result =
             NetworkMessageSerializer.deserializePayload(
                 MessageType.LOBBY_PLAYER_JOINED_BROADCAST,
+                bytes,
+            )
+
+        assertEquals(payload, result)
+    }
+
+    @Test
+    fun `should serialize registered player connection lost broadcast by runtime type`() {
+        val payload =
+            PlayerConnectionLostEvent(
+                lobbyCode = LobbyCode("EF57"),
+                playerId = PlayerId(17),
+                reason = PlayerConnectionLostReason.SOCKET_CLOSED,
+            )
+
+        val bytes = NetworkMessageSerializer.serializePayload(payload)
+        val result =
+            NetworkMessageSerializer.deserializePayload(
+                MessageType.LOBBY_PLAYER_CONNECTION_LOST_BROADCAST,
                 bytes,
             )
 

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/NetworkMessageSerializerTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/NetworkMessageSerializerTest.kt
@@ -20,6 +20,7 @@ import at.aau.pulverfass.shared.message.lobby.event.PlayerLeftLobbyEvent
 import at.aau.pulverfass.shared.message.lobby.request.CreateLobbyRequest
 import at.aau.pulverfass.shared.message.lobby.request.JoinLobbyRequest
 import at.aau.pulverfass.shared.message.lobby.request.LeaveLobbyRequest
+import at.aau.pulverfass.shared.message.lobby.request.LobbyPlayerCountRequest
 import at.aau.pulverfass.shared.message.lobby.request.MapGetRequest
 import at.aau.pulverfass.shared.message.lobby.request.StartPlayerSetRequest
 import at.aau.pulverfass.shared.message.lobby.request.TurnAdvanceRequest
@@ -27,6 +28,7 @@ import at.aau.pulverfass.shared.message.lobby.request.TurnStateGetRequest
 import at.aau.pulverfass.shared.message.lobby.response.CreateLobbyResponse
 import at.aau.pulverfass.shared.message.lobby.response.JoinLobbyResponse
 import at.aau.pulverfass.shared.message.lobby.response.LeaveLobbyResponse
+import at.aau.pulverfass.shared.message.lobby.response.LobbyPlayerCountResponse
 import at.aau.pulverfass.shared.message.lobby.response.MapDefinitionSnapshot
 import at.aau.pulverfass.shared.message.lobby.response.MapGetResponse
 import at.aau.pulverfass.shared.message.lobby.response.MapTerritoryDefinitionSnapshot
@@ -37,6 +39,8 @@ import at.aau.pulverfass.shared.message.lobby.response.TurnAdvanceResponse
 import at.aau.pulverfass.shared.message.lobby.response.TurnStateGetResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.CreateLobbyErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.JoinLobbyErrorResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.LobbyPlayerCountErrorCode
+import at.aau.pulverfass.shared.message.lobby.response.error.LobbyPlayerCountErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.MapGetErrorCode
 import at.aau.pulverfass.shared.message.lobby.response.error.MapGetErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.StartPlayerSetErrorCode
@@ -299,6 +303,57 @@ class NetworkMessageSerializerTest {
         val result =
             NetworkMessageSerializer.deserializePayload(
                 MessageType.LOBBY_PLAYER_CONNECTION_LOST_BROADCAST,
+                bytes,
+            )
+
+        assertEquals(payload, result)
+    }
+
+    @Test
+    fun `should deserialize lobby player count request payload for player count request type`() {
+        val payload = LobbyPlayerCountRequest(lobbyCode = LobbyCode("PC12"))
+        val bytes =
+            NetworkMessageSerializer.serializePayload(
+                LobbyPlayerCountRequest.serializer(),
+                payload,
+            )
+
+        val result =
+            NetworkMessageSerializer.deserializePayload(
+                MessageType.LOBBY_PLAYER_COUNT_REQUEST,
+                bytes,
+            )
+
+        assertEquals(payload, result)
+    }
+
+    @Test
+    fun `should serialize registered lobby player count response by runtime type`() {
+        val payload = LobbyPlayerCountResponse(lobbyCode = LobbyCode("PC34"), playerCount = 3)
+
+        val bytes = NetworkMessageSerializer.serializePayload(payload)
+        val result =
+            NetworkMessageSerializer.deserializePayload(
+                MessageType.LOBBY_PLAYER_COUNT_RESPONSE,
+                bytes,
+            )
+
+        assertEquals(payload, result)
+    }
+
+    @Test
+    fun `should serialize registered lobby player count error by runtime type`() {
+        val payload =
+            LobbyPlayerCountErrorResponse(
+                lobbyCode = LobbyCode("PC99"),
+                code = LobbyPlayerCountErrorCode.LOBBY_NOT_FOUND,
+                reason = "Lobby 'PC99' wurde nicht gefunden.",
+            )
+
+        val bytes = NetworkMessageSerializer.serializePayload(payload)
+        val result =
+            NetworkMessageSerializer.deserializePayload(
+                MessageType.LOBBY_PLAYER_COUNT_ERROR_RESPONSE,
                 bytes,
             )
 

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/NetworkPayloadRegistryTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/NetworkPayloadRegistryTest.kt
@@ -16,6 +16,8 @@ import at.aau.pulverfass.shared.message.connection.response.ReconnectResponse
 import at.aau.pulverfass.shared.message.lobby.event.GameStateDeltaEvent
 import at.aau.pulverfass.shared.message.lobby.event.GameStateSnapshotBroadcast
 import at.aau.pulverfass.shared.message.lobby.event.PhaseBoundaryEvent
+import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostEvent
+import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostReason
 import at.aau.pulverfass.shared.message.lobby.event.PlayerJoinedLobbyEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerLeftLobbyEvent
 import at.aau.pulverfass.shared.message.lobby.request.CreateLobbyRequest
@@ -201,6 +203,27 @@ class NetworkPayloadRegistryTest {
         assertEquals(MessageType.LOBBY_PLAYER_JOINED_BROADCAST, messageType)
         assertEquals(
             """{"lobbyCode":"EF56","playerId":8,"playerDisplayName":"Bob"}""",
+            serialized,
+        )
+        assertEquals(payload, deserialized)
+    }
+
+    @Test
+    fun `should resolve message type and serialization for player connection lost event`() {
+        val payload =
+            PlayerConnectionLostEvent(
+                lobbyCode = LobbyCode("EF57"),
+                playerId = PlayerId(18),
+                reason = PlayerConnectionLostReason.HEARTBEAT_TIMEOUT,
+            )
+
+        val messageType = NetworkPayloadRegistry.messageTypeFor(payload)
+        val serialized = NetworkPayloadRegistry.serializePayload(payload)
+        val deserialized = NetworkPayloadRegistry.deserializePayload(messageType, serialized)
+
+        assertEquals(MessageType.LOBBY_PLAYER_CONNECTION_LOST_BROADCAST, messageType)
+        assertEquals(
+            """{"lobbyCode":"EF57","playerId":18,"reason":"HEARTBEAT_TIMEOUT"}""",
             serialized,
         )
         assertEquals(payload, deserialized)

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/NetworkPayloadRegistryTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/NetworkPayloadRegistryTest.kt
@@ -23,6 +23,7 @@ import at.aau.pulverfass.shared.message.lobby.event.PlayerLeftLobbyEvent
 import at.aau.pulverfass.shared.message.lobby.request.CreateLobbyRequest
 import at.aau.pulverfass.shared.message.lobby.request.JoinLobbyRequest
 import at.aau.pulverfass.shared.message.lobby.request.LeaveLobbyRequest
+import at.aau.pulverfass.shared.message.lobby.request.LobbyPlayerCountRequest
 import at.aau.pulverfass.shared.message.lobby.request.MapGetRequest
 import at.aau.pulverfass.shared.message.lobby.request.StartPlayerSetRequest
 import at.aau.pulverfass.shared.message.lobby.request.TurnAdvanceRequest
@@ -30,6 +31,7 @@ import at.aau.pulverfass.shared.message.lobby.request.TurnStateGetRequest
 import at.aau.pulverfass.shared.message.lobby.response.CreateLobbyResponse
 import at.aau.pulverfass.shared.message.lobby.response.JoinLobbyResponse
 import at.aau.pulverfass.shared.message.lobby.response.LeaveLobbyResponse
+import at.aau.pulverfass.shared.message.lobby.response.LobbyPlayerCountResponse
 import at.aau.pulverfass.shared.message.lobby.response.MapDefinitionSnapshot
 import at.aau.pulverfass.shared.message.lobby.response.MapGetResponse
 import at.aau.pulverfass.shared.message.lobby.response.MapTerritoryDefinitionSnapshot
@@ -42,6 +44,8 @@ import at.aau.pulverfass.shared.message.lobby.response.TurnAdvanceResponse
 import at.aau.pulverfass.shared.message.lobby.response.TurnStateGetResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.CreateLobbyErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.JoinLobbyErrorResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.LobbyPlayerCountErrorCode
+import at.aau.pulverfass.shared.message.lobby.response.error.LobbyPlayerCountErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.MapGetErrorCode
 import at.aau.pulverfass.shared.message.lobby.response.error.MapGetErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.StartPlayerSetErrorCode
@@ -226,6 +230,53 @@ class NetworkPayloadRegistryTest {
             """{"lobbyCode":"EF57","playerId":18,"reason":"HEARTBEAT_TIMEOUT"}""",
             serialized,
         )
+        assertEquals(payload, deserialized)
+    }
+
+    @Test
+    fun `should resolve message type and serialization for lobby player count request`() {
+        val payload = LobbyPlayerCountRequest(LobbyCode("PC12"))
+
+        val messageType = NetworkPayloadRegistry.messageTypeFor(payload)
+        val serialized = NetworkPayloadRegistry.serializePayload(payload)
+        val deserialized = NetworkPayloadRegistry.deserializePayload(messageType, serialized)
+
+        assertEquals(MessageType.LOBBY_PLAYER_COUNT_REQUEST, messageType)
+        assertEquals("""{"lobbyCode":"PC12"}""", serialized)
+        assertEquals(payload, deserialized)
+    }
+
+    @Test
+    fun `should resolve message type and serialization for lobby player count response`() {
+        val payload =
+            LobbyPlayerCountResponse(
+                lobbyCode = LobbyCode("PC34"),
+                playerCount = 5,
+            )
+
+        val messageType = NetworkPayloadRegistry.messageTypeFor(payload)
+        val serialized = NetworkPayloadRegistry.serializePayload(payload)
+        val deserialized = NetworkPayloadRegistry.deserializePayload(messageType, serialized)
+
+        assertEquals(MessageType.LOBBY_PLAYER_COUNT_RESPONSE, messageType)
+        assertEquals("""{"lobbyCode":"PC34","playerCount":5}""", serialized)
+        assertEquals(payload, deserialized)
+    }
+
+    @Test
+    fun `should resolve message type and serialization for lobby player count error response`() {
+        val payload =
+            LobbyPlayerCountErrorResponse(
+                lobbyCode = LobbyCode("PC99"),
+                code = LobbyPlayerCountErrorCode.LOBBY_NOT_FOUND,
+                reason = "Lobby 'PC99' wurde nicht gefunden.",
+            )
+
+        val messageType = NetworkPayloadRegistry.messageTypeFor(payload)
+        val serialized = NetworkPayloadRegistry.serializePayload(payload)
+        val deserialized = NetworkPayloadRegistry.deserializePayload(messageType, serialized)
+
+        assertEquals(MessageType.LOBBY_PLAYER_COUNT_ERROR_RESPONSE, messageType)
         assertEquals(payload, deserialized)
     }
 

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/PlayerConnectionLostEventTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/PlayerConnectionLostEventTest.kt
@@ -1,0 +1,99 @@
+package at.aau.pulverfass.shared.network.message
+
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostEvent
+import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostEventSerializer
+import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostReason
+import at.aau.pulverfass.shared.message.protocol.NetworkMessagePayload
+import kotlinx.serialization.MissingFieldException
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class PlayerConnectionLostEventTest {
+    private val json = Json
+
+    @Test
+    fun `should create player connection lost event correctly`() {
+        val event =
+            PlayerConnectionLostEvent(
+                LobbyCode("AB12"),
+                PlayerId(7),
+                PlayerConnectionLostReason.SOCKET_CLOSED,
+            )
+
+        assertEquals(LobbyCode("AB12"), event.lobbyCode)
+        assertEquals(PlayerId(7), event.playerId)
+        assertEquals(PlayerConnectionLostReason.SOCKET_CLOSED, event.reason)
+    }
+
+    @Test
+    fun `should implement network message payload`() {
+        val event =
+            PlayerConnectionLostEvent(
+                LobbyCode("CD34"),
+                PlayerId(8),
+                PlayerConnectionLostReason.HEARTBEAT_TIMEOUT,
+            )
+        val payload: NetworkMessagePayload = event
+
+        assertEquals(event, payload)
+    }
+
+    @Test
+    fun `should serialize and deserialize player connection lost event`() {
+        val event =
+            PlayerConnectionLostEvent(
+                LobbyCode("EF56"),
+                PlayerId(9),
+                PlayerConnectionLostReason.HEARTBEAT_TIMEOUT,
+            )
+
+        val serialized = json.encodeToString(PlayerConnectionLostEvent.serializer(), event)
+        val deserialized = json.decodeFromString<PlayerConnectionLostEvent>(serialized)
+
+        assertEquals(
+            """{"lobbyCode":"EF56","playerId":9,"reason":"HEARTBEAT_TIMEOUT"}""",
+            serialized,
+        )
+        assertEquals(event, deserialized)
+    }
+
+    @Test
+    fun `should reject missing fields during deserialization`() {
+        assertThrows(SerializationException::class.java) {
+            json.decodeFromString<PlayerConnectionLostEvent>(
+                """{"lobbyCode":"AB12","playerId":9}""",
+            )
+        }
+    }
+
+    @Test
+    fun `should reject unexpected field during deserialization`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            PlayerConnectionLostEventSerializer.deserialize(SerializerTestDecoder(intArrayOf(99)))
+        }
+    }
+
+    @Test
+    fun `should reject missing fields in serializer directly`() {
+        assertThrows(MissingFieldException::class.java) {
+            PlayerConnectionLostEventSerializer.deserialize(
+                SerializerTestDecoder(intArrayOf(CompositeDecoder.DECODE_DONE)),
+            )
+        }
+        assertThrows(MissingFieldException::class.java) {
+            PlayerConnectionLostEventSerializer.deserialize(
+                SerializerTestDecoder(
+                    intArrayOf(0, 1, CompositeDecoder.DECODE_DONE),
+                    scalarString = "AB12",
+                    scalarLong = 9L,
+                ),
+            )
+        }
+    }
+}

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/SerializerTestDecoder.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/SerializerTestDecoder.kt
@@ -11,6 +11,7 @@ internal class SerializerTestDecoder(
     private val indices: IntArray,
     private val stringElements: Map<Int, String> = emptyMap(),
     private val scalarString: String? = null,
+    private val scalarLong: Long? = null,
 ) : Decoder, CompositeDecoder {
     private var indexPointer = 0
 
@@ -46,7 +47,7 @@ internal class SerializerTestDecoder(
 
     override fun decodeInt(): Int = error("Not used in serializer coverage tests.")
 
-    override fun decodeLong(): Long = error("Not used in serializer coverage tests.")
+    override fun decodeLong(): Long = scalarLong ?: error("No scalar long configured.")
 
     override fun decodeNotNullMark(): Boolean = true
 
@@ -94,7 +95,7 @@ internal class SerializerTestDecoder(
     override fun decodeLongElement(
         descriptor: SerialDescriptor,
         index: Int,
-    ): Long = error("Not used in serializer coverage tests.")
+    ): Long = scalarLong ?: error("No scalar long configured.")
 
     override fun decodeShortElement(
         descriptor: SerialDescriptor,


### PR DESCRIPTION
# Übersicht

Dieser PR integriert drei Lobby-/Netzwerk-Features Ende-zu-Ende über `shared`, `server` und – dort wo nötig – auch `app`:

* `PlayerConnectionLostEvent` für lobby-spezifische Disconnect-Benachrichtigungen
* `LobbyPlayerCountRequest/Response` für die autoritative Abfrage der aktuellen Spieleranzahl
* serverseitige Integration beider Message-Flows in Routing und Runtime

---

# Zugehörige Issues

* #166 ConnectionLost Updates (S2L) – Andere Spieler informieren wenn jemand die Connection verliert
* #167 PlayerCount in Lobby abfragen (C2S/S2C) – MessagePackage definieren
* #168 Integration: ConnectionLost + PlayerCount MessagePackages in Router/Server-Flow integrieren

---

# Änderungen

## Shared

* `PlayerConnectionLostEvent` hinzugefügt
* `PlayerConnectionLostReason` hinzugefügt
* `LobbyPlayerCountRequest` hinzugefügt
* `LobbyPlayerCountResponse` hinzugefügt
* `LobbyPlayerCountErrorResponse` hinzugefügt
* `LobbyPlayerCountErrorCode` hinzugefügt
* neue `MessageTypes` registriert
* Serializer in `NetworkPayloadRegistry` eingebunden

---

## Server

* Disconnect-Handling in den Lobby-Flow integriert
* `PlayerConnectionLostEvent` wird nur an Mitglieder der betroffenen Lobby gesendet
* veraltete Disconnects nach Reconnect werden ignoriert
* Handler für `LobbyPlayerCountRequest` in `MainServerLobbyRoutingService` ergänzt
* `LobbyPlayerCountResponse` wird nur an den anfragenden Client gesendet
* deterministische Fehlantwort mit `LOBBY_NOT_FOUND` für unbekannte Lobbys ergänzt
* Logging für die integrierten Message-Flows erweitert

---

## App

* Lobby-State verarbeitet `PlayerConnectionLostEvent`
* getrennte Spieler werden im Waiting Room sichtbar markiert

---

# Verhalten

## ConnectionLost

* bei tatsächlichem Verbindungsverlust eines Spielers sendet der Server genau ein lobby-scoped `PlayerConnectionLostEvent`
* Clients außerhalb der betroffenen Lobby erhalten kein Event
* normales Verlassen der Lobby bleibt semantisch getrennt von `ConnectionLost`

---

## PlayerCount

* ein Client kann die aktuelle autoritative Spieleranzahl einer Lobby abfragen
* die Antwort wird ausschließlich an den anfragenden Client gesendet
* es gibt keinen Broadcast und keine Side-Effects auf den Lobby-State
* unbekannte Lobbys liefern deterministisch `LOBBY_NOT_FOUND`

---

# Tests

Hinzugefügt bzw. erweitert wurden Tests für:

* Serializer-Roundtrip von `PlayerConnectionLostEvent`
* Serializer-Roundtrip von `LobbyPlayerCountRequest/Response/Error`
* Registry- und Codec-Integration

## Server-Integration

* erfolgreichen PlayerCount-Request
* Fehlerfall bei unbekannter Lobby
* korrekten Scope ohne Broadcast
* Disconnect-Broadcast nur an die betroffene Lobby
* produktive Verdrahtung über `moduleWithLobbyRuntime`

---

# Verifikation

## Erfolgreich ausgeführt

* `:shared:ktlintCheck`
* `:server:ktlintCheck`
* `:app:ktlintCheck`
* `:shared:test`
* `:server:test`
* `:app:testDebugUnitTest`
* `:app:assembleDebug`
* `:app:installDebug`

## Zusätzlich verifiziert

* App startet erfolgreich im Android-Emulator
* `MainActivity` wird korrekt gestartet und ist im Vordergrund
* kein Start-Crash in `logcat` festgestellt

---

# Hinweise

* Reconnect selbst ist weiterhin nicht Teil dieser Änderungen
* die fachliche Nutzung von `LobbyPlayerCountRequest/Response` im Frontend ist nicht Teil dieses PRs
* `PlayerConnectionLostEvent` kann clientseitig bereits für Disconnect-Anzeigen verwendet werden
