### PR TITLE
Feature: Phase 1 Backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,7 @@ jobs:
     name: Build and Unit Tests
     runs-on: self-hosted
     env:
-      TEST_DB_CONTAINER: pulverfass-ci-postgres-build
-      TEST_DB_PORT: '55432'
+      TEST_DB_CONTAINER: pulverfass-ci-postgres-build-${{ github.run_id }}
 
     steps:
       - name: Check out repository
@@ -84,14 +83,16 @@ jobs:
       - name: Start test PostgreSQL
         run: |
           set -eu
-          docker rm -f "${TEST_DB_CONTAINER}" >/dev/null 2>&1 || true
           docker run -d \
             --name "${TEST_DB_CONTAINER}" \
             -e POSTGRES_USER=postgres \
             -e POSTGRES_PASSWORD=postgres \
             -e POSTGRES_DB=pulverfass_test \
-            -p "${TEST_DB_PORT}:5432" \
+            -p 0:5432 \
             postgres:17-alpine
+
+          actual_port="$(docker port "${TEST_DB_CONTAINER}" 5432/tcp | head -1 | sed 's/.*://')"
+          echo "TEST_DB_PORT=${actual_port}" >> "${GITHUB_ENV}"
 
           for attempt in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
             if docker exec "${TEST_DB_CONTAINER}" pg_isready -U postgres -d pulverfass_test >/dev/null 2>&1; then
@@ -764,8 +765,7 @@ jobs:
     env:
       ANDROID_SDK_ROOT: ${{ github.workspace }}/android-sdk
       ANDROID_HOME: ${{ github.workspace }}/android-sdk
-      TEST_DB_CONTAINER: pulverfass-ci-postgres-analyze
-      TEST_DB_PORT: '55432'
+      TEST_DB_CONTAINER: pulverfass-ci-postgres-analyze-${{ github.run_id }}
 
     steps:
       - name: Check out repository
@@ -803,14 +803,16 @@ jobs:
       - name: Start test PostgreSQL
         run: |
           set -eu
-          docker rm -f "${TEST_DB_CONTAINER}" >/dev/null 2>&1 || true
           docker run -d \
             --name "${TEST_DB_CONTAINER}" \
             -e POSTGRES_USER=postgres \
             -e POSTGRES_PASSWORD=postgres \
             -e POSTGRES_DB=pulverfass_test \
-            -p "${TEST_DB_PORT}:5432" \
+            -p 0:5432 \
             postgres:17-alpine
+
+          actual_port="$(docker port "${TEST_DB_CONTAINER}" 5432/tcp | head -1 | sed 's/.*://')"
+          echo "TEST_DB_PORT=${actual_port}" >> "${GITHUB_ENV}"
 
           for attempt in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
             if docker exec "${TEST_DB_CONTAINER}" pg_isready -U postgres -d pulverfass_test >/dev/null 2>&1; then

--- a/server/src/main/kotlin/at/aau/pulverfass/server/lobby/CardSetValidator.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/lobby/CardSetValidator.kt
@@ -1,5 +1,6 @@
 package at.aau.pulverfass.server.lobby
 
+import at.aau.pulverfass.shared.lobby.state.CardState
 import at.aau.pulverfass.shared.lobby.state.CardType
 
 /**
@@ -35,5 +36,18 @@ object CardSetValidator {
 
             remainingByType.values.sum() == jokers
         }
+    }
+
+    fun canMakeAnySet(cards: List<CardState>): Boolean {
+        if (cards.size < 3) return false
+        val types = cards.map { it.type }
+        for (i in types.indices) {
+            for (j in i + 1 until types.size) {
+                for (k in j + 1 until types.size) {
+                    if (isValidSet(listOf(types[i], types[j], types[k]))) return true
+                }
+            }
+        }
+        return false
     }
 }

--- a/server/src/main/kotlin/at/aau/pulverfass/server/lobby/CardSetValidator.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/lobby/CardSetValidator.kt
@@ -1,0 +1,39 @@
+package at.aau.pulverfass.server.lobby
+
+import at.aau.pulverfass.shared.lobby.state.CardType
+
+/**
+ * Deterministische Validierung von Dreier-Sets für den Karten-Trade-In.
+ */
+object CardSetValidator {
+    private val validTargets =
+        listOf(
+            listOf(CardType.A, CardType.A, CardType.A),
+            listOf(CardType.B, CardType.B, CardType.B),
+            listOf(CardType.C, CardType.C, CardType.C),
+            listOf(CardType.A, CardType.B, CardType.C),
+        )
+
+    fun isValidSet(types: List<CardType>): Boolean {
+        if (types.size != 3) {
+            return false
+        }
+
+        val jokers = types.count { type -> type == CardType.JOKER }
+        val nonJokers = types.filterNot { type -> type == CardType.JOKER }
+
+        return validTargets.any { target ->
+            val remainingByType = target.groupingBy { type -> type }.eachCount().toMutableMap()
+
+            nonJokers.forEach { type ->
+                val remaining = remainingByType[type] ?: 0
+                if (remaining == 0) {
+                    return@any false
+                }
+                remainingByType[type] = remaining - 1
+            }
+
+            remainingByType.values.sum() == jokers
+        }
+    }
+}

--- a/server/src/main/kotlin/at/aau/pulverfass/server/lobby/runtime/LobbyEventLoop.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/lobby/runtime/LobbyEventLoop.kt
@@ -58,47 +58,8 @@ internal class LobbyEventLoop(
                 scope.launch {
                     for (item in events) {
                         when (item) {
-                            is QueuedItem.Single -> {
-                                try {
-                                    val beforeState = stateProcessor.currentState()
-                                    val afterState =
-                                        stateProcessor.apply(item.event, item.context)
-                                    item.processed.complete(
-                                        ProcessedLobbyEvent(
-                                            event = item.event,
-                                            beforeState = beforeState,
-                                            afterState = afterState,
-                                        ),
-                                    )
-                                } catch (cause: Throwable) {
-                                    item.processed.completeExceptionally(cause)
-                                }
-                            }
-                            is QueuedItem.Batch -> {
-                                val results = mutableListOf<ProcessedLobbyEvent>()
-                                var batchFailed = false
-                                for (event in item.events) {
-                                    if (batchFailed) break
-                                    try {
-                                        val beforeState = stateProcessor.currentState()
-                                        val afterState =
-                                            stateProcessor.apply(event, item.context)
-                                        results.add(
-                                            ProcessedLobbyEvent(
-                                                event = event,
-                                                beforeState = beforeState,
-                                                afterState = afterState,
-                                            ),
-                                        )
-                                    } catch (cause: Throwable) {
-                                        batchFailed = true
-                                        item.processed.completeExceptionally(cause)
-                                    }
-                                }
-                                if (!batchFailed) {
-                                    item.processed.complete(results)
-                                }
-                            }
+                            is QueuedItem.Single -> processSingle(item)
+                            is QueuedItem.Batch -> processBatch(item)
                         }
                     }
                 }
@@ -150,6 +111,43 @@ internal class LobbyEventLoop(
         val processed = CompletableDeferred<List<ProcessedLobbyEvent>>()
         events.send(QueuedItem.Batch(batch, context, processed))
         return processed.await()
+    }
+
+    private fun processSingle(item: QueuedItem.Single) {
+        try {
+            val beforeState = stateProcessor.currentState()
+            val afterState = stateProcessor.apply(item.event, item.context)
+            item.processed.complete(
+                ProcessedLobbyEvent(
+                    event = item.event,
+                    beforeState = beforeState,
+                    afterState = afterState,
+                ),
+            )
+        } catch (cause: Throwable) {
+            item.processed.completeExceptionally(cause)
+        }
+    }
+
+    private fun processBatch(item: QueuedItem.Batch) {
+        val results = mutableListOf<ProcessedLobbyEvent>()
+        for (event in item.events) {
+            try {
+                val beforeState = stateProcessor.currentState()
+                val afterState = stateProcessor.apply(event, item.context)
+                results.add(
+                    ProcessedLobbyEvent(
+                        event = event,
+                        beforeState = beforeState,
+                        afterState = afterState,
+                    ),
+                )
+            } catch (cause: Throwable) {
+                item.processed.completeExceptionally(cause)
+                return
+            }
+        }
+        item.processed.complete(results)
     }
 
     /**

--- a/server/src/main/kotlin/at/aau/pulverfass/server/lobby/runtime/LobbyEventLoop.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/lobby/runtime/LobbyEventLoop.kt
@@ -39,7 +39,7 @@ internal class LobbyEventLoop(
         }
     }
 
-    private val events = Channel<QueuedLobbyEvent>(capacity = queueCapacity)
+    private val events = Channel<QueuedItem>(capacity = queueCapacity)
     private val lifecycleLock = Any()
     private var loopJob: Job? = null
 
@@ -56,19 +56,49 @@ internal class LobbyEventLoop(
             }
             loopJob =
                 scope.launch {
-                    for (queued in events) {
-                        try {
-                            val beforeState = stateProcessor.currentState()
-                            val afterState = stateProcessor.apply(queued.event, queued.context)
-                            queued.processed.complete(
-                                ProcessedLobbyEvent(
-                                    event = queued.event,
-                                    beforeState = beforeState,
-                                    afterState = afterState,
-                                ),
-                            )
-                        } catch (cause: Throwable) {
-                            queued.processed.completeExceptionally(cause)
+                    for (item in events) {
+                        when (item) {
+                            is QueuedItem.Single -> {
+                                try {
+                                    val beforeState = stateProcessor.currentState()
+                                    val afterState =
+                                        stateProcessor.apply(item.event, item.context)
+                                    item.processed.complete(
+                                        ProcessedLobbyEvent(
+                                            event = item.event,
+                                            beforeState = beforeState,
+                                            afterState = afterState,
+                                        ),
+                                    )
+                                } catch (cause: Throwable) {
+                                    item.processed.completeExceptionally(cause)
+                                }
+                            }
+                            is QueuedItem.Batch -> {
+                                val results = mutableListOf<ProcessedLobbyEvent>()
+                                var batchFailed = false
+                                for (event in item.events) {
+                                    if (batchFailed) break
+                                    try {
+                                        val beforeState = stateProcessor.currentState()
+                                        val afterState =
+                                            stateProcessor.apply(event, item.context)
+                                        results.add(
+                                            ProcessedLobbyEvent(
+                                                event = event,
+                                                beforeState = beforeState,
+                                                afterState = afterState,
+                                            ),
+                                        )
+                                    } catch (cause: Throwable) {
+                                        batchFailed = true
+                                        item.processed.completeExceptionally(cause)
+                                    }
+                                }
+                                if (!batchFailed) {
+                                    item.processed.complete(results)
+                                }
+                            }
                         }
                     }
                 }
@@ -96,7 +126,29 @@ internal class LobbyEventLoop(
             "Lobby event loop for '${lobbyCode.value}' is not running."
         }
         val processed = CompletableDeferred<ProcessedLobbyEvent>()
-        events.send(QueuedLobbyEvent(event, context, processed))
+        events.send(QueuedItem.Single(event, context, processed))
+        return processed.await()
+    }
+
+    /**
+     * Reiht mehrere Events als atomare Einheit ein.
+     *
+     * Alle Events werden als einzelne Queue-Nachricht verarbeitet, sodass kein
+     * fremdes Event zwischen den Batch-Events interleaven kann.
+     */
+    suspend fun submitBatch(
+        batch: List<LobbyEvent>,
+        context: EventContext? = null,
+    ): List<ProcessedLobbyEvent> {
+        require(batch.all { it.lobbyCode == lobbyCode }) {
+            "Alle Batch-Events müssen zur Lobby '$lobbyCode' gehören."
+        }
+        val activeJob = synchronized(lifecycleLock) { loopJob }
+        check(activeJob?.isActive == true) {
+            "Lobby event loop for '${lobbyCode.value}' is not running."
+        }
+        val processed = CompletableDeferred<List<ProcessedLobbyEvent>>()
+        events.send(QueuedItem.Batch(batch, context, processed))
         return processed.await()
     }
 
@@ -119,14 +171,19 @@ internal class LobbyEventLoop(
     }
 }
 
-/**
- * Interne Queue-Nachricht inklusive technischer Completion-Signalisierung.
- */
-private data class QueuedLobbyEvent(
-    val event: LobbyEvent,
-    val context: EventContext?,
-    val processed: CompletableDeferred<ProcessedLobbyEvent>,
-)
+private sealed class QueuedItem {
+    data class Single(
+        val event: LobbyEvent,
+        val context: EventContext?,
+        val processed: CompletableDeferred<ProcessedLobbyEvent>,
+    ) : QueuedItem()
+
+    data class Batch(
+        val events: List<LobbyEvent>,
+        val context: EventContext?,
+        val processed: CompletableDeferred<List<ProcessedLobbyEvent>>,
+    ) : QueuedItem()
+}
 
 internal data class ProcessedLobbyEvent(
     val event: LobbyEvent,

--- a/server/src/main/kotlin/at/aau/pulverfass/server/lobby/runtime/LobbyManager.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/lobby/runtime/LobbyManager.kt
@@ -83,6 +83,14 @@ class LobbyManager(
         return requireRuntime(event.lobbyCode).submit(event, context)
     }
 
+    suspend fun submitAll(
+        lobbyCode: LobbyCode,
+        events: List<LobbyEvent>,
+        context: EventContext? = null,
+    ) {
+        requireRuntime(lobbyCode).submitAll(events, context)
+    }
+
     /**
      * Entfernt und stoppt eine einzelne Lobby-Runtime.
      */

--- a/server/src/main/kotlin/at/aau/pulverfass/server/lobby/runtime/LobbyRuntime.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/lobby/runtime/LobbyRuntime.kt
@@ -101,6 +101,44 @@ class LobbyRuntime private constructor(
     }
 
     /**
+     * Reicht mehrere Events als atomare Batch-Einheit ein.
+     *
+     * Alle Events werden ohne Unterbrechung durch fremde Events verarbeitet.
+     * Hook-Aufrufe feuern für jedes einzelne Event im Batch.
+     */
+    suspend fun submitAll(
+        events: List<LobbyEvent>,
+        context: EventContext? = null,
+    ) {
+        events.forEach { event -> hooks.onEventEnqueued(lobbyCode, event, context) }
+        val processedList =
+            try {
+                eventLoop.submitBatch(events, context)
+            } catch (cause: Throwable) {
+                hooks.onEventRejected(lobbyCode, events.first(), cause)
+                throw cause
+            }
+        processedList.forEach { processed ->
+            try {
+                hooks.onEventAccepted(
+                    lobbyCode,
+                    processed.event,
+                    processed.beforeState,
+                    processed.afterState,
+                )
+            } catch (cause: Exception) {
+                logger.warn(
+                    "Accepted-event hook failed for lobby {} and event {}. " +
+                        "State mutation was already applied.",
+                    lobbyCode.value,
+                    processed.event::class.simpleName,
+                    cause,
+                )
+            }
+        }
+    }
+
+    /**
      * Beendet die Runtime kontrolliert.
      *
      * Mehrfache Aufrufe sind erlaubt und wirken nur beim ersten Aufruf.

--- a/server/src/main/kotlin/at/aau/pulverfass/server/persistence/LobbyPersistenceGateway.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/persistence/LobbyPersistenceGateway.kt
@@ -10,6 +10,8 @@ import at.aau.pulverfass.shared.lobby.event.InvalidActionDetected
 import at.aau.pulverfass.shared.lobby.event.LobbyClosed
 import at.aau.pulverfass.shared.lobby.event.LobbyCreated
 import at.aau.pulverfass.shared.lobby.event.LobbyEvent
+import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsChangedEvent
+import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsSetEvent
 import at.aau.pulverfass.shared.lobby.event.PlayerJoined
 import at.aau.pulverfass.shared.lobby.event.PlayerKicked
 import at.aau.pulverfass.shared.lobby.event.PlayerLeft
@@ -173,6 +175,20 @@ private fun LobbyEvent.toPersistedPayload(): PersistedEventPayload =
             persistedPayload(
                 type = "lobby_created",
                 "lobbyCode" to lobbyCode.value,
+            )
+        is PendingReinforcementsSetEvent ->
+            persistedPayload(
+                type = "pending_reinforcements_set",
+                "lobbyCode" to lobbyCode.value,
+                "playerId" to playerId.value,
+                "amount" to amount,
+            )
+        is PendingReinforcementsChangedEvent ->
+            persistedPayload(
+                type = "pending_reinforcements_changed",
+                "lobbyCode" to lobbyCode.value,
+                "playerId" to playerId.value,
+                "delta" to delta,
             )
         is LobbyClosed ->
             persistedPayload(

--- a/server/src/main/kotlin/at/aau/pulverfass/server/persistence/LobbyPersistenceGateway.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/persistence/LobbyPersistenceGateway.kt
@@ -3,8 +3,10 @@ package at.aau.pulverfass.server.persistence
 import at.aau.pulverfass.server.DatabaseReadiness
 import at.aau.pulverfass.server.DatabaseReadinessProbe
 import at.aau.pulverfass.server.DatabaseReadinessState
+import at.aau.pulverfass.shared.ids.CardId
 import at.aau.pulverfass.shared.ids.PlayerId
 import at.aau.pulverfass.shared.ids.TerritoryId
+import at.aau.pulverfass.shared.lobby.event.CardSetTradedInEvent
 import at.aau.pulverfass.shared.lobby.event.GameStarted
 import at.aau.pulverfass.shared.lobby.event.InvalidActionDetected
 import at.aau.pulverfass.shared.lobby.event.LobbyClosed
@@ -12,6 +14,7 @@ import at.aau.pulverfass.shared.lobby.event.LobbyCreated
 import at.aau.pulverfass.shared.lobby.event.LobbyEvent
 import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsChangedEvent
 import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsSetEvent
+import at.aau.pulverfass.shared.lobby.event.PlayerCardsRemovedEvent
 import at.aau.pulverfass.shared.lobby.event.PlayerJoined
 import at.aau.pulverfass.shared.lobby.event.PlayerKicked
 import at.aau.pulverfass.shared.lobby.event.PlayerLeft
@@ -26,6 +29,8 @@ import at.aau.pulverfass.shared.lobby.state.GameState
 import at.aau.pulverfass.shared.message.lobby.event.GameStateSnapshotBroadcast
 import at.aau.pulverfass.shared.message.lobby.event.PhaseBoundaryEvent
 import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
@@ -169,12 +174,32 @@ private data class PersistedEventPayload(
     val payload: JsonElement,
 )
 
+private val stringListSerializer = ListSerializer(String.serializer())
+
 private fun LobbyEvent.toPersistedPayload(): PersistedEventPayload =
     when (this) {
         is LobbyCreated ->
             persistedPayload(
                 type = "lobby_created",
                 "lobbyCode" to lobbyCode.value,
+            )
+        is CardSetTradedInEvent ->
+            PersistedEventPayload(
+                type = "card_set_traded_in",
+                payload =
+                    buildJsonObject {
+                        put("lobbyCode", lobbyCode.value)
+                        put("playerId", playerId.value)
+                        put("value", value)
+                        put("tradeIndex", tradeIndex)
+                        put(
+                            "cardIds",
+                            Json.Default.encodeToJsonElement(
+                                stringListSerializer,
+                                cardIds.map(CardId::value),
+                            ),
+                        )
+                    },
             )
         is PendingReinforcementsSetEvent ->
             persistedPayload(
@@ -189,6 +214,22 @@ private fun LobbyEvent.toPersistedPayload(): PersistedEventPayload =
                 "lobbyCode" to lobbyCode.value,
                 "playerId" to playerId.value,
                 "delta" to delta,
+            )
+        is PlayerCardsRemovedEvent ->
+            PersistedEventPayload(
+                type = "player_cards_removed",
+                payload =
+                    buildJsonObject {
+                        put("lobbyCode", lobbyCode.value)
+                        put("playerId", playerId.value)
+                        put(
+                            "cardIds",
+                            Json.Default.encodeToJsonElement(
+                                stringListSerializer,
+                                cardIds.map(CardId::value),
+                            ),
+                        )
+                    },
             )
         is LobbyClosed ->
             persistedPayload(

--- a/server/src/main/kotlin/at/aau/pulverfass/server/persistence/LobbyRecoveryLoader.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/persistence/LobbyRecoveryLoader.kt
@@ -10,6 +10,8 @@ import at.aau.pulverfass.shared.lobby.event.InvalidActionDetected
 import at.aau.pulverfass.shared.lobby.event.LobbyClosed
 import at.aau.pulverfass.shared.lobby.event.LobbyCreated
 import at.aau.pulverfass.shared.lobby.event.LobbyEvent
+import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsChangedEvent
+import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsSetEvent
 import at.aau.pulverfass.shared.lobby.event.PlayerJoined
 import at.aau.pulverfass.shared.lobby.event.PlayerKicked
 import at.aau.pulverfass.shared.lobby.event.PlayerLeft
@@ -24,6 +26,7 @@ import at.aau.pulverfass.shared.lobby.reducer.DefaultLobbyEventReducer
 import at.aau.pulverfass.shared.lobby.reducer.LobbyEventReducer
 import at.aau.pulverfass.shared.lobby.state.GameState
 import at.aau.pulverfass.shared.lobby.state.GameStatus
+import at.aau.pulverfass.shared.lobby.state.PendingReinforcements
 import at.aau.pulverfass.shared.lobby.state.TerritoryState
 import at.aau.pulverfass.shared.lobby.state.TurnPhase
 import at.aau.pulverfass.shared.lobby.state.TurnState
@@ -146,6 +149,7 @@ data class PersistedLobbyRecoverySnapshot(
     val definition: MapDefinitionSnapshot,
     val territoryStates: List<MapTerritoryStateSnapshot>,
     val setupTroopsToPlaceByPlayer: List<PersistedSetupTroopsSnapshot>,
+    val pendingReinforcements: PendingReinforcements? = null,
 ) {
     companion object {
         fun fromGameState(gameState: GameState): PersistedLobbyRecoverySnapshot =
@@ -190,6 +194,7 @@ data class PersistedLobbyRecoverySnapshot(
                             troopCount = troopCount,
                         )
                     },
+                pendingReinforcements = gameState.pendingReinforcements,
             )
     }
 
@@ -233,6 +238,7 @@ data class PersistedLobbyRecoverySnapshot(
                 },
             setupTroopsToPlaceByPlayer =
                 setupTroopsToPlaceByPlayer.associate { it.playerId to it.troopCount },
+            pendingReinforcements = pendingReinforcements,
         )
     }
 }
@@ -317,6 +323,18 @@ internal fun PersistedLobbyEventRecord.toLobbyEvent(): LobbyEvent {
 
     return when (eventType) {
         "lobby_created" -> LobbyCreated(lobbyCode)
+        "pending_reinforcements_set" ->
+            PendingReinforcementsSetEvent(
+                lobbyCode = lobbyCode,
+                playerId = PlayerId(jsonObject.long("playerId")),
+                amount = jsonObject.int("amount"),
+            )
+        "pending_reinforcements_changed" ->
+            PendingReinforcementsChangedEvent(
+                lobbyCode = lobbyCode,
+                playerId = PlayerId(jsonObject.long("playerId")),
+                delta = jsonObject.int("delta"),
+            )
         "lobby_closed" -> LobbyClosed(lobbyCode, reason = jsonObject.nullableString("reason"))
         "player_joined" ->
             PlayerJoined(

--- a/server/src/main/kotlin/at/aau/pulverfass/server/persistence/LobbyRecoveryLoader.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/persistence/LobbyRecoveryLoader.kt
@@ -2,9 +2,11 @@ package at.aau.pulverfass.server.persistence
 
 import at.aau.pulverfass.server.lobby.runtime.LobbyManager
 import at.aau.pulverfass.server.map.MapDefinitionRepository
+import at.aau.pulverfass.shared.ids.CardId
 import at.aau.pulverfass.shared.ids.LobbyCode
 import at.aau.pulverfass.shared.ids.PlayerId
 import at.aau.pulverfass.shared.ids.TerritoryId
+import at.aau.pulverfass.shared.lobby.event.CardSetTradedInEvent
 import at.aau.pulverfass.shared.lobby.event.GameStarted
 import at.aau.pulverfass.shared.lobby.event.InvalidActionDetected
 import at.aau.pulverfass.shared.lobby.event.LobbyClosed
@@ -12,6 +14,7 @@ import at.aau.pulverfass.shared.lobby.event.LobbyCreated
 import at.aau.pulverfass.shared.lobby.event.LobbyEvent
 import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsChangedEvent
 import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsSetEvent
+import at.aau.pulverfass.shared.lobby.event.PlayerCardsRemovedEvent
 import at.aau.pulverfass.shared.lobby.event.PlayerJoined
 import at.aau.pulverfass.shared.lobby.event.PlayerKicked
 import at.aau.pulverfass.shared.lobby.event.PlayerLeft
@@ -24,8 +27,11 @@ import at.aau.pulverfass.shared.lobby.event.TurnEnded
 import at.aau.pulverfass.shared.lobby.event.TurnStateUpdatedEvent
 import at.aau.pulverfass.shared.lobby.reducer.DefaultLobbyEventReducer
 import at.aau.pulverfass.shared.lobby.reducer.LobbyEventReducer
+import at.aau.pulverfass.shared.lobby.state.DeckState
+import at.aau.pulverfass.shared.lobby.state.DiscardPileState
 import at.aau.pulverfass.shared.lobby.state.GameState
 import at.aau.pulverfass.shared.lobby.state.GameStatus
+import at.aau.pulverfass.shared.lobby.state.HandState
 import at.aau.pulverfass.shared.lobby.state.PendingReinforcements
 import at.aau.pulverfass.shared.lobby.state.TerritoryState
 import at.aau.pulverfass.shared.lobby.state.TurnPhase
@@ -47,6 +53,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.longOrNull
@@ -150,6 +157,10 @@ data class PersistedLobbyRecoverySnapshot(
     val territoryStates: List<MapTerritoryStateSnapshot>,
     val setupTroopsToPlaceByPlayer: List<PersistedSetupTroopsSnapshot>,
     val pendingReinforcements: PendingReinforcements? = null,
+    val handState: HandState = HandState(),
+    val deckState: DeckState = DeckState(),
+    val discardPileState: DiscardPileState = DiscardPileState(),
+    val tradedInSetCount: Int = 0,
 ) {
     companion object {
         fun fromGameState(gameState: GameState): PersistedLobbyRecoverySnapshot =
@@ -195,6 +206,10 @@ data class PersistedLobbyRecoverySnapshot(
                         )
                     },
                 pendingReinforcements = gameState.pendingReinforcements,
+                handState = gameState.handState,
+                deckState = gameState.deckState,
+                discardPileState = gameState.discardPileState,
+                tradedInSetCount = gameState.tradedInSetCount,
             )
     }
 
@@ -239,6 +254,10 @@ data class PersistedLobbyRecoverySnapshot(
             setupTroopsToPlaceByPlayer =
                 setupTroopsToPlaceByPlayer.associate { it.playerId to it.troopCount },
             pendingReinforcements = pendingReinforcements,
+            handState = handState,
+            deckState = deckState,
+            discardPileState = discardPileState,
+            tradedInSetCount = tradedInSetCount,
         )
     }
 }
@@ -323,6 +342,14 @@ internal fun PersistedLobbyEventRecord.toLobbyEvent(): LobbyEvent {
 
     return when (eventType) {
         "lobby_created" -> LobbyCreated(lobbyCode)
+        "card_set_traded_in" ->
+            CardSetTradedInEvent(
+                lobbyCode = lobbyCode,
+                playerId = PlayerId(jsonObject.long("playerId")),
+                cardIds = jsonObject.stringList("cardIds").map(::CardId),
+                value = jsonObject.int("value"),
+                tradeIndex = jsonObject.int("tradeIndex"),
+            )
         "pending_reinforcements_set" ->
             PendingReinforcementsSetEvent(
                 lobbyCode = lobbyCode,
@@ -334,6 +361,12 @@ internal fun PersistedLobbyEventRecord.toLobbyEvent(): LobbyEvent {
                 lobbyCode = lobbyCode,
                 playerId = PlayerId(jsonObject.long("playerId")),
                 delta = jsonObject.int("delta"),
+            )
+        "player_cards_removed" ->
+            PlayerCardsRemovedEvent(
+                lobbyCode = lobbyCode,
+                playerId = PlayerId(jsonObject.long("playerId")),
+                cardIds = jsonObject.stringList("cardIds").map(::CardId),
             )
         "lobby_closed" -> LobbyClosed(lobbyCode, reason = jsonObject.nullableString("reason"))
         "player_joined" ->
@@ -417,6 +450,9 @@ internal fun PersistedLobbyEventRecord.toLobbyEvent(): LobbyEvent {
 }
 
 private fun JsonObject.string(key: String): String = getValue(key).jsonPrimitive.content
+
+private fun JsonObject.stringList(key: String): List<String> =
+    getValue(key).jsonArray.map { element -> element.jsonPrimitive.content }
 
 private fun JsonObject.nullableString(key: String): String? =
     this[key]?.jsonPrimitive?.contentOrNull

--- a/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
@@ -608,13 +608,15 @@ class MainServerLobbyRoutingService(
         previousTurnState: TurnState?,
         context: EventContext,
     ) {
-        if (previousTurnState?.turnPhase != TurnPhase.DRAW_CARD) {
-            return
-        }
-
         val currentState = lobbyManager.getLobby(lobbyCode)?.currentState() ?: return
         val currentTurnState = currentState.resolvedTurnState ?: return
         if (currentTurnState.turnPhase != TurnPhase.REINFORCEMENTS) {
+            return
+        }
+        // Skip if already in REINFORCEMENTS for the same player (no phase entry occurred)
+        if (previousTurnState?.turnPhase == TurnPhase.REINFORCEMENTS &&
+            previousTurnState.activePlayerId == currentTurnState.activePlayerId
+        ) {
             return
         }
 
@@ -702,6 +704,13 @@ class MainServerLobbyRoutingService(
             is LobbyRoutingResult.Success -> {
                 dispatchNetworkMessages(request)
                 if (lobbyCode != null) {
+                    if (request.payload is StartGameRequest) {
+                        grantBaseReinforcementsOnPhaseStart(
+                            lobbyCode = lobbyCode,
+                            previousTurnState = previousTurnState,
+                            context = request.context,
+                        )
+                    }
                     broadcastTurnStateIfChanged(
                         lobbyCode = lobbyCode,
                         previousTurnState = previousTurnState,
@@ -1149,6 +1158,10 @@ class MainServerLobbyRoutingService(
         require(currentTurnState.activePlayerId == payload.playerId) { "NOT_ACTIVE_PLAYER" }
         check(!(currentTurnState.isPaused)) { "GAME_PAUSED" }
         require(currentTurnState.turnPhase == TurnPhase.REINFORCEMENTS) { "PHASE_MISMATCH" }
+        val hand = state.handOf(payload.playerId)
+        require(
+            !(hand.size >= 5 && CardSetValidator.canMakeAnySet(hand)),
+        ) { "FORCED_TRADE_REQUIRED" }
         require(payload.placements.isNotEmpty()) { "INVALID_PLACEMENT" }
 
         payload.placements.forEach { placement ->
@@ -1271,6 +1284,10 @@ class MainServerLobbyRoutingService(
         require(currentTurnState.activePlayerId == payload.playerId) { "NOT_ACTIVE_PLAYER" }
         check(!(currentTurnState.isPaused)) { "GAME_PAUSED" }
         require(currentTurnState.turnPhase == TurnPhase.REINFORCEMENTS) { "PHASE_MISMATCH" }
+        val hand = state.handOf(payload.playerId)
+        require(
+            !(hand.size >= 5 && CardSetValidator.canMakeAnySet(hand)),
+        ) { "FORCED_TRADE_REQUIRED" }
         require(state.pendingReinforcementsFor(payload.playerId) == 0) {
             "PENDING_REINFORCEMENTS_REMAINING"
         }
@@ -1427,6 +1444,7 @@ class MainServerLobbyRoutingService(
                 "TERRITORY_NOT_OWNED" -> PlaceReinforcementsErrorCode.TERRITORY_NOT_OWNED
                 "OVERSPEND" -> PlaceReinforcementsErrorCode.OVERSPEND
                 "INVALID_PLACEMENT" -> PlaceReinforcementsErrorCode.INVALID_PLACEMENT
+                "FORCED_TRADE_REQUIRED" -> PlaceReinforcementsErrorCode.FORCED_TRADE_REQUIRED
                 else -> PlaceReinforcementsErrorCode.NOT_ACTIVE_PLAYER
             }
 
@@ -1487,6 +1505,9 @@ class MainServerLobbyRoutingService(
                 PlaceReinforcementsErrorCode.INVALID_PLACEMENT ->
                     "Die Verstärkungsplatzierung muss mindestens ein Ziel enthalten und alle " +
                         "Mengen müssen positiv sein."
+                PlaceReinforcementsErrorCode.FORCED_TRADE_REQUIRED ->
+                    "Truppenplatzierung ist gesperrt: Spieler '${payload.playerId.value}' hat " +
+                        "mindestens 5 Karten und kann ein Set abgeben."
             }
 
         return PlaceReinforcementsErrorResponse(code = code, reason = reason)
@@ -1574,6 +1595,7 @@ class MainServerLobbyRoutingService(
                 "PHASE_MISMATCH" -> ConfirmReinforcementsDoneErrorCode.PHASE_MISMATCH
                 "PENDING_REINFORCEMENTS_REMAINING" ->
                     ConfirmReinforcementsDoneErrorCode.PENDING_REINFORCEMENTS_REMAINING
+                "FORCED_TRADE_REQUIRED" -> ConfirmReinforcementsDoneErrorCode.FORCED_TRADE_REQUIRED
                 else -> ConfirmReinforcementsDoneErrorCode.NOT_ACTIVE_PLAYER
             }
 

--- a/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
@@ -1458,8 +1458,7 @@ class MainServerLobbyRoutingService(
                 PlaceReinforcementsErrorCode.REQUESTER_MISMATCH -> {
                     val contextPlayerId = request.context.playerId
                     if (contextPlayerId == null) {
-                        "Connection ist keinem Spieler für Lobby " +
-                            "'${payload.lobbyCode.value}' zugeordnet."
+                        connectionNotAssignedToLobby(payload.lobbyCode)
                     } else {
                         "Requester '${payload.playerId.value}' passt nicht " +
                             "zur aktuellen Connection '${contextPlayerId.value}'."
@@ -1609,8 +1608,7 @@ class MainServerLobbyRoutingService(
                 ConfirmReinforcementsDoneErrorCode.REQUESTER_MISMATCH -> {
                     val contextPlayerId = request.context.playerId
                     if (contextPlayerId == null) {
-                        "Connection ist keinem Spieler für Lobby " +
-                            "'${payload.lobbyCode.value}' zugeordnet."
+                        connectionNotAssignedToLobby(payload.lobbyCode)
                     } else {
                         "Requester '${payload.playerId.value}' passt nicht " +
                             "zur aktuellen Connection '${contextPlayerId.value}'."
@@ -1684,8 +1682,7 @@ class MainServerLobbyRoutingService(
                 StartPlayerSetErrorCode.REQUESTER_MISMATCH -> {
                     val contextPlayerId = request.context.playerId
                     if (contextPlayerId == null) {
-                        "Connection ist keinem Spieler für Lobby " +
-                            "'${payload.lobbyCode.value}' zugeordnet."
+                        connectionNotAssignedToLobby(payload.lobbyCode)
                     } else {
                         "Requester '${payload.requesterPlayerId.value}' passt " +
                             "nicht zur aktuellen Connection '${contextPlayerId.value}'."
@@ -2041,6 +2038,9 @@ class MainServerLobbyRoutingService(
         activeJob.cancel()
         activeJob.join()
     }
+
+    private fun connectionNotAssignedToLobby(lobbyCode: LobbyCode): String =
+        "Connection ist keinem Spieler für Lobby '${lobbyCode.value}' zugeordnet."
 }
 
 /**

--- a/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
@@ -24,7 +24,6 @@ import at.aau.pulverfass.shared.lobby.state.TurnPhase
 import at.aau.pulverfass.shared.lobby.state.TurnState
 import at.aau.pulverfass.shared.lobby.state.TurnStateMachine
 import at.aau.pulverfass.shared.message.connection.request.ReconnectRequest
-import at.aau.pulverfass.shared.message.lobby.request.ConfirmReinforcementsDoneRequest
 import at.aau.pulverfass.shared.message.lobby.event.GameStartedEvent
 import at.aau.pulverfass.shared.message.lobby.event.PhaseBoundaryEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostEvent
@@ -32,6 +31,7 @@ import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostReason
 import at.aau.pulverfass.shared.message.lobby.event.PlayerJoinedLobbyEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerKickedLobbyEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerLeftLobbyEvent
+import at.aau.pulverfass.shared.message.lobby.request.ConfirmReinforcementsDoneRequest
 import at.aau.pulverfass.shared.message.lobby.request.CreateLobbyRequest
 import at.aau.pulverfass.shared.message.lobby.request.GameStateCatchUpRequest
 import at.aau.pulverfass.shared.message.lobby.request.GameStatePrivateGetRequest
@@ -43,11 +43,10 @@ import at.aau.pulverfass.shared.message.lobby.request.MapGetRequest
 import at.aau.pulverfass.shared.message.lobby.request.PlaceReinforcementsRequest
 import at.aau.pulverfass.shared.message.lobby.request.StartGameRequest
 import at.aau.pulverfass.shared.message.lobby.request.StartPlayerSetRequest
-import at.aau.pulverfass.shared.message.lobby.request.TerritoryPlacement
 import at.aau.pulverfass.shared.message.lobby.request.TurnAdvanceRequest
 import at.aau.pulverfass.shared.message.lobby.request.TurnStateGetRequest
-import at.aau.pulverfass.shared.message.lobby.response.CreateLobbyResponse
 import at.aau.pulverfass.shared.message.lobby.response.ConfirmReinforcementsDoneResponse
+import at.aau.pulverfass.shared.message.lobby.response.CreateLobbyResponse
 import at.aau.pulverfass.shared.message.lobby.response.GameStateCatchUpResponse
 import at.aau.pulverfass.shared.message.lobby.response.GameStatePrivateGetResponse
 import at.aau.pulverfass.shared.message.lobby.response.JoinLobbyResponse
@@ -60,13 +59,13 @@ import at.aau.pulverfass.shared.message.lobby.response.StartGameResponse
 import at.aau.pulverfass.shared.message.lobby.response.StartPlayerSetResponse
 import at.aau.pulverfass.shared.message.lobby.response.TurnAdvanceResponse
 import at.aau.pulverfass.shared.message.lobby.response.TurnStateGetResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.ConfirmReinforcementsDoneErrorCode
+import at.aau.pulverfass.shared.message.lobby.response.error.ConfirmReinforcementsDoneErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.CreateLobbyErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.GameStateCatchUpErrorCode
 import at.aau.pulverfass.shared.message.lobby.response.error.GameStateCatchUpErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.GameStatePrivateGetErrorCode
 import at.aau.pulverfass.shared.message.lobby.response.error.GameStatePrivateGetErrorResponse
-import at.aau.pulverfass.shared.message.lobby.response.error.ConfirmReinforcementsDoneErrorCode
-import at.aau.pulverfass.shared.message.lobby.response.error.ConfirmReinforcementsDoneErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.JoinLobbyErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.KickPlayerErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.LobbyPlayerCountErrorCode
@@ -1109,7 +1108,14 @@ class MainServerLobbyRoutingService(
             require(placement.amount > 0) { "INVALID_PLACEMENT" }
         }
 
-        val totalPlacement = payload.placements.sumOf(TerritoryPlacement::amount)
+        val totalPlacement =
+            try {
+                payload.placements.fold(0) { sum, placement ->
+                    Math.addExact(sum, placement.amount)
+                }
+            } catch (_: ArithmeticException) {
+                throw IllegalArgumentException("INVALID_PLACEMENT")
+            }
         require(totalPlacement <= state.pendingReinforcementsFor(payload.playerId)) { "OVERSPEND" }
 
         val projectedTroopCounts = linkedMapOf<TerritoryId, Int>()
@@ -1121,7 +1127,12 @@ class MainServerLobbyRoutingService(
                 val currentTroopCount =
                     projectedTroopCounts[placement.territoryId]
                         ?: state.troopCountOf(placement.territoryId)
-                val updatedTroopCount = currentTroopCount + placement.amount
+                val updatedTroopCount =
+                    try {
+                        Math.addExact(currentTroopCount, placement.amount)
+                    } catch (_: ArithmeticException) {
+                        throw IllegalArgumentException("INVALID_PLACEMENT")
+                    }
                 projectedTroopCounts[placement.territoryId] = updatedTroopCount
 
                 TerritoryTroopsChangedEvent(
@@ -1161,7 +1172,6 @@ class MainServerLobbyRoutingService(
         require(state.pendingReinforcementsFor(payload.playerId) == 0) {
             "PENDING_REINFORCEMENTS_REMAINING"
         }
-        requireForcedTradeRuleSatisfied(state, payload.playerId)
 
         return buildTurnAdvanceEvent(
             request = request,
@@ -1362,10 +1372,16 @@ class MainServerLobbyRoutingService(
                 }
                 PlaceReinforcementsErrorCode.TERRITORY_NOT_OWNED ->
                     "Alle Zielterritorien müssen Spieler '${payload.playerId.value}' gehören."
-                PlaceReinforcementsErrorCode.OVERSPEND ->
+                PlaceReinforcementsErrorCode.OVERSPEND -> {
+                    val remainingPending =
+                        lobbyManager
+                            .getLobby(payload.lobbyCode)
+                            ?.currentState()
+                            ?.pendingReinforcementsFor(payload.playerId)
+                            ?: 0
                     "Angeforderte Verstärkungen (${payload.placements.sumOf { it.amount }}) " +
-                        "überschreiten den verbleibenden Pool von " +
-                        "${lobbyManager.getLobby(payload.lobbyCode)?.currentState()?.pendingReinforcementsFor(payload.playerId) ?: 0}."
+                        "überschreiten den verbleibenden Pool von $remainingPending."
+                }
                 PlaceReinforcementsErrorCode.INVALID_PLACEMENT ->
                     "Die Verstärkungsplatzierung muss mindestens ein Ziel enthalten und alle " +
                         "Mengen müssen positiv sein."
@@ -1387,8 +1403,6 @@ class MainServerLobbyRoutingService(
                 "PHASE_MISMATCH" -> ConfirmReinforcementsDoneErrorCode.PHASE_MISMATCH
                 "PENDING_REINFORCEMENTS_REMAINING" ->
                     ConfirmReinforcementsDoneErrorCode.PENDING_REINFORCEMENTS_REMAINING
-                "FORCED_TRADE_REQUIRED" ->
-                    ConfirmReinforcementsDoneErrorCode.FORCED_TRADE_REQUIRED
                 else -> ConfirmReinforcementsDoneErrorCode.NOT_ACTIVE_PLAYER
             }
 
@@ -1399,9 +1413,11 @@ class MainServerLobbyRoutingService(
                 ConfirmReinforcementsDoneErrorCode.REQUESTER_MISMATCH -> {
                     val contextPlayerId = request.context.playerId
                     if (contextPlayerId == null) {
-                        "Connection ist keinem Spieler für Lobby '${payload.lobbyCode.value}' zugeordnet."
+                        "Connection ist keinem Spieler für Lobby " +
+                            "'${payload.lobbyCode.value}' zugeordnet."
                     } else {
-                        "Requester '${payload.playerId.value}' passt nicht zur aktuellen Connection '${contextPlayerId.value}'."
+                        "Requester '${payload.playerId.value}' passt nicht " +
+                            "zur aktuellen Connection '${contextPlayerId.value}'."
                     }
                 }
                 ConfirmReinforcementsDoneErrorCode.NOT_ACTIVE_PLAYER -> {
@@ -1409,42 +1425,36 @@ class MainServerLobbyRoutingService(
                     val activePlayer = currentState?.activePlayer
                     when {
                         activePlayer == null ->
-                            "Für Lobby '${payload.lobbyCode.value}' ist aktuell kein aktiver Spieler gesetzt."
+                            "Für Lobby '${payload.lobbyCode.value}' ist aktuell " +
+                                "kein aktiver Spieler gesetzt."
                         else ->
-                            "Nur der aktive Spieler '${activePlayer.value}' darf die Reinforcements-Phase beenden."
+                            "Nur der aktive Spieler '${activePlayer.value}' darf " +
+                                "die Reinforcements-Phase beenden."
                     }
                 }
                 ConfirmReinforcementsDoneErrorCode.GAME_PAUSED ->
-                    "Lobby '${payload.lobbyCode.value}' ist pausiert; Phasenwechsel ist aktuell nicht erlaubt."
+                    "Lobby '${payload.lobbyCode.value}' ist pausiert; " +
+                        "Phasenwechsel ist aktuell nicht erlaubt."
                 ConfirmReinforcementsDoneErrorCode.PHASE_MISMATCH -> {
                     val currentPhase =
                         lobbyManager.getLobby(payload.lobbyCode)?.currentState()?.activeTurnPhase
                     if (currentPhase == null) {
-                        "Die Reinforcements-Phase ist für Lobby '${payload.lobbyCode.value}' aktuell nicht aktiv."
+                        "Die Reinforcements-Phase ist für Lobby " +
+                            "'${payload.lobbyCode.value}' aktuell nicht aktiv."
                     } else {
-                        "Bestätigung ist nur in Phase 'REINFORCEMENTS' erlaubt, aktueller Serverzustand ist '${currentPhase.name}'."
+                        "Bestätigung ist nur in Phase 'REINFORCEMENTS' erlaubt, " +
+                            "aktueller Serverzustand ist '${currentPhase.name}'."
                     }
                 }
                 ConfirmReinforcementsDoneErrorCode.PENDING_REINFORCEMENTS_REMAINING ->
-                    "Die Reinforcements-Phase kann erst beendet werden, wenn keine ausstehenden Verstärkungen mehr vorhanden sind."
+                    "Die Reinforcements-Phase kann erst beendet werden, wenn " +
+                        "keine ausstehenden Verstärkungen mehr vorhanden sind."
                 ConfirmReinforcementsDoneErrorCode.FORCED_TRADE_REQUIRED ->
-                    "Die Reinforcements-Phase kann erst beendet werden, wenn die Pflichtabgabe von Karten erfüllt ist."
+                    "Die Reinforcements-Phase kann erst beendet werden, wenn " +
+                        "die Pflichtabgabe von Karten erfüllt ist."
             }
 
         return ConfirmReinforcementsDoneErrorResponse(code = code, reason = reason)
-    }
-
-    /**
-     * Hook für die Pflichtabgabe aus Issue 11.
-     *
-     * Solange Karten noch nicht im autoritativen State modelliert sind, gibt es
-     * hier bewusst keinen zusätzlichen Reject-Pfad.
-     */
-    private fun requireForcedTradeRuleSatisfied(
-        state: GameState,
-        playerId: PlayerId,
-    ) {
-        state.hasPlayer(playerId)
     }
 
     private fun startPlayerSetErrorResponse(

--- a/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
@@ -1,6 +1,7 @@
 package at.aau.pulverfass.server.routing
 
 import at.aau.pulverfass.server.ServerNetwork
+import at.aau.pulverfass.server.lobby.CardSetValidator
 import at.aau.pulverfass.server.lobby.mapping.DecodedNetworkRequest
 import at.aau.pulverfass.server.lobby.runtime.LobbyManager
 import at.aau.pulverfass.server.persistence.LobbyPersistenceCallbacks
@@ -10,8 +11,10 @@ import at.aau.pulverfass.shared.ids.ConnectionId
 import at.aau.pulverfass.shared.ids.LobbyCode
 import at.aau.pulverfass.shared.ids.PlayerId
 import at.aau.pulverfass.shared.ids.TerritoryId
+import at.aau.pulverfass.shared.lobby.event.CardSetTradedInEvent
 import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsChangedEvent
 import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsSetEvent
+import at.aau.pulverfass.shared.lobby.event.PlayerCardsRemovedEvent
 import at.aau.pulverfass.shared.lobby.event.StartPlayerConfigured
 import at.aau.pulverfass.shared.lobby.event.TerritoryOwnerChangedEvent
 import at.aau.pulverfass.shared.lobby.event.TerritoryTroopsChangedEvent
@@ -19,6 +22,7 @@ import at.aau.pulverfass.shared.lobby.event.TurnStateUpdatedEvent
 import at.aau.pulverfass.shared.lobby.state.BaseReinforcementRuleEngine
 import at.aau.pulverfass.shared.lobby.state.GameState
 import at.aau.pulverfass.shared.lobby.state.GameStatus
+import at.aau.pulverfass.shared.lobby.state.TradeInProgression
 import at.aau.pulverfass.shared.lobby.state.TurnPauseReasons
 import at.aau.pulverfass.shared.lobby.state.TurnPhase
 import at.aau.pulverfass.shared.lobby.state.TurnState
@@ -28,6 +32,7 @@ import at.aau.pulverfass.shared.message.lobby.event.GameStartedEvent
 import at.aau.pulverfass.shared.message.lobby.event.PhaseBoundaryEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostReason
+import at.aau.pulverfass.shared.message.lobby.event.PlayerHandUpdatedEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerJoinedLobbyEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerKickedLobbyEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerLeftLobbyEvent
@@ -43,6 +48,7 @@ import at.aau.pulverfass.shared.message.lobby.request.MapGetRequest
 import at.aau.pulverfass.shared.message.lobby.request.PlaceReinforcementsRequest
 import at.aau.pulverfass.shared.message.lobby.request.StartGameRequest
 import at.aau.pulverfass.shared.message.lobby.request.StartPlayerSetRequest
+import at.aau.pulverfass.shared.message.lobby.request.TradeInCardsRequest
 import at.aau.pulverfass.shared.message.lobby.request.TurnAdvanceRequest
 import at.aau.pulverfass.shared.message.lobby.request.TurnStateGetRequest
 import at.aau.pulverfass.shared.message.lobby.response.ConfirmReinforcementsDoneResponse
@@ -57,6 +63,7 @@ import at.aau.pulverfass.shared.message.lobby.response.MapGetResponse
 import at.aau.pulverfass.shared.message.lobby.response.PlaceReinforcementsResponse
 import at.aau.pulverfass.shared.message.lobby.response.StartGameResponse
 import at.aau.pulverfass.shared.message.lobby.response.StartPlayerSetResponse
+import at.aau.pulverfass.shared.message.lobby.response.TradeInCardsResponse
 import at.aau.pulverfass.shared.message.lobby.response.TurnAdvanceResponse
 import at.aau.pulverfass.shared.message.lobby.response.TurnStateGetResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.ConfirmReinforcementsDoneErrorCode
@@ -77,6 +84,8 @@ import at.aau.pulverfass.shared.message.lobby.response.error.PlaceReinforcements
 import at.aau.pulverfass.shared.message.lobby.response.error.StartGameErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.StartPlayerSetErrorCode
 import at.aau.pulverfass.shared.message.lobby.response.error.StartPlayerSetErrorResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.TradeInCardsErrorCode
+import at.aau.pulverfass.shared.message.lobby.response.error.TradeInCardsErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.TurnAdvanceErrorCode
 import at.aau.pulverfass.shared.message.lobby.response.error.TurnAdvanceErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.TurnStateGetErrorCode
@@ -169,6 +178,7 @@ class MainServerLobbyRoutingService(
             is GameStatePrivateGetRequest -> routeGameStatePrivateGetRequest(request)
             is PlaceReinforcementsRequest -> routePlaceReinforcementsRequest(request)
             is StartPlayerSetRequest -> routeStartPlayerSetRequest(request)
+            is TradeInCardsRequest -> routeTradeInCardsRequest(request)
             is TurnStateGetRequest -> routeTurnStateGetRequest(request)
             is TurnAdvanceRequest -> routeTurnAdvanceRequest(request)
             else -> routeDecodedRequest(request)
@@ -539,6 +549,43 @@ class MainServerLobbyRoutingService(
             hooks.onRouted(request.connectionId)
         }.onFailure { cause ->
             val error = placeReinforcementsErrorResponse(request, payload, cause)
+            network.send(request.connectionId, error)
+            hooks.onRoutingError(
+                request.connectionId,
+                LobbyRoutingError.InvalidRoutingData(
+                    reason = error.reason,
+                    context =
+                        LobbyRoutingContext(
+                            connectionId = request.connectionId,
+                            messageType = request.receivedPacket.header.type,
+                            lobbyCode = payload.lobbyCode,
+                        ),
+                    cause = cause,
+                ),
+            )
+        }
+    }
+
+    private suspend fun routeTradeInCardsRequest(request: DecodedNetworkRequest) {
+        val payload = request.payload as TradeInCardsRequest
+
+        runCatching {
+            val events = buildTradeInCardsEvents(request, payload)
+            events.forEach { event -> lobbyManager.submit(event, request.context) }
+            network.send(
+                request.connectionId,
+                TradeInCardsResponse(lobbyCode = payload.lobbyCode),
+            )
+            val updatedState =
+                lobbyManager.getLobby(payload.lobbyCode)?.currentState()
+                    ?: throw IllegalStateException("GAME_NOT_FOUND")
+            gameStateDelivery.sendPrivateState(
+                payload.lobbyCode,
+                PlayerHandUpdatedEvent.fromGameState(updatedState, payload.playerId),
+            )
+            hooks.onRouted(request.connectionId)
+        }.onFailure { cause ->
+            val error = tradeInCardsErrorResponse(request, payload, cause)
             network.send(request.connectionId, error)
             hooks.onRoutingError(
                 request.connectionId,
@@ -1150,6 +1197,61 @@ class MainServerLobbyRoutingService(
             )
     }
 
+    private fun buildTradeInCardsEvents(
+        request: DecodedNetworkRequest,
+        payload: TradeInCardsRequest,
+    ): List<at.aau.pulverfass.shared.lobby.event.LobbyEvent> {
+        val lobby =
+            lobbyManager.getLobby(payload.lobbyCode)
+                ?: throw IllegalStateException("GAME_NOT_FOUND")
+        val state = lobby.currentState()
+        val contextPlayerId = request.context.playerId
+        val currentTurnState =
+            state.resolvedTurnState
+                ?: throw IllegalArgumentException("NOT_ACTIVE_PLAYER")
+
+        require(!(contextPlayerId == null || contextPlayerId != payload.playerId)) {
+            "REQUESTER_MISMATCH"
+        }
+        require(currentTurnState.activePlayerId == payload.playerId) { "NOT_ACTIVE_PLAYER" }
+        check(!(currentTurnState.isPaused)) { "GAME_PAUSED" }
+        require(currentTurnState.turnPhase == TurnPhase.REINFORCEMENTS) { "PHASE_MISMATCH" }
+        require(payload.cardIds.size == 3) { "INVALID_REQUEST" }
+        require(payload.cardIds.distinct().size == payload.cardIds.size) { "INVALID_REQUEST" }
+
+        val cardsById = state.handOf(payload.playerId).associateBy { card -> card.cardId }
+        val selectedCards =
+            payload.cardIds.map { cardId ->
+                cardsById[cardId] ?: throw IllegalArgumentException("CARDS_NOT_OWNED")
+            }
+        require(CardSetValidator.isValidSet(selectedCards.map { card -> card.type })) {
+            "INVALID_SET"
+        }
+
+        val tradeIndex = state.tradedInSetCount + 1
+        val tradeValue = TradeInProgression.tradeInValue(tradeIndex)
+
+        return listOf(
+            CardSetTradedInEvent(
+                lobbyCode = payload.lobbyCode,
+                playerId = payload.playerId,
+                cardIds = payload.cardIds,
+                value = tradeValue,
+                tradeIndex = tradeIndex,
+            ),
+            PendingReinforcementsChangedEvent(
+                lobbyCode = payload.lobbyCode,
+                playerId = payload.playerId,
+                delta = tradeValue,
+            ),
+            PlayerCardsRemovedEvent(
+                lobbyCode = payload.lobbyCode,
+                playerId = payload.playerId,
+                cardIds = payload.cardIds,
+            ),
+        )
+    }
+
     private fun buildConfirmReinforcementsDoneEvent(
         request: DecodedNetworkRequest,
         payload: ConfirmReinforcementsDoneRequest,
@@ -1388,6 +1490,75 @@ class MainServerLobbyRoutingService(
             }
 
         return PlaceReinforcementsErrorResponse(code = code, reason = reason)
+    }
+
+    private fun tradeInCardsErrorResponse(
+        request: DecodedNetworkRequest,
+        payload: TradeInCardsRequest,
+        cause: Throwable,
+    ): TradeInCardsErrorResponse {
+        val code =
+            when (cause.message) {
+                "GAME_NOT_FOUND" -> TradeInCardsErrorCode.GAME_NOT_FOUND
+                "REQUESTER_MISMATCH" -> TradeInCardsErrorCode.REQUESTER_MISMATCH
+                "GAME_PAUSED" -> TradeInCardsErrorCode.GAME_PAUSED
+                "PHASE_MISMATCH" -> TradeInCardsErrorCode.PHASE_MISMATCH
+                "CARDS_NOT_OWNED" -> TradeInCardsErrorCode.CARDS_NOT_OWNED
+                "INVALID_SET" -> TradeInCardsErrorCode.INVALID_SET
+                "INVALID_REQUEST" -> TradeInCardsErrorCode.INVALID_REQUEST
+                else -> TradeInCardsErrorCode.NOT_ACTIVE_PLAYER
+            }
+
+        val reason =
+            when (code) {
+                TradeInCardsErrorCode.GAME_NOT_FOUND ->
+                    "Lobby '${payload.lobbyCode.value}' wurde nicht gefunden."
+                TradeInCardsErrorCode.REQUESTER_MISMATCH -> {
+                    val contextPlayerId = request.context.playerId
+                    if (contextPlayerId == null) {
+                        "Connection ist keinem Spieler fuer Lobby " +
+                            "'${payload.lobbyCode.value}' zugeordnet."
+                    } else {
+                        "Requester '${payload.playerId.value}' passt nicht " +
+                            "zur aktuellen Connection '${contextPlayerId.value}'."
+                    }
+                }
+                TradeInCardsErrorCode.NOT_ACTIVE_PLAYER -> {
+                    val currentState = lobbyManager.getLobby(payload.lobbyCode)?.currentState()
+                    val activePlayer = currentState?.activePlayer
+                    when {
+                        activePlayer == null ->
+                            "Fuer Lobby '${payload.lobbyCode.value}' ist aktuell kein aktiver " +
+                                "Spieler gesetzt."
+                        else ->
+                            "Nur der aktive Spieler '${activePlayer.value}' darf waehrend der " +
+                                "Reinforcements-Phase Karten eintauschen."
+                    }
+                }
+                TradeInCardsErrorCode.GAME_PAUSED ->
+                    "Lobby '${payload.lobbyCode.value}' ist pausiert; Karten-Trade-In ist " +
+                        "aktuell nicht erlaubt."
+                TradeInCardsErrorCode.PHASE_MISMATCH -> {
+                    val currentPhase =
+                        lobbyManager.getLobby(payload.lobbyCode)?.currentState()?.activeTurnPhase
+                    if (currentPhase == null) {
+                        "Die Reinforcements-Phase ist fuer Lobby '${payload.lobbyCode.value}' " +
+                            "aktuell nicht aktiv."
+                    } else {
+                        "Karten-Trade-In ist nur in Phase 'REINFORCEMENTS' erlaubt, " +
+                            "aktueller Serverzustand ist '${currentPhase.name}'."
+                    }
+                }
+                TradeInCardsErrorCode.CARDS_NOT_OWNED ->
+                    "Alle eingetauschten Karten muessen Spieler " +
+                        "'${payload.playerId.value}' gehoeren."
+                TradeInCardsErrorCode.INVALID_SET ->
+                    "Die ausgewaehlten Karten bilden kein gueltiges Trade-In-Set."
+                TradeInCardsErrorCode.INVALID_REQUEST ->
+                    "Ein Karten-Trade-In muss genau drei unterschiedliche Karten enthalten."
+            }
+
+        return TradeInCardsErrorResponse(code = code, reason = reason)
     }
 
     private fun confirmReinforcementsDoneErrorResponse(

--- a/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
@@ -9,16 +9,22 @@ import at.aau.pulverfass.shared.event.EventContext
 import at.aau.pulverfass.shared.ids.ConnectionId
 import at.aau.pulverfass.shared.ids.LobbyCode
 import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.ids.TerritoryId
+import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsChangedEvent
+import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsSetEvent
 import at.aau.pulverfass.shared.lobby.event.StartPlayerConfigured
 import at.aau.pulverfass.shared.lobby.event.TerritoryOwnerChangedEvent
 import at.aau.pulverfass.shared.lobby.event.TerritoryTroopsChangedEvent
 import at.aau.pulverfass.shared.lobby.event.TurnStateUpdatedEvent
+import at.aau.pulverfass.shared.lobby.state.BaseReinforcementRuleEngine
 import at.aau.pulverfass.shared.lobby.state.GameState
 import at.aau.pulverfass.shared.lobby.state.GameStatus
 import at.aau.pulverfass.shared.lobby.state.TurnPauseReasons
+import at.aau.pulverfass.shared.lobby.state.TurnPhase
 import at.aau.pulverfass.shared.lobby.state.TurnState
 import at.aau.pulverfass.shared.lobby.state.TurnStateMachine
 import at.aau.pulverfass.shared.message.connection.request.ReconnectRequest
+import at.aau.pulverfass.shared.message.lobby.request.ConfirmReinforcementsDoneRequest
 import at.aau.pulverfass.shared.message.lobby.event.GameStartedEvent
 import at.aau.pulverfass.shared.message.lobby.event.PhaseBoundaryEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostEvent
@@ -34,11 +40,14 @@ import at.aau.pulverfass.shared.message.lobby.request.KickPlayerRequest
 import at.aau.pulverfass.shared.message.lobby.request.LeaveLobbyRequest
 import at.aau.pulverfass.shared.message.lobby.request.LobbyPlayerCountRequest
 import at.aau.pulverfass.shared.message.lobby.request.MapGetRequest
+import at.aau.pulverfass.shared.message.lobby.request.PlaceReinforcementsRequest
 import at.aau.pulverfass.shared.message.lobby.request.StartGameRequest
 import at.aau.pulverfass.shared.message.lobby.request.StartPlayerSetRequest
+import at.aau.pulverfass.shared.message.lobby.request.TerritoryPlacement
 import at.aau.pulverfass.shared.message.lobby.request.TurnAdvanceRequest
 import at.aau.pulverfass.shared.message.lobby.request.TurnStateGetRequest
 import at.aau.pulverfass.shared.message.lobby.response.CreateLobbyResponse
+import at.aau.pulverfass.shared.message.lobby.response.ConfirmReinforcementsDoneResponse
 import at.aau.pulverfass.shared.message.lobby.response.GameStateCatchUpResponse
 import at.aau.pulverfass.shared.message.lobby.response.GameStatePrivateGetResponse
 import at.aau.pulverfass.shared.message.lobby.response.JoinLobbyResponse
@@ -46,6 +55,7 @@ import at.aau.pulverfass.shared.message.lobby.response.KickPlayerResponse
 import at.aau.pulverfass.shared.message.lobby.response.LeaveLobbyResponse
 import at.aau.pulverfass.shared.message.lobby.response.LobbyPlayerCountResponse
 import at.aau.pulverfass.shared.message.lobby.response.MapGetResponse
+import at.aau.pulverfass.shared.message.lobby.response.PlaceReinforcementsResponse
 import at.aau.pulverfass.shared.message.lobby.response.StartGameResponse
 import at.aau.pulverfass.shared.message.lobby.response.StartPlayerSetResponse
 import at.aau.pulverfass.shared.message.lobby.response.TurnAdvanceResponse
@@ -55,12 +65,16 @@ import at.aau.pulverfass.shared.message.lobby.response.error.GameStateCatchUpErr
 import at.aau.pulverfass.shared.message.lobby.response.error.GameStateCatchUpErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.GameStatePrivateGetErrorCode
 import at.aau.pulverfass.shared.message.lobby.response.error.GameStatePrivateGetErrorResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.ConfirmReinforcementsDoneErrorCode
+import at.aau.pulverfass.shared.message.lobby.response.error.ConfirmReinforcementsDoneErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.JoinLobbyErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.KickPlayerErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.LobbyPlayerCountErrorCode
 import at.aau.pulverfass.shared.message.lobby.response.error.LobbyPlayerCountErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.MapGetErrorCode
 import at.aau.pulverfass.shared.message.lobby.response.error.MapGetErrorResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.PlaceReinforcementsErrorCode
+import at.aau.pulverfass.shared.message.lobby.response.error.PlaceReinforcementsErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.StartGameErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.StartPlayerSetErrorCode
 import at.aau.pulverfass.shared.message.lobby.response.error.StartPlayerSetErrorResponse
@@ -148,11 +162,13 @@ class MainServerLobbyRoutingService(
                     connectionId = packet.connectionId,
                     payload = payload,
                 )
+            is ConfirmReinforcementsDoneRequest -> routeConfirmReinforcementsDoneRequest(request)
             is CreateLobbyRequest -> routeCreateLobbyRequest(packet)
             is LobbyPlayerCountRequest -> routeLobbyPlayerCountRequest(request)
             is MapGetRequest -> routeMapGetRequest(request)
             is GameStateCatchUpRequest -> routeGameStateCatchUpRequest(request)
             is GameStatePrivateGetRequest -> routeGameStatePrivateGetRequest(request)
+            is PlaceReinforcementsRequest -> routePlaceReinforcementsRequest(request)
             is StartPlayerSetRequest -> routeStartPlayerSetRequest(request)
             is TurnStateGetRequest -> routeTurnStateGetRequest(request)
             is TurnAdvanceRequest -> routeTurnAdvanceRequest(request)
@@ -449,6 +465,11 @@ class MainServerLobbyRoutingService(
         runCatching {
             val turnStateUpdate = buildTurnAdvanceEvent(request, payload)
             lobbyManager.submit(turnStateUpdate, request.context)
+            grantBaseReinforcementsOnPhaseStart(
+                lobbyCode = payload.lobbyCode,
+                previousTurnState = previousTurnState,
+                context = request.context,
+            )
             network.send(request.connectionId, TurnAdvanceResponse(payload.lobbyCode))
             broadcastPhaseBoundaryIfChanged(payload.lobbyCode, previousTurnState)
             broadcastTurnStateIfChanged(payload.lobbyCode, previousTurnState)
@@ -471,6 +492,99 @@ class MainServerLobbyRoutingService(
                 ),
             )
         }
+    }
+
+    private suspend fun routeConfirmReinforcementsDoneRequest(request: DecodedNetworkRequest) {
+        val payload = request.payload as ConfirmReinforcementsDoneRequest
+        val previousTurnState = currentTurnState(payload.lobbyCode)
+
+        runCatching {
+            val turnStateUpdate = buildConfirmReinforcementsDoneEvent(request, payload)
+            lobbyManager.submit(turnStateUpdate, request.context)
+            network.send(
+                request.connectionId,
+                ConfirmReinforcementsDoneResponse(payload.lobbyCode),
+            )
+            broadcastPhaseBoundaryIfChanged(payload.lobbyCode, previousTurnState)
+            broadcastTurnStateIfChanged(payload.lobbyCode, previousTurnState)
+            hooks.onRouted(request.connectionId)
+        }.onFailure { cause ->
+            val error = confirmReinforcementsDoneErrorResponse(request, payload, cause)
+            network.send(request.connectionId, error)
+            hooks.onRoutingError(
+                request.connectionId,
+                LobbyRoutingError.InvalidRoutingData(
+                    reason = error.reason,
+                    context =
+                        LobbyRoutingContext(
+                            connectionId = request.connectionId,
+                            messageType = request.receivedPacket.header.type,
+                            lobbyCode = payload.lobbyCode,
+                        ),
+                    cause = cause,
+                ),
+            )
+        }
+    }
+
+    private suspend fun routePlaceReinforcementsRequest(request: DecodedNetworkRequest) {
+        val payload = request.payload as PlaceReinforcementsRequest
+
+        runCatching {
+            val events = buildPlaceReinforcementsEvents(request, payload)
+            events.forEach { event -> lobbyManager.submit(event, request.context) }
+            network.send(
+                request.connectionId,
+                PlaceReinforcementsResponse(lobbyCode = payload.lobbyCode),
+            )
+            hooks.onRouted(request.connectionId)
+        }.onFailure { cause ->
+            val error = placeReinforcementsErrorResponse(request, payload, cause)
+            network.send(request.connectionId, error)
+            hooks.onRoutingError(
+                request.connectionId,
+                LobbyRoutingError.InvalidRoutingData(
+                    reason = error.reason,
+                    context =
+                        LobbyRoutingContext(
+                            connectionId = request.connectionId,
+                            messageType = request.receivedPacket.header.type,
+                            lobbyCode = payload.lobbyCode,
+                        ),
+                    cause = cause,
+                ),
+            )
+        }
+    }
+
+    private suspend fun grantBaseReinforcementsOnPhaseStart(
+        lobbyCode: LobbyCode,
+        previousTurnState: TurnState?,
+        context: EventContext,
+    ) {
+        if (previousTurnState?.turnPhase != TurnPhase.DRAW_CARD) {
+            return
+        }
+
+        val currentState = lobbyManager.getLobby(lobbyCode)?.currentState() ?: return
+        val currentTurnState = currentState.resolvedTurnState ?: return
+        if (currentTurnState.turnPhase != TurnPhase.REINFORCEMENTS) {
+            return
+        }
+
+        val breakdown =
+            BaseReinforcementRuleEngine.computeBaseReinforcements(
+                playerId = currentTurnState.activePlayerId,
+                state = currentState,
+            )
+        lobbyManager.submit(
+            PendingReinforcementsSetEvent(
+                lobbyCode = lobbyCode,
+                playerId = currentTurnState.activePlayerId,
+                amount = breakdown.total,
+            ),
+            context,
+        )
     }
 
     private suspend fun routeStartPlayerSetRequest(request: DecodedNetworkRequest) {
@@ -970,6 +1084,96 @@ class MainServerLobbyRoutingService(
         return pausedOrAdvancedTurnState.toUpdatedEvent(payload.lobbyCode)
     }
 
+    private fun buildPlaceReinforcementsEvents(
+        request: DecodedNetworkRequest,
+        payload: PlaceReinforcementsRequest,
+    ): List<at.aau.pulverfass.shared.lobby.event.LobbyEvent> {
+        val lobby =
+            lobbyManager.getLobby(payload.lobbyCode)
+                ?: throw IllegalStateException("GAME_NOT_FOUND")
+        val state = lobby.currentState()
+        val contextPlayerId = request.context.playerId
+        val currentTurnState =
+            state.resolvedTurnState
+                ?: throw IllegalArgumentException("NOT_ACTIVE_PLAYER")
+
+        require(!(contextPlayerId == null || contextPlayerId != payload.playerId)) {
+            "REQUESTER_MISMATCH"
+        }
+        require(currentTurnState.activePlayerId == payload.playerId) { "NOT_ACTIVE_PLAYER" }
+        check(!(currentTurnState.isPaused)) { "GAME_PAUSED" }
+        require(currentTurnState.turnPhase == TurnPhase.REINFORCEMENTS) { "PHASE_MISMATCH" }
+        require(payload.placements.isNotEmpty()) { "INVALID_PLACEMENT" }
+
+        payload.placements.forEach { placement ->
+            require(placement.amount > 0) { "INVALID_PLACEMENT" }
+        }
+
+        val totalPlacement = payload.placements.sumOf(TerritoryPlacement::amount)
+        require(totalPlacement <= state.pendingReinforcementsFor(payload.playerId)) { "OVERSPEND" }
+
+        val projectedTroopCounts = linkedMapOf<TerritoryId, Int>()
+        val territoryEvents =
+            payload.placements.map { placement ->
+                val ownerId = state.ownerOf(placement.territoryId)
+                require(ownerId == payload.playerId) { "TERRITORY_NOT_OWNED" }
+
+                val currentTroopCount =
+                    projectedTroopCounts[placement.territoryId]
+                        ?: state.troopCountOf(placement.territoryId)
+                val updatedTroopCount = currentTroopCount + placement.amount
+                projectedTroopCounts[placement.territoryId] = updatedTroopCount
+
+                TerritoryTroopsChangedEvent(
+                    lobbyCode = payload.lobbyCode,
+                    territoryId = placement.territoryId,
+                    troopCount = updatedTroopCount,
+                )
+            }
+
+        return territoryEvents +
+            PendingReinforcementsChangedEvent(
+                lobbyCode = payload.lobbyCode,
+                playerId = payload.playerId,
+                delta = -totalPlacement,
+            )
+    }
+
+    private fun buildConfirmReinforcementsDoneEvent(
+        request: DecodedNetworkRequest,
+        payload: ConfirmReinforcementsDoneRequest,
+    ): TurnStateUpdatedEvent {
+        val lobby =
+            lobbyManager.getLobby(payload.lobbyCode)
+                ?: throw IllegalStateException("GAME_NOT_FOUND")
+        val state = lobby.currentState()
+        val contextPlayerId = request.context.playerId
+        val currentTurnState =
+            state.resolvedTurnState
+                ?: throw IllegalArgumentException("NOT_ACTIVE_PLAYER")
+
+        require(!(contextPlayerId == null || contextPlayerId != payload.playerId)) {
+            "REQUESTER_MISMATCH"
+        }
+        require(currentTurnState.activePlayerId == payload.playerId) { "NOT_ACTIVE_PLAYER" }
+        check(!(currentTurnState.isPaused)) { "GAME_PAUSED" }
+        require(currentTurnState.turnPhase == TurnPhase.REINFORCEMENTS) { "PHASE_MISMATCH" }
+        require(state.pendingReinforcementsFor(payload.playerId) == 0) {
+            "PENDING_REINFORCEMENTS_REMAINING"
+        }
+        requireForcedTradeRuleSatisfied(state, payload.playerId)
+
+        return buildTurnAdvanceEvent(
+            request = request,
+            payload =
+                TurnAdvanceRequest(
+                    lobbyCode = payload.lobbyCode,
+                    playerId = payload.playerId,
+                    expectedPhase = TurnPhase.REINFORCEMENTS,
+                ),
+        )
+    }
+
     private fun buildStartPlayerConfiguredEvent(
         request: DecodedNetworkRequest,
         payload: StartPlayerSetRequest,
@@ -1095,6 +1299,152 @@ class MainServerLobbyRoutingService(
             }
 
         return TurnAdvanceErrorResponse(code = code, reason = reason)
+    }
+
+    private fun placeReinforcementsErrorResponse(
+        request: DecodedNetworkRequest,
+        payload: PlaceReinforcementsRequest,
+        cause: Throwable,
+    ): PlaceReinforcementsErrorResponse {
+        val code =
+            when (cause.message) {
+                "GAME_NOT_FOUND" -> PlaceReinforcementsErrorCode.GAME_NOT_FOUND
+                "REQUESTER_MISMATCH" -> PlaceReinforcementsErrorCode.REQUESTER_MISMATCH
+                "GAME_PAUSED" -> PlaceReinforcementsErrorCode.GAME_PAUSED
+                "PHASE_MISMATCH" -> PlaceReinforcementsErrorCode.PHASE_MISMATCH
+                "TERRITORY_NOT_OWNED" -> PlaceReinforcementsErrorCode.TERRITORY_NOT_OWNED
+                "OVERSPEND" -> PlaceReinforcementsErrorCode.OVERSPEND
+                "INVALID_PLACEMENT" -> PlaceReinforcementsErrorCode.INVALID_PLACEMENT
+                else -> PlaceReinforcementsErrorCode.NOT_ACTIVE_PLAYER
+            }
+
+        val reason =
+            when (code) {
+                PlaceReinforcementsErrorCode.GAME_NOT_FOUND ->
+                    "Lobby '${payload.lobbyCode.value}' wurde nicht gefunden."
+                PlaceReinforcementsErrorCode.REQUESTER_MISMATCH -> {
+                    val contextPlayerId = request.context.playerId
+                    if (contextPlayerId == null) {
+                        "Connection ist keinem Spieler für Lobby " +
+                            "'${payload.lobbyCode.value}' zugeordnet."
+                    } else {
+                        "Requester '${payload.playerId.value}' passt nicht " +
+                            "zur aktuellen Connection '${contextPlayerId.value}'."
+                    }
+                }
+                PlaceReinforcementsErrorCode.NOT_ACTIVE_PLAYER -> {
+                    val currentState = lobbyManager.getLobby(payload.lobbyCode)?.currentState()
+                    val activePlayer = currentState?.activePlayer
+                    when {
+                        activePlayer == null ->
+                            "Für Lobby '${payload.lobbyCode.value}' ist aktuell kein aktiver " +
+                                "Spieler gesetzt."
+                        else ->
+                            "Nur der aktive Spieler '${activePlayer.value}' darf in der " +
+                                "Reinforcements-Phase Truppen platzieren."
+                    }
+                }
+                PlaceReinforcementsErrorCode.GAME_PAUSED ->
+                    "Lobby '${payload.lobbyCode.value}' ist pausiert; " +
+                        "Truppenplatzierung ist aktuell nicht erlaubt."
+                PlaceReinforcementsErrorCode.PHASE_MISMATCH -> {
+                    val currentPhase =
+                        lobbyManager.getLobby(
+                            payload.lobbyCode,
+                        )?.currentState()?.activeTurnPhase
+                    if (currentPhase == null) {
+                        "Die Reinforcements-Phase ist für Lobby '${payload.lobbyCode.value}' " +
+                            "aktuell nicht aktiv."
+                    } else {
+                        "Truppenplatzierung ist nur in Phase 'REINFORCEMENTS' erlaubt, " +
+                            "aktueller Serverzustand ist '${currentPhase.name}'."
+                    }
+                }
+                PlaceReinforcementsErrorCode.TERRITORY_NOT_OWNED ->
+                    "Alle Zielterritorien müssen Spieler '${payload.playerId.value}' gehören."
+                PlaceReinforcementsErrorCode.OVERSPEND ->
+                    "Angeforderte Verstärkungen (${payload.placements.sumOf { it.amount }}) " +
+                        "überschreiten den verbleibenden Pool von " +
+                        "${lobbyManager.getLobby(payload.lobbyCode)?.currentState()?.pendingReinforcementsFor(payload.playerId) ?: 0}."
+                PlaceReinforcementsErrorCode.INVALID_PLACEMENT ->
+                    "Die Verstärkungsplatzierung muss mindestens ein Ziel enthalten und alle " +
+                        "Mengen müssen positiv sein."
+            }
+
+        return PlaceReinforcementsErrorResponse(code = code, reason = reason)
+    }
+
+    private fun confirmReinforcementsDoneErrorResponse(
+        request: DecodedNetworkRequest,
+        payload: ConfirmReinforcementsDoneRequest,
+        cause: Throwable,
+    ): ConfirmReinforcementsDoneErrorResponse {
+        val code =
+            when (cause.message) {
+                "GAME_NOT_FOUND" -> ConfirmReinforcementsDoneErrorCode.GAME_NOT_FOUND
+                "REQUESTER_MISMATCH" -> ConfirmReinforcementsDoneErrorCode.REQUESTER_MISMATCH
+                "GAME_PAUSED" -> ConfirmReinforcementsDoneErrorCode.GAME_PAUSED
+                "PHASE_MISMATCH" -> ConfirmReinforcementsDoneErrorCode.PHASE_MISMATCH
+                "PENDING_REINFORCEMENTS_REMAINING" ->
+                    ConfirmReinforcementsDoneErrorCode.PENDING_REINFORCEMENTS_REMAINING
+                "FORCED_TRADE_REQUIRED" ->
+                    ConfirmReinforcementsDoneErrorCode.FORCED_TRADE_REQUIRED
+                else -> ConfirmReinforcementsDoneErrorCode.NOT_ACTIVE_PLAYER
+            }
+
+        val reason =
+            when (code) {
+                ConfirmReinforcementsDoneErrorCode.GAME_NOT_FOUND ->
+                    "Lobby '${payload.lobbyCode.value}' wurde nicht gefunden."
+                ConfirmReinforcementsDoneErrorCode.REQUESTER_MISMATCH -> {
+                    val contextPlayerId = request.context.playerId
+                    if (contextPlayerId == null) {
+                        "Connection ist keinem Spieler für Lobby '${payload.lobbyCode.value}' zugeordnet."
+                    } else {
+                        "Requester '${payload.playerId.value}' passt nicht zur aktuellen Connection '${contextPlayerId.value}'."
+                    }
+                }
+                ConfirmReinforcementsDoneErrorCode.NOT_ACTIVE_PLAYER -> {
+                    val currentState = lobbyManager.getLobby(payload.lobbyCode)?.currentState()
+                    val activePlayer = currentState?.activePlayer
+                    when {
+                        activePlayer == null ->
+                            "Für Lobby '${payload.lobbyCode.value}' ist aktuell kein aktiver Spieler gesetzt."
+                        else ->
+                            "Nur der aktive Spieler '${activePlayer.value}' darf die Reinforcements-Phase beenden."
+                    }
+                }
+                ConfirmReinforcementsDoneErrorCode.GAME_PAUSED ->
+                    "Lobby '${payload.lobbyCode.value}' ist pausiert; Phasenwechsel ist aktuell nicht erlaubt."
+                ConfirmReinforcementsDoneErrorCode.PHASE_MISMATCH -> {
+                    val currentPhase =
+                        lobbyManager.getLobby(payload.lobbyCode)?.currentState()?.activeTurnPhase
+                    if (currentPhase == null) {
+                        "Die Reinforcements-Phase ist für Lobby '${payload.lobbyCode.value}' aktuell nicht aktiv."
+                    } else {
+                        "Bestätigung ist nur in Phase 'REINFORCEMENTS' erlaubt, aktueller Serverzustand ist '${currentPhase.name}'."
+                    }
+                }
+                ConfirmReinforcementsDoneErrorCode.PENDING_REINFORCEMENTS_REMAINING ->
+                    "Die Reinforcements-Phase kann erst beendet werden, wenn keine ausstehenden Verstärkungen mehr vorhanden sind."
+                ConfirmReinforcementsDoneErrorCode.FORCED_TRADE_REQUIRED ->
+                    "Die Reinforcements-Phase kann erst beendet werden, wenn die Pflichtabgabe von Karten erfüllt ist."
+            }
+
+        return ConfirmReinforcementsDoneErrorResponse(code = code, reason = reason)
+    }
+
+    /**
+     * Hook für die Pflichtabgabe aus Issue 11.
+     *
+     * Solange Karten noch nicht im autoritativen State modelliert sind, gibt es
+     * hier bewusst keinen zusätzlichen Reject-Pfad.
+     */
+    private fun requireForcedTradeRuleSatisfied(
+        state: GameState,
+        playerId: PlayerId,
+    ) {
+        state.hasPlayer(playerId)
     }
 
     private fun startPlayerSetErrorResponse(

--- a/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
@@ -541,7 +541,7 @@ class MainServerLobbyRoutingService(
 
         runCatching {
             val events = buildPlaceReinforcementsEvents(request, payload)
-            events.forEach { event -> lobbyManager.submit(event, request.context) }
+            lobbyManager.submitAll(payload.lobbyCode, events, request.context)
             network.send(
                 request.connectionId,
                 PlaceReinforcementsResponse(lobbyCode = payload.lobbyCode),
@@ -571,7 +571,7 @@ class MainServerLobbyRoutingService(
 
         runCatching {
             val events = buildTradeInCardsEvents(request, payload)
-            events.forEach { event -> lobbyManager.submit(event, request.context) }
+            lobbyManager.submitAll(payload.lobbyCode, events, request.context)
             network.send(
                 request.connectionId,
                 TradeInCardsResponse(lobbyCode = payload.lobbyCode),
@@ -1181,6 +1181,9 @@ class MainServerLobbyRoutingService(
         val projectedTroopCounts = linkedMapOf<TerritoryId, Int>()
         val territoryEvents =
             payload.placements.map { placement ->
+                require(state.territoryStateOf(placement.territoryId) != null) {
+                    "INVALID_PLACEMENT"
+                }
                 val ownerId = state.ownerOf(placement.territoryId)
                 require(ownerId == payload.playerId) { "TERRITORY_NOT_OWNED" }
 

--- a/server/src/main/kotlin/at/aau/pulverfass/server/routing/PublicGameStateBuilder.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/routing/PublicGameStateBuilder.kt
@@ -1,6 +1,7 @@
 package at.aau.pulverfass.server.routing
 
 import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.lobby.event.CardSetTradedInEvent
 import at.aau.pulverfass.shared.lobby.event.LobbyEvent
 import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsChangedEvent
 import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsSetEvent
@@ -163,6 +164,17 @@ class PublicGameStateBuilder {
             }
 
             when (event) {
+                is CardSetTradedInEvent ->
+                    add(
+                        ReinforcementsGrantedEvent(
+                            lobbyCode = lobbyCode,
+                            playerId = event.playerId,
+                            amount = event.value,
+                            territoryBonus = 0,
+                            continentBonus = 0,
+                            cardBonus = event.value,
+                        ),
+                    )
                 is PendingReinforcementsChangedEvent -> add(event)
                 is PendingReinforcementsSetEvent -> {
                     val breakdown =

--- a/server/src/main/kotlin/at/aau/pulverfass/server/routing/PublicGameStateBuilder.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/routing/PublicGameStateBuilder.kt
@@ -52,7 +52,12 @@ class PublicGameStateBuilder {
             lobbyCode = gameState.lobbyCode,
             stateVersion = gameState.stateVersion,
             determinism = mapProjection.determinism,
-            turnState = PublicTurnStateSnapshot.from(resolvedTurnState),
+            turnState =
+                PublicTurnStateSnapshot.from(
+                    turnState = resolvedTurnState,
+                    pendingReinforcements =
+                        gameState.pendingReinforcementsFor(resolvedTurnState.activePlayerId),
+                ),
             definition = mapProjection.definition,
             territoryStates = mapProjection.territoryStates,
         )

--- a/server/src/main/kotlin/at/aau/pulverfass/server/routing/PublicGameStateBuilder.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/routing/PublicGameStateBuilder.kt
@@ -2,15 +2,19 @@ package at.aau.pulverfass.server.routing
 
 import at.aau.pulverfass.shared.ids.LobbyCode
 import at.aau.pulverfass.shared.lobby.event.LobbyEvent
+import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsChangedEvent
+import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsSetEvent
 import at.aau.pulverfass.shared.lobby.event.StartPlayerConfigured
 import at.aau.pulverfass.shared.lobby.event.TerritoryOwnerChangedEvent
 import at.aau.pulverfass.shared.lobby.event.TerritoryTroopsChangedEvent
 import at.aau.pulverfass.shared.lobby.event.TurnStateUpdatedEvent
+import at.aau.pulverfass.shared.lobby.state.BaseReinforcementRuleEngine
 import at.aau.pulverfass.shared.lobby.state.GameState
 import at.aau.pulverfass.shared.message.lobby.event.GameStartedEvent
 import at.aau.pulverfass.shared.message.lobby.event.GameStateDeltaEvent
 import at.aau.pulverfass.shared.message.lobby.event.GameStateSnapshotBroadcast
 import at.aau.pulverfass.shared.message.lobby.event.PublicGameEvent
+import at.aau.pulverfass.shared.message.lobby.event.ReinforcementsGrantedEvent
 import at.aau.pulverfass.shared.message.lobby.event.VisibleGameStatePayload
 import at.aau.pulverfass.shared.message.lobby.response.GameStateCatchUpResponse
 import at.aau.pulverfass.shared.message.lobby.response.MapDefinitionSnapshot
@@ -159,6 +163,24 @@ class PublicGameStateBuilder {
             }
 
             when (event) {
+                is PendingReinforcementsChangedEvent -> add(event)
+                is PendingReinforcementsSetEvent -> {
+                    val breakdown =
+                        BaseReinforcementRuleEngine.computeBaseReinforcements(
+                            playerId = event.playerId,
+                            state = currentState,
+                        )
+                    add(
+                        ReinforcementsGrantedEvent(
+                            lobbyCode = lobbyCode,
+                            playerId = event.playerId,
+                            amount = event.amount,
+                            territoryBonus = breakdown.territoryBonus,
+                            continentBonus = breakdown.continentBonus,
+                            cardBonus = event.amount - breakdown.total,
+                        ),
+                    )
+                }
                 is TerritoryOwnerChangedEvent,
                 is TerritoryTroopsChangedEvent,
                 ->

--- a/server/src/test/kotlin/at/aau/pulverfass/server/ConfirmReinforcementsDoneIntegrationTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/ConfirmReinforcementsDoneIntegrationTest.kt
@@ -1,0 +1,349 @@
+package at.aau.pulverfass.server
+
+import at.aau.pulverfass.server.lobby.mapping.DefaultNetworkToLobbyEventMapper
+import at.aau.pulverfass.server.lobby.runtime.LobbyManager
+import at.aau.pulverfass.server.routing.MainServerLobbyRoutingService
+import at.aau.pulverfass.server.routing.MainServerLobbyRoutingServiceHooks
+import at.aau.pulverfass.server.routing.MainServerRouter
+import at.aau.pulverfass.shared.ids.ConnectionId
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.lobby.event.TurnStateUpdatedEvent
+import at.aau.pulverfass.shared.lobby.state.GameState
+import at.aau.pulverfass.shared.lobby.state.GameStatus
+import at.aau.pulverfass.shared.lobby.state.PendingReinforcements
+import at.aau.pulverfass.shared.lobby.state.TurnPhase
+import at.aau.pulverfass.shared.lobby.state.TurnState
+import at.aau.pulverfass.shared.message.lobby.event.GameStateDeltaEvent
+import at.aau.pulverfass.shared.message.lobby.event.PhaseBoundaryEvent
+import at.aau.pulverfass.shared.message.lobby.request.ConfirmReinforcementsDoneRequest
+import at.aau.pulverfass.shared.message.lobby.response.ConfirmReinforcementsDoneResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.ConfirmReinforcementsDoneErrorCode
+import at.aau.pulverfass.shared.message.lobby.response.error.ConfirmReinforcementsDoneErrorResponse
+import at.aau.pulverfass.shared.network.codec.MessageCodec
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.client.plugins.websocket.webSocketSession
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import io.ktor.websocket.Frame
+import io.ktor.websocket.close
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import java.util.concurrent.ConcurrentHashMap
+
+class ConfirmReinforcementsDoneIntegrationTest {
+    @Test
+    fun `pending zero advances to attack`() =
+        testApplication {
+            val network = ServerNetwork()
+            val serverScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            val lobbyManager = LobbyManager(serverScope)
+            val router =
+                MainServerRouter(
+                    lobbyManager = lobbyManager,
+                    mapper = DefaultNetworkToLobbyEventMapper(),
+                )
+            val playersByConnection = ConcurrentHashMap<ConnectionId, PlayerId>()
+            val connectionsByPlayer = ConcurrentHashMap<PlayerId, ConnectionId>()
+            val routingService =
+                MainServerLobbyRoutingService(
+                    network = network,
+                    router = router,
+                    lobbyManager = lobbyManager,
+                    playerIdResolver = { connectionId -> playersByConnection[connectionId] },
+                    connectionIdResolver = { playerId -> connectionsByPlayer[playerId] },
+                    hooks = MainServerLobbyRoutingServiceHooks(),
+                )
+
+            application {
+                module(network)
+            }
+
+            val lobbyCode = LobbyCode("CRI1")
+            val playerOne = PlayerId(1)
+            val playerTwo = PlayerId(2)
+            lobbyManager.createLobby(
+                lobbyCode = lobbyCode,
+                initialState =
+                    reinforcementState(
+                        lobbyCode = lobbyCode,
+                        players = listOf(playerOne, playerTwo),
+                        activePlayerId = playerOne,
+                        pendingAmount = 0,
+                    ),
+            )
+            routingService.start(serverScope)
+
+            val client =
+                createClient {
+                    install(WebSockets)
+                }
+
+            try {
+                coroutineScope {
+                    val actorSession =
+                        connectSessionWithConnection(
+                            client = client,
+                            network = network,
+                            playerId = playerOne,
+                            playersByConnection = playersByConnection,
+                            connectionsByPlayer = connectionsByPlayer,
+                        )
+                    val watcherSession =
+                        connectSessionWithConnection(
+                            client = client,
+                            network = network,
+                            playerId = playerTwo,
+                            playersByConnection = playersByConnection,
+                            connectionsByPlayer = connectionsByPlayer,
+                        )
+
+                    actorSession.first.send(
+                        Frame.Binary(
+                            fin = true,
+                            data =
+                                MessageCodec.encode(
+                                    ConfirmReinforcementsDoneRequest(
+                                        lobbyCode = lobbyCode,
+                                        playerId = playerOne,
+                                    ),
+                                ),
+                        ),
+                    )
+
+                    val expectedUpdate =
+                        TurnStateUpdatedEvent(
+                            lobbyCode = lobbyCode,
+                            activePlayerId = playerOne,
+                            turnPhase = TurnPhase.ATTACK,
+                            turnCount = 1,
+                            startPlayerId = playerOne,
+                        )
+                    val expectedDelta =
+                        GameStateDeltaEvent(
+                            lobbyCode = lobbyCode,
+                            fromVersion = 1,
+                            toVersion = 1,
+                            events = listOf(expectedUpdate),
+                        )
+
+                    assertEquals(expectedDelta, receiveAnyPayload(actorSession.first))
+                    assertEquals(
+                        ConfirmReinforcementsDoneResponse(lobbyCode),
+                        receiveAnyPayload(actorSession.first),
+                    )
+                    assertEquals(
+                        PhaseBoundaryEvent(
+                            lobbyCode = lobbyCode,
+                            stateVersion = 1,
+                            previousPhase = TurnPhase.REINFORCEMENTS,
+                            nextPhase = TurnPhase.ATTACK,
+                            activePlayerId = playerOne,
+                            turnCount = 1,
+                        ),
+                        receiveAnyPayload(actorSession.first),
+                    )
+                    assertEquals(expectedUpdate, receiveAnyPayload(actorSession.first))
+
+                    assertEquals(expectedDelta, receiveAnyPayload(watcherSession.first))
+                    assertEquals(
+                        PhaseBoundaryEvent(
+                            lobbyCode = lobbyCode,
+                            stateVersion = 1,
+                            previousPhase = TurnPhase.REINFORCEMENTS,
+                            nextPhase = TurnPhase.ATTACK,
+                            activePlayerId = playerOne,
+                            turnCount = 1,
+                        ),
+                        receiveAnyPayload(watcherSession.first),
+                    )
+                    assertEquals(expectedUpdate, receiveAnyPayload(watcherSession.first))
+
+                    val updatedState =
+                        lobbyManager.getLobby(lobbyCode)?.currentState()
+                            ?: error("state missing")
+                    assertEquals(TurnPhase.ATTACK, updatedState.activeTurnPhase)
+                    assertNull(receiveRelevantTestPayloadOrNull(actorSession.first))
+                    assertNull(receiveRelevantTestPayloadOrNull(watcherSession.first))
+
+                    actorSession.first.close()
+                    watcherSession.first.close()
+                }
+            } finally {
+                routingService.stop()
+                lobbyManager.shutdownAll()
+                serverScope.cancel()
+            }
+        }
+
+    @Test
+    fun `pending greater than zero fails`() =
+        testApplication {
+            val lobbyCode = LobbyCode("CRI2")
+            val playerOne = PlayerId(1)
+            val playerTwo = PlayerId(2)
+            val initialState =
+                reinforcementState(
+                    lobbyCode = lobbyCode,
+                    players = listOf(playerOne, playerTwo),
+                    activePlayerId = playerOne,
+                    pendingAmount = 2,
+                )
+
+            val (error, snapshot) =
+                exerciseFailingConfirm(
+                    lobbyCode = lobbyCode,
+                    state = initialState,
+                    requesterPlayerId = playerOne,
+                    request =
+                        ConfirmReinforcementsDoneRequest(
+                            lobbyCode = lobbyCode,
+                            playerId = playerOne,
+                        ),
+                )
+
+            assertEquals(
+                ConfirmReinforcementsDoneErrorCode.PENDING_REINFORCEMENTS_REMAINING,
+                error.code,
+            )
+            assertEquals(TurnPhase.REINFORCEMENTS, snapshot.activeTurnPhase)
+            assertEquals(2, snapshot.pendingReinforcementsFor(playerOne))
+        }
+
+    private suspend fun ApplicationTestBuilder.exerciseFailingConfirm(
+        lobbyCode: LobbyCode,
+        state: GameState,
+        requesterPlayerId: PlayerId,
+        request: ConfirmReinforcementsDoneRequest,
+    ): Pair<ConfirmReinforcementsDoneErrorResponse, GameState> {
+        val network = ServerNetwork()
+        val serverScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val lobbyManager = LobbyManager(serverScope)
+        val router =
+            MainServerRouter(
+                lobbyManager = lobbyManager,
+                mapper = DefaultNetworkToLobbyEventMapper(),
+            )
+        val playersByConnection = ConcurrentHashMap<ConnectionId, PlayerId>()
+        val connectionsByPlayer = ConcurrentHashMap<PlayerId, ConnectionId>()
+        val routingService =
+            MainServerLobbyRoutingService(
+                network = network,
+                router = router,
+                lobbyManager = lobbyManager,
+                playerIdResolver = { connectionId -> playersByConnection[connectionId] },
+                connectionIdResolver = { playerId -> connectionsByPlayer[playerId] },
+                hooks = MainServerLobbyRoutingServiceHooks(),
+            )
+
+        application {
+            module(network)
+        }
+        lobbyManager.createLobby(lobbyCode = lobbyCode, initialState = state)
+        routingService.start(serverScope)
+
+        val client =
+            createClient {
+                install(WebSockets)
+            }
+
+        return try {
+            coroutineScope {
+                val requesterSession =
+                    connectSessionWithConnection(
+                        client = client,
+                        network = network,
+                        playerId = requesterPlayerId,
+                        playersByConnection = playersByConnection,
+                        connectionsByPlayer = connectionsByPlayer,
+                    )
+
+                requesterSession.first.send(
+                    Frame.Binary(
+                        fin = true,
+                        data = MessageCodec.encode(request),
+                    ),
+                )
+
+                val error =
+                    assertIs<ConfirmReinforcementsDoneErrorResponse>(
+                        receiveRelevantTestPayload(requesterSession.first),
+                    )
+                assertNull(receiveRelevantTestPayloadOrNull(requesterSession.first))
+
+                val snapshot =
+                    lobbyManager.getLobby(lobbyCode)?.currentState()
+                        ?: error("snapshot missing")
+                requesterSession.first.close()
+                error to snapshot
+            }
+        } finally {
+            routingService.stop()
+            lobbyManager.shutdownAll()
+            serverScope.cancel()
+        }
+    }
+
+    private fun reinforcementState(
+        lobbyCode: LobbyCode,
+        players: List<PlayerId>,
+        activePlayerId: PlayerId,
+        pendingAmount: Int,
+    ): GameState =
+        GameState
+            .initial(
+                lobbyCode = lobbyCode,
+                mapDefinition = defaultMapDefinition(),
+                players = players,
+                playerDisplayNames = players.associateWith { "Player ${it.value}" },
+            ).copy(
+                lobbyOwner = players.firstOrNull(),
+                activePlayer = activePlayerId,
+                turnOrder = players,
+                turnNumber = 1,
+                turnState =
+                    TurnState(
+                        activePlayerId = activePlayerId,
+                        turnPhase = TurnPhase.REINFORCEMENTS,
+                        turnCount = 1,
+                        startPlayerId = players.first(),
+                    ),
+                status = GameStatus.RUNNING,
+                pendingReinforcements = PendingReinforcements(activePlayerId, pendingAmount),
+            )
+
+    private suspend fun connectSessionWithConnection(
+        client: io.ktor.client.HttpClient,
+        network: ServerNetwork,
+        playerId: PlayerId,
+        playersByConnection: ConcurrentHashMap<ConnectionId, PlayerId>,
+        connectionsByPlayer: ConcurrentHashMap<PlayerId, ConnectionId>,
+    ) = coroutineScope {
+        val session = client.webSocketSession("/ws")
+        val sessionToken = receiveTestConnectionToken(session)
+        val connectionId = awaitTestConnectionId(network, sessionToken)
+        playersByConnection[connectionId] = playerId
+        connectionsByPlayer[playerId] = connectionId
+        session to connectionId
+    }
+
+    private suspend fun receiveAnyPayload(
+        session: io.ktor.client.plugins.websocket.DefaultClientWebSocketSession,
+    ): Any = receiveRelevantTestPayload(session)
+
+    private inline fun <reified T> assertIs(value: Any?): T {
+        require(value is T) {
+            "Expected ${T::class.simpleName}, but was ${value?.let { it::class.simpleName }}."
+        }
+        return value
+    }
+
+    private fun defaultMapDefinition() =
+        at.aau.pulverfass.shared.map.config.MapConfigLoader.loadDefault()
+}

--- a/server/src/test/kotlin/at/aau/pulverfass/server/ConfirmReinforcementsDoneIntegrationTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/ConfirmReinforcementsDoneIntegrationTest.kt
@@ -183,6 +183,69 @@ class ConfirmReinforcementsDoneIntegrationTest {
         }
 
     @Test
+    fun `confirm rejected when requester is not active player`() =
+        testApplication {
+            val lobbyCode = LobbyCode("CRNP")
+            val playerOne = PlayerId(1)
+            val playerTwo = PlayerId(2)
+            val initialState =
+                reinforcementState(
+                    lobbyCode = lobbyCode,
+                    players = listOf(playerOne, playerTwo),
+                    activePlayerId = playerTwo,
+                    pendingAmount = 0,
+                )
+
+            val (error, snapshot) =
+                exerciseFailingConfirm(
+                    lobbyCode = lobbyCode,
+                    state = initialState,
+                    requesterPlayerId = playerOne,
+                    request =
+                        ConfirmReinforcementsDoneRequest(
+                            lobbyCode = lobbyCode,
+                            playerId = playerOne,
+                        ),
+                )
+
+            assertEquals(ConfirmReinforcementsDoneErrorCode.NOT_ACTIVE_PLAYER, error.code)
+            assertEquals(initialState.stateVersion, snapshot.stateVersion)
+            assertEquals(TurnPhase.REINFORCEMENTS, snapshot.activeTurnPhase)
+        }
+
+    @Test
+    fun `confirm rejected when phase is not REINFORCEMENTS`() =
+        testApplication {
+            val lobbyCode = LobbyCode("CRPM")
+            val playerOne = PlayerId(1)
+            val playerTwo = PlayerId(2)
+            val initialState =
+                reinforcementState(
+                    lobbyCode = lobbyCode,
+                    players = listOf(playerOne, playerTwo),
+                    activePlayerId = playerOne,
+                    pendingAmount = 0,
+                    turnPhase = TurnPhase.ATTACK,
+                )
+
+            val (error, snapshot) =
+                exerciseFailingConfirm(
+                    lobbyCode = lobbyCode,
+                    state = initialState,
+                    requesterPlayerId = playerOne,
+                    request =
+                        ConfirmReinforcementsDoneRequest(
+                            lobbyCode = lobbyCode,
+                            playerId = playerOne,
+                        ),
+                )
+
+            assertEquals(ConfirmReinforcementsDoneErrorCode.PHASE_MISMATCH, error.code)
+            assertEquals(initialState.stateVersion, snapshot.stateVersion)
+            assertEquals(TurnPhase.ATTACK, snapshot.activeTurnPhase)
+        }
+
+    @Test
     fun `pending greater than zero fails`() =
         testApplication {
             val lobbyCode = LobbyCode("CRI2")
@@ -295,6 +358,7 @@ class ConfirmReinforcementsDoneIntegrationTest {
         players: List<PlayerId>,
         activePlayerId: PlayerId,
         pendingAmount: Int,
+        turnPhase: TurnPhase = TurnPhase.REINFORCEMENTS,
     ): GameState =
         GameState
             .initial(
@@ -310,7 +374,7 @@ class ConfirmReinforcementsDoneIntegrationTest {
                 turnState =
                     TurnState(
                         activePlayerId = activePlayerId,
-                        turnPhase = TurnPhase.REINFORCEMENTS,
+                        turnPhase = turnPhase,
                         turnCount = 1,
                         startPlayerId = players.first(),
                     ),

--- a/server/src/test/kotlin/at/aau/pulverfass/server/ForcedTradeInIntegrationTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/ForcedTradeInIntegrationTest.kt
@@ -1,0 +1,452 @@
+package at.aau.pulverfass.server
+
+import at.aau.pulverfass.server.lobby.mapping.DefaultNetworkToLobbyEventMapper
+import at.aau.pulverfass.server.lobby.runtime.LobbyManager
+import at.aau.pulverfass.server.routing.MainServerLobbyRoutingService
+import at.aau.pulverfass.server.routing.MainServerLobbyRoutingServiceHooks
+import at.aau.pulverfass.server.routing.MainServerRouter
+import at.aau.pulverfass.shared.ids.CardId
+import at.aau.pulverfass.shared.ids.ConnectionId
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.ids.TerritoryId
+import at.aau.pulverfass.shared.lobby.state.CardState
+import at.aau.pulverfass.shared.lobby.state.CardType
+import at.aau.pulverfass.shared.lobby.state.GameState
+import at.aau.pulverfass.shared.lobby.state.GameStatus
+import at.aau.pulverfass.shared.lobby.state.HandState
+import at.aau.pulverfass.shared.lobby.state.PendingReinforcements
+import at.aau.pulverfass.shared.lobby.state.TerritoryState
+import at.aau.pulverfass.shared.lobby.state.TurnPhase
+import at.aau.pulverfass.shared.lobby.state.TurnState
+import at.aau.pulverfass.shared.map.config.MapConfigLoader
+import at.aau.pulverfass.shared.message.lobby.request.ConfirmReinforcementsDoneRequest
+import at.aau.pulverfass.shared.message.lobby.request.PlaceReinforcementsRequest
+import at.aau.pulverfass.shared.message.lobby.request.TerritoryPlacement
+import at.aau.pulverfass.shared.message.lobby.response.ConfirmReinforcementsDoneResponse
+import at.aau.pulverfass.shared.message.lobby.response.PlaceReinforcementsResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.ConfirmReinforcementsDoneErrorCode
+import at.aau.pulverfass.shared.message.lobby.response.error.ConfirmReinforcementsDoneErrorResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.PlaceReinforcementsErrorCode
+import at.aau.pulverfass.shared.message.lobby.response.error.PlaceReinforcementsErrorResponse
+import at.aau.pulverfass.shared.network.codec.MessageCodec
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.client.plugins.websocket.webSocketSession
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import io.ktor.websocket.Frame
+import io.ktor.websocket.close
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import java.util.concurrent.ConcurrentHashMap
+
+class ForcedTradeInIntegrationTest {
+    private val mapDefinition = MapConfigLoader.loadDefault()
+    private val firstTerritoryId = mapDefinition.territories.first().territoryId
+    private val playerOne = PlayerId(1)
+    private val playerTwo = PlayerId(2)
+
+    // 5-card hand that contains a valid set (A, B, C present → A+B+C is valid).
+    private val fiveCardHandWithSet =
+        listOf(
+            CardState(CardId("a1"), CardType.A),
+            CardState(CardId("a2"), CardType.A),
+            CardState(CardId("b1"), CardType.B),
+            CardState(CardId("b2"), CardType.B),
+            CardState(CardId("c1"), CardType.C),
+        )
+
+    // 4-card hand that contains a valid set (below forced-trade threshold).
+    private val fourCardHandWithSet =
+        listOf(
+            CardState(CardId("x1"), CardType.A),
+            CardState(CardId("x2"), CardType.B),
+            CardState(CardId("x3"), CardType.C),
+            CardState(CardId("x4"), CardType.A),
+        )
+
+    @Test
+    fun `confirm reinforcements done is blocked when 5 cards and can form set`() =
+        testApplication {
+            val lobbyCode = LobbyCode("FTI1")
+            val state =
+                forcedTradeState(
+                    lobbyCode = lobbyCode,
+                    hand = fiveCardHandWithSet,
+                    pendingAmount = 0,
+                )
+
+            val error =
+                exerciseFailingConfirm(
+                    lobbyCode = lobbyCode,
+                    state = state,
+                    request =
+                        ConfirmReinforcementsDoneRequest(
+                            lobbyCode = lobbyCode,
+                            playerId = playerOne,
+                        ),
+                )
+
+            assertEquals(ConfirmReinforcementsDoneErrorCode.FORCED_TRADE_REQUIRED, error.code)
+        }
+
+    @Test
+    fun `place reinforcements is blocked when 5 cards and can form set`() =
+        testApplication {
+            val lobbyCode = LobbyCode("FTI2")
+            val state =
+                forcedTradeState(
+                    lobbyCode = lobbyCode,
+                    hand = fiveCardHandWithSet,
+                    pendingAmount = 3,
+                    ownedTerritoryId = firstTerritoryId,
+                )
+
+            val error =
+                exerciseFailingPlace(
+                    lobbyCode = lobbyCode,
+                    state = state,
+                    request =
+                        PlaceReinforcementsRequest(
+                            lobbyCode = lobbyCode,
+                            playerId = playerOne,
+                            placements = listOf(TerritoryPlacement(firstTerritoryId, 1)),
+                        ),
+                )
+
+            assertEquals(PlaceReinforcementsErrorCode.FORCED_TRADE_REQUIRED, error.code)
+        }
+
+    @Test
+    fun `confirm reinforcements done is allowed when exactly 4 cards even with valid set`() =
+        testApplication {
+            val lobbyCode = LobbyCode("FTI3")
+            val state =
+                forcedTradeState(
+                    lobbyCode = lobbyCode,
+                    hand = fourCardHandWithSet,
+                    pendingAmount = 0,
+                )
+
+            val network = ServerNetwork()
+            val serverScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            val lobbyManager = LobbyManager(serverScope)
+            val router =
+                MainServerRouter(
+                    lobbyManager = lobbyManager,
+                    mapper = DefaultNetworkToLobbyEventMapper(),
+                )
+            val playersByConnection = ConcurrentHashMap<ConnectionId, PlayerId>()
+            val connectionsByPlayer = ConcurrentHashMap<PlayerId, ConnectionId>()
+            val routingService =
+                MainServerLobbyRoutingService(
+                    network = network,
+                    router = router,
+                    lobbyManager = lobbyManager,
+                    playerIdResolver = { id -> playersByConnection[id] },
+                    connectionIdResolver = { id -> connectionsByPlayer[id] },
+                    hooks = MainServerLobbyRoutingServiceHooks(),
+                )
+
+            application { module(network) }
+            lobbyManager.createLobby(lobbyCode = lobbyCode, initialState = state)
+            routingService.start(serverScope)
+
+            val client = createClient { install(WebSockets) }
+
+            try {
+                coroutineScope {
+                    val session =
+                        connectSession(
+                            client = client,
+                            network = network,
+                            playerId = playerOne,
+                            playersByConnection = playersByConnection,
+                            connectionsByPlayer = connectionsByPlayer,
+                        )
+
+                    session.send(
+                        Frame.Binary(
+                            fin = true,
+                            data =
+                                MessageCodec.encode(
+                                    ConfirmReinforcementsDoneRequest(
+                                        lobbyCode = lobbyCode,
+                                        playerId = playerOne,
+                                    ),
+                                ),
+                        ),
+                    )
+
+                    val response = receiveRelevantTestPayload(session, skipGameSync = true)
+                    session.close()
+
+                    assertEquals(ConfirmReinforcementsDoneResponse(lobbyCode), response)
+                }
+            } finally {
+                routingService.stop()
+                lobbyManager.shutdownAll()
+                serverScope.cancel()
+            }
+        }
+
+    @Test
+    fun `place reinforcements is allowed when exactly 4 cards even with valid set`() =
+        testApplication {
+            val lobbyCode = LobbyCode("FTI4")
+            val state =
+                forcedTradeState(
+                    lobbyCode = lobbyCode,
+                    hand = fourCardHandWithSet,
+                    pendingAmount = 3,
+                    ownedTerritoryId = firstTerritoryId,
+                )
+
+            val network = ServerNetwork()
+            val serverScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            val lobbyManager = LobbyManager(serverScope)
+            val router =
+                MainServerRouter(
+                    lobbyManager = lobbyManager,
+                    mapper = DefaultNetworkToLobbyEventMapper(),
+                )
+            val playersByConnection = ConcurrentHashMap<ConnectionId, PlayerId>()
+            val connectionsByPlayer = ConcurrentHashMap<PlayerId, ConnectionId>()
+            val routingService =
+                MainServerLobbyRoutingService(
+                    network = network,
+                    router = router,
+                    lobbyManager = lobbyManager,
+                    playerIdResolver = { id -> playersByConnection[id] },
+                    connectionIdResolver = { id -> connectionsByPlayer[id] },
+                    hooks = MainServerLobbyRoutingServiceHooks(),
+                )
+
+            application { module(network) }
+            lobbyManager.createLobby(lobbyCode = lobbyCode, initialState = state)
+            routingService.start(serverScope)
+
+            val client = createClient { install(WebSockets) }
+
+            try {
+                coroutineScope {
+                    val session =
+                        connectSession(
+                            client = client,
+                            network = network,
+                            playerId = playerOne,
+                            playersByConnection = playersByConnection,
+                            connectionsByPlayer = connectionsByPlayer,
+                        )
+
+                    session.send(
+                        Frame.Binary(
+                            fin = true,
+                            data =
+                                MessageCodec.encode(
+                                    PlaceReinforcementsRequest(
+                                        lobbyCode = lobbyCode,
+                                        playerId = playerOne,
+                                        placements =
+                                            listOf(
+                                                TerritoryPlacement(firstTerritoryId, 1),
+                                            ),
+                                    ),
+                                ),
+                        ),
+                    )
+
+                    receiveRelevantTestPayload(session) // GameStateDeltaEvent (troop change)
+                    receiveRelevantTestPayload(session) // TerritoryTroopsChangedEvent direct
+                    receiveRelevantTestPayload(session) // GameStateDeltaEvent (pending change)
+                    val response = receiveRelevantTestPayload(session)
+                    session.close()
+
+                    assertEquals(PlaceReinforcementsResponse(lobbyCode = lobbyCode), response)
+                }
+            } finally {
+                routingService.stop()
+                lobbyManager.shutdownAll()
+                serverScope.cancel()
+            }
+        }
+
+    private suspend fun ApplicationTestBuilder.exerciseFailingConfirm(
+        lobbyCode: LobbyCode,
+        state: GameState,
+        request: ConfirmReinforcementsDoneRequest,
+    ): ConfirmReinforcementsDoneErrorResponse {
+        val network = ServerNetwork()
+        val serverScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val lobbyManager = LobbyManager(serverScope)
+        val router =
+            MainServerRouter(
+                lobbyManager = lobbyManager,
+                mapper = DefaultNetworkToLobbyEventMapper(),
+            )
+        val playersByConnection = ConcurrentHashMap<ConnectionId, PlayerId>()
+        val connectionsByPlayer = ConcurrentHashMap<PlayerId, ConnectionId>()
+        val routingService =
+            MainServerLobbyRoutingService(
+                network = network,
+                router = router,
+                lobbyManager = lobbyManager,
+                playerIdResolver = { id -> playersByConnection[id] },
+                connectionIdResolver = { id -> connectionsByPlayer[id] },
+                hooks = MainServerLobbyRoutingServiceHooks(),
+            )
+
+        application { module(network) }
+        lobbyManager.createLobby(lobbyCode = lobbyCode, initialState = state)
+        routingService.start(serverScope)
+
+        val client = createClient { install(WebSockets) }
+
+        return try {
+            coroutineScope {
+                val session =
+                    connectSession(
+                        client = client,
+                        network = network,
+                        playerId = playerOne,
+                        playersByConnection = playersByConnection,
+                        connectionsByPlayer = connectionsByPlayer,
+                    )
+
+                session.send(Frame.Binary(fin = true, data = MessageCodec.encode(request)))
+
+                val response =
+                    receiveRelevantTestPayload(session) as ConfirmReinforcementsDoneErrorResponse
+                assertNull(receiveRelevantTestPayloadOrNull(session))
+                session.close()
+                response
+            }
+        } finally {
+            routingService.stop()
+            lobbyManager.shutdownAll()
+            serverScope.cancel()
+        }
+    }
+
+    private suspend fun ApplicationTestBuilder.exerciseFailingPlace(
+        lobbyCode: LobbyCode,
+        state: GameState,
+        request: PlaceReinforcementsRequest,
+    ): PlaceReinforcementsErrorResponse {
+        val network = ServerNetwork()
+        val serverScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val lobbyManager = LobbyManager(serverScope)
+        val router =
+            MainServerRouter(
+                lobbyManager = lobbyManager,
+                mapper = DefaultNetworkToLobbyEventMapper(),
+            )
+        val playersByConnection = ConcurrentHashMap<ConnectionId, PlayerId>()
+        val connectionsByPlayer = ConcurrentHashMap<PlayerId, ConnectionId>()
+        val routingService =
+            MainServerLobbyRoutingService(
+                network = network,
+                router = router,
+                lobbyManager = lobbyManager,
+                playerIdResolver = { id -> playersByConnection[id] },
+                connectionIdResolver = { id -> connectionsByPlayer[id] },
+                hooks = MainServerLobbyRoutingServiceHooks(),
+            )
+
+        application { module(network) }
+        lobbyManager.createLobby(lobbyCode = lobbyCode, initialState = state)
+        routingService.start(serverScope)
+
+        val client = createClient { install(WebSockets) }
+
+        return try {
+            coroutineScope {
+                val session =
+                    connectSession(
+                        client = client,
+                        network = network,
+                        playerId = playerOne,
+                        playersByConnection = playersByConnection,
+                        connectionsByPlayer = connectionsByPlayer,
+                    )
+
+                session.send(Frame.Binary(fin = true, data = MessageCodec.encode(request)))
+
+                val response =
+                    receiveRelevantTestPayload(session) as PlaceReinforcementsErrorResponse
+                assertNull(receiveRelevantTestPayloadOrNull(session))
+                session.close()
+                response
+            }
+        } finally {
+            routingService.stop()
+            lobbyManager.shutdownAll()
+            serverScope.cancel()
+        }
+    }
+
+    private suspend fun connectSession(
+        client: io.ktor.client.HttpClient,
+        network: ServerNetwork,
+        playerId: PlayerId,
+        playersByConnection: ConcurrentHashMap<ConnectionId, PlayerId>,
+        connectionsByPlayer: ConcurrentHashMap<PlayerId, ConnectionId>,
+    ) = coroutineScope {
+        val session = client.webSocketSession("/ws")
+        val sessionToken = receiveTestConnectionToken(session)
+        val connectionId = awaitTestConnectionId(network, sessionToken)
+        playersByConnection[connectionId] = playerId
+        connectionsByPlayer[playerId] = connectionId
+        session
+    }
+
+    private fun forcedTradeState(
+        lobbyCode: LobbyCode,
+        hand: List<CardState>,
+        pendingAmount: Int,
+        ownedTerritoryId: TerritoryId? = null,
+    ): GameState {
+        val players = listOf(playerOne, playerTwo)
+        val baseState =
+            GameState.initial(
+                lobbyCode = lobbyCode,
+                mapDefinition = mapDefinition,
+                players = players,
+                playerDisplayNames = players.associateWith { "Player ${it.value}" },
+            )
+
+        val updatedTerritories =
+            baseState.allTerritoryStates().associate { ts ->
+                ts.territoryId to
+                    TerritoryState(
+                        territoryId = ts.territoryId,
+                        ownerId = if (ts.territoryId == ownedTerritoryId) playerOne else null,
+                        troopCount = if (ts.territoryId == ownedTerritoryId) 3 else 0,
+                    )
+            }
+
+        return baseState.copy(
+            lobbyOwner = playerOne,
+            activePlayer = playerOne,
+            turnOrder = players,
+            turnNumber = 1,
+            turnState =
+                TurnState(
+                    activePlayerId = playerOne,
+                    turnPhase = TurnPhase.REINFORCEMENTS,
+                    turnCount = 1,
+                    startPlayerId = playerOne,
+                ),
+            status = GameStatus.RUNNING,
+            pendingReinforcements = PendingReinforcements(playerOne, pendingAmount),
+            handState = HandState(cardsByPlayer = mapOf(playerOne to hand)),
+            territoryStates = updatedTerritories,
+        )
+    }
+}

--- a/server/src/test/kotlin/at/aau/pulverfass/server/GameStateTransportIntegrationTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/GameStateTransportIntegrationTest.kt
@@ -18,6 +18,7 @@ import at.aau.pulverfass.shared.map.config.MapConfigLoader
 import at.aau.pulverfass.shared.message.lobby.event.GameStateDeltaEvent
 import at.aau.pulverfass.shared.message.lobby.event.GameStateSnapshotBroadcast
 import at.aau.pulverfass.shared.message.lobby.event.PhaseBoundaryEvent
+import at.aau.pulverfass.shared.message.lobby.event.ReinforcementsGrantedEvent
 import at.aau.pulverfass.shared.message.lobby.request.GameStateCatchUpReason
 import at.aau.pulverfass.shared.message.lobby.request.GameStateCatchUpRequest
 import at.aau.pulverfass.shared.message.lobby.request.GameStatePrivateGetRequest
@@ -193,6 +194,15 @@ class GameStateTransportIntegrationTest {
                                 startPlayerId = playerOne,
                             ),
                         expectSnapshot = true,
+                        expectedGrantedEvent =
+                            ReinforcementsGrantedEvent(
+                                lobbyCode = lobbyCode,
+                                playerId = playerTwo,
+                                amount = 3,
+                                territoryBonus = 3,
+                                continentBonus = 0,
+                                cardBonus = 0,
+                            ),
                     )
 
                     playerTwoSession.first.send(
@@ -214,7 +224,7 @@ class GameStateTransportIntegrationTest {
                             receiveAnyPayload(playerTwoSession.first),
                         )
                     assertEquals(lobbyCode, catchUp.lobbyCode)
-                    assertEquals(4, catchUp.stateVersion)
+                    assertEquals(5, catchUp.stateVersion)
                     assertEquals(playerTwo, catchUp.turnState.activePlayerId)
                     assertEquals(TurnPhase.REINFORCEMENTS, catchUp.turnState.turnPhase)
                     assertEquals(defaultMapDefinition().mapHash, catchUp.determinism.mapHash)
@@ -223,7 +233,7 @@ class GameStateTransportIntegrationTest {
                     val history = routingService.roundHistory(lobbyCode)
                     assertEquals(1, history.size)
                     assertEquals(1, history.single().roundIndex)
-                    assertEquals(4, history.single().endStateVersion)
+                    assertEquals(5, history.single().endStateVersion)
                     assertTrue(history.single().deltas.isNotEmpty())
                     assertTrue(history.single().phaseBoundaries.isNotEmpty())
                     assertTrue(history.single().turnStateChanges.isNotEmpty())
@@ -255,6 +265,7 @@ class GameStateTransportIntegrationTest {
         expectedVersion: Long,
         expectedUpdate: TurnStateUpdatedEvent,
         expectSnapshot: Boolean = false,
+        expectedGrantedEvent: ReinforcementsGrantedEvent? = null,
     ) {
         actor.send(
             Frame.Binary(
@@ -272,11 +283,22 @@ class GameStateTransportIntegrationTest {
             ),
             receiveAnyPayload(actor),
         )
+        if (expectedGrantedEvent != null) {
+            assertEquals(
+                GameStateDeltaEvent(
+                    lobbyCode = request.lobbyCode,
+                    fromVersion = expectedVersion + 1,
+                    toVersion = expectedVersion + 1,
+                    events = listOf(expectedGrantedEvent),
+                ),
+                receiveAnyPayload(actor),
+            )
+        }
         assertEquals(TurnAdvanceResponse(request.lobbyCode), receiveAnyPayload(actor))
         assertEquals(
             PhaseBoundaryEvent(
                 lobbyCode = request.lobbyCode,
-                stateVersion = expectedVersion,
+                stateVersion = if (expectedGrantedEvent == null) expectedVersion else expectedVersion + 1,
                 previousPhase = request.expectedPhase ?: error("expectedPhase required in test"),
                 nextPhase = expectedUpdate.turnPhase,
                 activePlayerId = expectedUpdate.activePlayerId,
@@ -287,7 +309,10 @@ class GameStateTransportIntegrationTest {
         assertEquals(expectedUpdate, receiveAnyPayload(actor))
         if (expectSnapshot) {
             val snapshot = assertIs<GameStateSnapshotBroadcast>(receiveAnyPayload(actor))
-            assertEquals(expectedVersion, snapshot.stateVersion)
+            assertEquals(
+                if (expectedGrantedEvent == null) expectedVersion else expectedVersion + 1,
+                snapshot.stateVersion,
+            )
             assertEquals(expectedUpdate.activePlayerId, snapshot.turnState.activePlayerId)
             assertEquals(expectedUpdate.turnPhase, snapshot.turnState.turnPhase)
         }
@@ -301,10 +326,21 @@ class GameStateTransportIntegrationTest {
             ),
             receiveAnyPayload(watcher),
         )
+        if (expectedGrantedEvent != null) {
+            assertEquals(
+                GameStateDeltaEvent(
+                    lobbyCode = request.lobbyCode,
+                    fromVersion = expectedVersion + 1,
+                    toVersion = expectedVersion + 1,
+                    events = listOf(expectedGrantedEvent),
+                ),
+                receiveAnyPayload(watcher),
+            )
+        }
         assertEquals(
             PhaseBoundaryEvent(
                 lobbyCode = request.lobbyCode,
-                stateVersion = expectedVersion,
+                stateVersion = if (expectedGrantedEvent == null) expectedVersion else expectedVersion + 1,
                 previousPhase = request.expectedPhase ?: error("expectedPhase required in test"),
                 nextPhase = expectedUpdate.turnPhase,
                 activePlayerId = expectedUpdate.activePlayerId,
@@ -315,7 +351,10 @@ class GameStateTransportIntegrationTest {
         assertEquals(expectedUpdate, receiveAnyPayload(watcher))
         if (expectSnapshot) {
             val snapshot = assertIs<GameStateSnapshotBroadcast>(receiveAnyPayload(watcher))
-            assertEquals(expectedVersion, snapshot.stateVersion)
+            assertEquals(
+                if (expectedGrantedEvent == null) expectedVersion else expectedVersion + 1,
+                snapshot.stateVersion,
+            )
             assertEquals(expectedUpdate.activePlayerId, snapshot.turnState.activePlayerId)
             assertEquals(expectedUpdate.turnPhase, snapshot.turnState.turnPhase)
         }

--- a/server/src/test/kotlin/at/aau/pulverfass/server/GameStateTransportIntegrationTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/GameStateTransportIntegrationTest.kt
@@ -298,7 +298,8 @@ class GameStateTransportIntegrationTest {
         assertEquals(
             PhaseBoundaryEvent(
                 lobbyCode = request.lobbyCode,
-                stateVersion = if (expectedGrantedEvent == null) expectedVersion else expectedVersion + 1,
+                stateVersion =
+                    if (expectedGrantedEvent == null) expectedVersion else expectedVersion + 1,
                 previousPhase = request.expectedPhase ?: error("expectedPhase required in test"),
                 nextPhase = expectedUpdate.turnPhase,
                 activePlayerId = expectedUpdate.activePlayerId,
@@ -340,7 +341,8 @@ class GameStateTransportIntegrationTest {
         assertEquals(
             PhaseBoundaryEvent(
                 lobbyCode = request.lobbyCode,
-                stateVersion = if (expectedGrantedEvent == null) expectedVersion else expectedVersion + 1,
+                stateVersion =
+                    if (expectedGrantedEvent == null) expectedVersion else expectedVersion + 1,
                 previousPhase = request.expectedPhase ?: error("expectedPhase required in test"),
                 nextPhase = expectedUpdate.turnPhase,
                 activePlayerId = expectedUpdate.activePlayerId,

--- a/server/src/test/kotlin/at/aau/pulverfass/server/GameStateTransportIntegrationTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/GameStateTransportIntegrationTest.kt
@@ -227,6 +227,7 @@ class GameStateTransportIntegrationTest {
                     assertEquals(5, catchUp.stateVersion)
                     assertEquals(playerTwo, catchUp.turnState.activePlayerId)
                     assertEquals(TurnPhase.REINFORCEMENTS, catchUp.turnState.turnPhase)
+                    assertEquals(3, catchUp.turnState.pendingReinforcements)
                     assertEquals(defaultMapDefinition().mapHash, catchUp.determinism.mapHash)
                     assertNull(receivePayloadOrNull(playerOneSession.first))
 

--- a/server/src/test/kotlin/at/aau/pulverfass/server/LobbyPersistenceHooksIntegrationTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/LobbyPersistenceHooksIntegrationTest.kt
@@ -183,7 +183,7 @@ class LobbyPersistenceHooksIntegrationTest {
                         )
                     assertEquals(1, persistedSnapshots.size)
                     val snapshot = persistedSnapshots.single()
-                    assertEquals(4L, snapshot.stateVersion)
+                    assertEquals(5L, snapshot.stateVersion)
                     assertEquals(1, snapshot.turnCount)
 
                     val snapshotJson = Json.parseToJsonElement(snapshot.snapshotJson).jsonObject

--- a/server/src/test/kotlin/at/aau/pulverfass/server/MainServerLobbyRoutingIntegrationTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/MainServerLobbyRoutingIntegrationTest.kt
@@ -132,7 +132,7 @@ class MainServerLobbyRoutingIntegrationTest {
                     val response = assertIs<MapGetResponse>(payload)
 
                     assertEquals(lobbyCode, response.lobbyCode)
-                    assertEquals(1, response.schemaVersion)
+                    assertEquals(2, response.schemaVersion)
                     assertEquals(defaultMapDefinition().mapHash, response.mapHash)
                     assertEquals(3, response.stateVersion)
                     assertEquals(24, response.definition.territories.size)
@@ -235,7 +235,7 @@ class MainServerLobbyRoutingIntegrationTest {
                     val response = assertIs<MapGetResponse>(receivePayload(session))
 
                     assertEquals(createResponse.lobbyCode, response.lobbyCode)
-                    assertEquals(1, response.schemaVersion)
+                    assertEquals(2, response.schemaVersion)
                     assertEquals(defaultMapDefinition().mapHash, response.mapHash)
                     assertEquals(1, response.stateVersion)
                     assertEquals(24, response.definition.territories.size)

--- a/server/src/test/kotlin/at/aau/pulverfass/server/PhaseOneOrchestrationIntegrationTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/PhaseOneOrchestrationIntegrationTest.kt
@@ -1,0 +1,359 @@
+package at.aau.pulverfass.server
+
+import at.aau.pulverfass.server.lobby.mapping.DefaultNetworkToLobbyEventMapper
+import at.aau.pulverfass.server.lobby.runtime.LobbyManager
+import at.aau.pulverfass.server.routing.MainServerLobbyRoutingService
+import at.aau.pulverfass.server.routing.MainServerLobbyRoutingServiceHooks
+import at.aau.pulverfass.server.routing.MainServerRouter
+import at.aau.pulverfass.shared.ids.ConnectionId
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.lobby.state.GameState
+import at.aau.pulverfass.shared.lobby.state.GameStatus
+import at.aau.pulverfass.shared.lobby.state.TurnPhase
+import at.aau.pulverfass.shared.lobby.state.TurnState
+import at.aau.pulverfass.shared.map.config.MapConfigLoader
+import at.aau.pulverfass.shared.message.lobby.event.GameStateDeltaEvent
+import at.aau.pulverfass.shared.message.lobby.event.ReinforcementsGrantedEvent
+import at.aau.pulverfass.shared.message.lobby.request.StartGameRequest
+import at.aau.pulverfass.shared.message.lobby.request.TurnAdvanceRequest
+import at.aau.pulverfass.shared.network.codec.MessageCodec
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.client.plugins.websocket.webSocketSession
+import io.ktor.server.testing.testApplication
+import io.ktor.websocket.Frame
+import io.ktor.websocket.close
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.concurrent.ConcurrentHashMap
+
+class PhaseOneOrchestrationIntegrationTest {
+    private val mapDefinition = MapConfigLoader.loadDefault()
+
+    @Test
+    fun `DRAW_CARD to REINFORCEMENTS advance grants reinforcements exactly once`() =
+        testApplication {
+            val lobbyCode = LobbyCode("PO01")
+            val playerOne = PlayerId(1)
+            val playerTwo = PlayerId(2)
+
+            val network = ServerNetwork()
+            val serverScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            val lobbyManager = LobbyManager(serverScope)
+            val router = MainServerRouter(lobbyManager, DefaultNetworkToLobbyEventMapper())
+            val playersByConnection = ConcurrentHashMap<ConnectionId, PlayerId>()
+            val connectionsByPlayer = ConcurrentHashMap<PlayerId, ConnectionId>()
+            val routingService =
+                MainServerLobbyRoutingService(
+                    network = network,
+                    router = router,
+                    lobbyManager = lobbyManager,
+                    playerIdResolver = { playersByConnection[it] },
+                    connectionIdResolver = { connectionsByPlayer[it] },
+                    hooks = MainServerLobbyRoutingServiceHooks(),
+                )
+
+            lobbyManager.createLobby(
+                lobbyCode = lobbyCode,
+                initialState =
+                    runningGameState(
+                        lobbyCode = lobbyCode,
+                        players = listOf(playerOne, playerTwo),
+                        activePlayerId = playerOne,
+                        turnPhase = TurnPhase.DRAW_CARD,
+                    ),
+            )
+
+            application { module(network) }
+            routingService.start(serverScope)
+
+            val client = createClient { install(WebSockets) }
+
+            try {
+                coroutineScope {
+                    val (p1Session, _) =
+                        connectSession(
+                            client,
+                            network,
+                            playerOne,
+                            playersByConnection,
+                            connectionsByPlayer,
+                        )
+                    val (p2Session, _) =
+                        connectSession(
+                            client,
+                            network,
+                            playerTwo,
+                            playersByConnection,
+                            connectionsByPlayer,
+                        )
+
+                    p1Session.send(
+                        Frame.Binary(
+                            fin = true,
+                            data =
+                                MessageCodec.encode(
+                                    TurnAdvanceRequest(lobbyCode, playerOne, TurnPhase.DRAW_CARD),
+                                ),
+                        ),
+                    )
+
+                    // playerTwo receives 5 messages in deterministic order:
+                    // 1) delta with TurnStateUpdatedEvent (playerTwo enters REINFORCEMENTS)
+                    receiveAnyPayload(p2Session)
+
+                    // 2) delta with exactly one ReinforcementsGrantedEvent — the base grant
+                    val grantDelta = receiveAnyPayload(p2Session) as GameStateDeltaEvent
+                    val grant = grantDelta.events.single() as ReinforcementsGrantedEvent
+                    assertEquals(playerTwo, grant.playerId)
+                    assertEquals(0, grant.cardBonus)
+                    assertEquals(3, grant.amount)
+
+                    // 3-5) PhaseBoundaryEvent, TurnStateUpdatedEvent, GameStateSnapshotBroadcast
+                    receiveAnyPayload(p2Session)
+                    receiveAnyPayload(p2Session)
+                    receiveAnyPayload(p2Session)
+
+                    // No second grant: the base grant fires exactly once per phase entry
+                    assertNull(receiveAnyPayloadOrNull(p2Session))
+
+                    p1Session.close()
+                    p2Session.close()
+                }
+            } finally {
+                routingService.stop()
+                lobbyManager.shutdownAll()
+                serverScope.cancel()
+            }
+        }
+
+    @Test
+    fun `game start grants base reinforcements for first active player`() =
+        testApplication {
+            val lobbyCode = LobbyCode("PO02")
+            val playerOne = PlayerId(1)
+            val playerTwo = PlayerId(2)
+            val playerThree = PlayerId(3)
+            val players = listOf(playerOne, playerTwo, playerThree)
+
+            val network = ServerNetwork()
+            val serverScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            val lobbyManager = LobbyManager(serverScope)
+            val router = MainServerRouter(lobbyManager, DefaultNetworkToLobbyEventMapper())
+            val playersByConnection = ConcurrentHashMap<ConnectionId, PlayerId>()
+            val connectionsByPlayer = ConcurrentHashMap<PlayerId, ConnectionId>()
+            val routingService =
+                MainServerLobbyRoutingService(
+                    network = network,
+                    router = router,
+                    lobbyManager = lobbyManager,
+                    playerIdResolver = { playersByConnection[it] },
+                    connectionIdResolver = { connectionsByPlayer[it] },
+                    hooks = MainServerLobbyRoutingServiceHooks(),
+                )
+
+            val initialState =
+                GameState.initial(
+                    lobbyCode = lobbyCode,
+                    mapDefinition = mapDefinition,
+                    players = players,
+                    playerDisplayNames = players.associateWith { "Player ${it.value}" },
+                ).copy(
+                    lobbyOwner = playerOne,
+                    activePlayer = null,
+                    turnOrder = players,
+                    turnState = null,
+                    status = GameStatus.WAITING_FOR_PLAYERS,
+                )
+
+            application { module(network) }
+            lobbyManager.createLobby(lobbyCode = lobbyCode, initialState = initialState)
+            routingService.start(serverScope)
+
+            val client = createClient { install(WebSockets) }
+
+            try {
+                coroutineScope {
+                    val (session, _) =
+                        connectSession(
+                            client,
+                            network,
+                            playerOne,
+                            playersByConnection,
+                            connectionsByPlayer,
+                        )
+
+                    session.send(
+                        Frame.Binary(
+                            fin = true,
+                            data = MessageCodec.encode(StartGameRequest(lobbyCode)),
+                        ),
+                    )
+
+                    // Consume the 3 non-delta messages (deltas are skipped by skipGameSync=true):
+                    // StartGameResponse, GameStartedEvent, TurnStateUpdatedEvent
+                    receiveRelevantTestPayload(session, skipGameSync = true)
+                    receiveRelevantTestPayload(session, skipGameSync = true)
+                    receiveRelevantTestPayload(session, skipGameSync = true)
+
+                    // The grant is submitted before TurnStateUpdatedEvent, so by the time we
+                    // receive TurnStateUpdatedEvent the pending amount is already applied.
+                    val finalState =
+                        lobbyManager.getLobby(lobbyCode)?.currentState() ?: error("state missing")
+                    val activePlayer =
+                        finalState.activePlayer ?: error("no active player after start")
+                    assertTrue(
+                        finalState.pendingReinforcementsFor(activePlayer) >= 3,
+                        "Expected base reinforcements >= 3 for active player after game start",
+                    )
+
+                    session.close()
+                }
+            } finally {
+                routingService.stop()
+                lobbyManager.shutdownAll()
+                serverScope.cancel()
+            }
+        }
+
+    @Test
+    fun `REINFORCEMENTS to ATTACK advance does not trigger a grant`() =
+        testApplication {
+            val lobbyCode = LobbyCode("PO03")
+            val playerOne = PlayerId(1)
+            val playerTwo = PlayerId(2)
+
+            val network = ServerNetwork()
+            val serverScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            val lobbyManager = LobbyManager(serverScope)
+            val router = MainServerRouter(lobbyManager, DefaultNetworkToLobbyEventMapper())
+            val playersByConnection = ConcurrentHashMap<ConnectionId, PlayerId>()
+            val connectionsByPlayer = ConcurrentHashMap<PlayerId, ConnectionId>()
+            val routingService =
+                MainServerLobbyRoutingService(
+                    network = network,
+                    router = router,
+                    lobbyManager = lobbyManager,
+                    playerIdResolver = { playersByConnection[it] },
+                    connectionIdResolver = { connectionsByPlayer[it] },
+                    hooks = MainServerLobbyRoutingServiceHooks(),
+                )
+
+            lobbyManager.createLobby(
+                lobbyCode = lobbyCode,
+                initialState =
+                    runningGameState(
+                        lobbyCode = lobbyCode,
+                        players = listOf(playerOne, playerTwo),
+                        activePlayerId = playerOne,
+                        turnPhase = TurnPhase.REINFORCEMENTS,
+                    ),
+            )
+
+            application { module(network) }
+            routingService.start(serverScope)
+
+            val client = createClient { install(WebSockets) }
+
+            try {
+                coroutineScope {
+                    val (session, _) =
+                        connectSession(
+                            client,
+                            network,
+                            playerOne,
+                            playersByConnection,
+                            connectionsByPlayer,
+                        )
+
+                    session.send(
+                        Frame.Binary(
+                            fin = true,
+                            data =
+                                MessageCodec.encode(
+                                    TurnAdvanceRequest(
+                                        lobbyCode,
+                                        playerOne,
+                                        TurnPhase.REINFORCEMENTS,
+                                    ),
+                                ),
+                        ),
+                    )
+
+                    // Wait for TurnAdvanceResponse (skips the delta); server is done by then.
+                    receiveRelevantTestPayload(session, skipGameSync = true)
+
+                    // Advancing from REINFORCEMENTS → ATTACK must not grant any pending troops.
+                    val state =
+                        lobbyManager.getLobby(lobbyCode)?.currentState() ?: error("state missing")
+                    assertEquals(0, state.pendingReinforcementsFor(playerOne))
+
+                    session.close()
+                }
+            } finally {
+                routingService.stop()
+                lobbyManager.shutdownAll()
+                serverScope.cancel()
+            }
+        }
+
+    private fun runningGameState(
+        lobbyCode: LobbyCode,
+        players: List<PlayerId>,
+        activePlayerId: PlayerId,
+        turnPhase: TurnPhase,
+    ): GameState =
+        GameState.initial(
+            lobbyCode = lobbyCode,
+            mapDefinition = mapDefinition,
+            players = players,
+            playerDisplayNames = players.associateWith { "Player ${it.value}" },
+        ).copy(
+            lobbyOwner = players.firstOrNull(),
+            activePlayer = activePlayerId,
+            turnOrder = players,
+            turnNumber = 1,
+            turnState =
+                TurnState(
+                    activePlayerId = activePlayerId,
+                    turnPhase = turnPhase,
+                    turnCount = 1,
+                    startPlayerId = players.first(),
+                ),
+            status = GameStatus.RUNNING,
+        )
+
+    private suspend fun connectSession(
+        client: io.ktor.client.HttpClient,
+        network: ServerNetwork,
+        playerId: PlayerId,
+        playersByConnection: ConcurrentHashMap<ConnectionId, PlayerId>,
+        connectionsByPlayer: ConcurrentHashMap<PlayerId, ConnectionId>,
+    ) = coroutineScope {
+        val session = client.webSocketSession("/ws")
+        val sessionToken = receiveTestConnectionToken(session)
+        val connectionId = awaitTestConnectionId(network, sessionToken)
+        playersByConnection[connectionId] = playerId
+        connectionsByPlayer[playerId] = connectionId
+        session to connectionId
+    }
+
+    private suspend fun receiveAnyPayload(
+        session: io.ktor.client.plugins.websocket.DefaultClientWebSocketSession,
+    ) = receiveRelevantTestPayload(session)
+
+    private suspend fun receiveAnyPayloadOrNull(
+        session: io.ktor.client.plugins.websocket.DefaultClientWebSocketSession,
+    ) = receiveRelevantTestPayloadOrNull(
+        session = session,
+        skipGameSync = false,
+        timeoutMillis = 300,
+    )
+}

--- a/server/src/test/kotlin/at/aau/pulverfass/server/PlaceReinforcementsIntegrationTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/PlaceReinforcementsIntegrationTest.kt
@@ -272,7 +272,10 @@ class PlaceReinforcementsIntegrationTest {
 
             assertEquals(PlaceReinforcementsErrorCode.TERRITORY_NOT_OWNED, error.code)
             assertEquals(baseState.stateVersion, snapshot.stateVersion)
-            assertEquals(baseState.pendingReinforcementsFor(playerOne), snapshot.pendingReinforcementsFor(playerOne))
+            assertEquals(
+                baseState.pendingReinforcementsFor(playerOne),
+                snapshot.pendingReinforcementsFor(playerOne),
+            )
         }
 
     @Test
@@ -382,6 +385,86 @@ class PlaceReinforcementsIntegrationTest {
             assertEquals(PlaceReinforcementsErrorCode.OVERSPEND, error.code)
             assertEquals(2, snapshot.pendingReinforcementsFor(playerOne))
             assertEquals(1, snapshot.troopCountOf(territoryA))
+        }
+
+    @Test
+    fun `invalid request is rejected when placement sum overflows int`() =
+        testApplication {
+            val lobbyCode = LobbyCode("PRI6")
+            val playerOne = PlayerId(1)
+            val playerTwo = PlayerId(2)
+            val territoryA = defaultMapDefinition().territories[0].territoryId
+            val territoryB = defaultMapDefinition().territories[1].territoryId
+            val baseState =
+                reinforcementGame(
+                    lobbyCode = lobbyCode,
+                    players = listOf(playerOne, playerTwo),
+                    activePlayerId = playerOne,
+                    turnPhase = TurnPhase.REINFORCEMENTS,
+                    pendingPlayerId = playerOne,
+                    pendingAmount = Int.MAX_VALUE,
+                    owners = mapOf(territoryA to playerOne, territoryB to playerOne),
+                    troopCounts = mapOf(territoryA to 0, territoryB to 0),
+                )
+
+            val (error, snapshot) =
+                exerciseFailingPlacement(
+                    lobbyCode = lobbyCode,
+                    state = baseState,
+                    requesterPlayerId = playerOne,
+                    request =
+                        PlaceReinforcementsRequest(
+                            lobbyCode = lobbyCode,
+                            playerId = playerOne,
+                            placements =
+                                listOf(
+                                    TerritoryPlacement(territoryA, Int.MAX_VALUE),
+                                    TerritoryPlacement(territoryB, 1),
+                                ),
+                        ),
+                )
+
+            assertEquals(PlaceReinforcementsErrorCode.INVALID_PLACEMENT, error.code)
+            assertEquals(Int.MAX_VALUE, snapshot.pendingReinforcementsFor(playerOne))
+            assertEquals(0, snapshot.troopCountOf(territoryA))
+            assertEquals(0, snapshot.troopCountOf(territoryB))
+        }
+
+    @Test
+    fun `invalid request is rejected when troop count would overflow int`() =
+        testApplication {
+            val lobbyCode = LobbyCode("PRI7")
+            val playerOne = PlayerId(1)
+            val playerTwo = PlayerId(2)
+            val territoryA = defaultMapDefinition().territories[0].territoryId
+            val baseState =
+                reinforcementGame(
+                    lobbyCode = lobbyCode,
+                    players = listOf(playerOne, playerTwo),
+                    activePlayerId = playerOne,
+                    turnPhase = TurnPhase.REINFORCEMENTS,
+                    pendingPlayerId = playerOne,
+                    pendingAmount = 1,
+                    owners = mapOf(territoryA to playerOne),
+                    troopCounts = mapOf(territoryA to Int.MAX_VALUE),
+                )
+
+            val (error, snapshot) =
+                exerciseFailingPlacement(
+                    lobbyCode = lobbyCode,
+                    state = baseState,
+                    requesterPlayerId = playerOne,
+                    request =
+                        PlaceReinforcementsRequest(
+                            lobbyCode = lobbyCode,
+                            playerId = playerOne,
+                            placements = listOf(TerritoryPlacement(territoryA, 1)),
+                        ),
+                )
+
+            assertEquals(PlaceReinforcementsErrorCode.INVALID_PLACEMENT, error.code)
+            assertEquals(1, snapshot.pendingReinforcementsFor(playerOne))
+            assertEquals(Int.MAX_VALUE, snapshot.troopCountOf(territoryA))
         }
 
     private suspend fun ApplicationTestBuilder.exerciseFailingPlacement(

--- a/server/src/test/kotlin/at/aau/pulverfass/server/PlaceReinforcementsIntegrationTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/PlaceReinforcementsIntegrationTest.kt
@@ -1,0 +1,534 @@
+package at.aau.pulverfass.server
+
+import at.aau.pulverfass.server.lobby.mapping.DefaultNetworkToLobbyEventMapper
+import at.aau.pulverfass.server.lobby.runtime.LobbyManager
+import at.aau.pulverfass.server.routing.MainServerLobbyRoutingService
+import at.aau.pulverfass.server.routing.MainServerLobbyRoutingServiceHooks
+import at.aau.pulverfass.server.routing.MainServerRouter
+import at.aau.pulverfass.shared.ids.ConnectionId
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.ids.TerritoryId
+import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsChangedEvent
+import at.aau.pulverfass.shared.lobby.event.TerritoryTroopsChangedEvent
+import at.aau.pulverfass.shared.lobby.state.GameState
+import at.aau.pulverfass.shared.lobby.state.GameStatus
+import at.aau.pulverfass.shared.lobby.state.PendingReinforcements
+import at.aau.pulverfass.shared.lobby.state.TerritoryState
+import at.aau.pulverfass.shared.lobby.state.TurnPhase
+import at.aau.pulverfass.shared.lobby.state.TurnState
+import at.aau.pulverfass.shared.message.lobby.event.GameStateDeltaEvent
+import at.aau.pulverfass.shared.message.lobby.request.PlaceReinforcementsRequest
+import at.aau.pulverfass.shared.message.lobby.request.TerritoryPlacement
+import at.aau.pulverfass.shared.message.lobby.response.PlaceReinforcementsResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.PlaceReinforcementsErrorCode
+import at.aau.pulverfass.shared.message.lobby.response.error.PlaceReinforcementsErrorResponse
+import at.aau.pulverfass.shared.network.codec.MessageCodec
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.client.plugins.websocket.webSocketSession
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import io.ktor.websocket.Frame
+import io.ktor.websocket.close
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import java.util.concurrent.ConcurrentHashMap
+
+class PlaceReinforcementsIntegrationTest {
+    @Test
+    fun `valid batch placement updates troops and pending deterministically`() =
+        testApplication {
+            val network = ServerNetwork()
+            val serverScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            val lobbyManager = LobbyManager(serverScope)
+            val router =
+                MainServerRouter(
+                    lobbyManager = lobbyManager,
+                    mapper = DefaultNetworkToLobbyEventMapper(),
+                )
+            val playersByConnection = ConcurrentHashMap<ConnectionId, PlayerId>()
+            val connectionsByPlayer = ConcurrentHashMap<PlayerId, ConnectionId>()
+            val routingService =
+                MainServerLobbyRoutingService(
+                    network = network,
+                    router = router,
+                    lobbyManager = lobbyManager,
+                    playerIdResolver = { connectionId -> playersByConnection[connectionId] },
+                    connectionIdResolver = { playerId -> connectionsByPlayer[playerId] },
+                    hooks = MainServerLobbyRoutingServiceHooks(),
+                )
+
+            application {
+                module(network)
+            }
+
+            val lobbyCode = LobbyCode("PRI1")
+            val playerOne = PlayerId(1)
+            val playerTwo = PlayerId(2)
+            val territoryA = defaultMapDefinition().territories[0].territoryId
+            val territoryB = defaultMapDefinition().territories[1].territoryId
+            val territoryC = defaultMapDefinition().territories[2].territoryId
+
+            lobbyManager.createLobby(
+                lobbyCode = lobbyCode,
+                initialState =
+                    reinforcementGame(
+                        lobbyCode = lobbyCode,
+                        players = listOf(playerOne, playerTwo),
+                        activePlayerId = playerOne,
+                        turnPhase = TurnPhase.REINFORCEMENTS,
+                        pendingPlayerId = playerOne,
+                        pendingAmount = 5,
+                        owners =
+                            mapOf(
+                                territoryA to playerOne,
+                                territoryB to playerOne,
+                                territoryC to playerTwo,
+                            ),
+                        troopCounts =
+                            mapOf(
+                                territoryA to 1,
+                                territoryB to 2,
+                                territoryC to 4,
+                            ),
+                    ),
+            )
+            routingService.start(serverScope)
+
+            val client =
+                createClient {
+                    install(WebSockets)
+                }
+
+            try {
+                coroutineScope {
+                    val actorSession =
+                        connectSessionWithConnection(
+                            client = client,
+                            network = network,
+                            playerId = playerOne,
+                            playersByConnection = playersByConnection,
+                            connectionsByPlayer = connectionsByPlayer,
+                        )
+                    val watcherSession =
+                        connectSessionWithConnection(
+                            client = client,
+                            network = network,
+                            playerId = playerTwo,
+                            playersByConnection = playersByConnection,
+                            connectionsByPlayer = connectionsByPlayer,
+                        )
+
+                    actorSession.first.send(
+                        Frame.Binary(
+                            fin = true,
+                            data =
+                                MessageCodec.encode(
+                                    PlaceReinforcementsRequest(
+                                        lobbyCode = lobbyCode,
+                                        playerId = playerOne,
+                                        placements =
+                                            listOf(
+                                                TerritoryPlacement(territoryA, 2),
+                                                TerritoryPlacement(territoryB, 2),
+                                            ),
+                                    ),
+                                ),
+                        ),
+                    )
+
+                    val actorTroopDeltaOne =
+                        GameStateDeltaEvent(
+                            lobbyCode = lobbyCode,
+                            fromVersion = 1,
+                            toVersion = 1,
+                            events =
+                                listOf(
+                                    TerritoryTroopsChangedEvent(
+                                        lobbyCode = lobbyCode,
+                                        territoryId = territoryA,
+                                        troopCount = 3,
+                                        stateVersion = 1,
+                                    ),
+                                ),
+                        )
+                    val actorTroopEventOne =
+                        TerritoryTroopsChangedEvent(
+                            lobbyCode = lobbyCode,
+                            territoryId = territoryA,
+                            troopCount = 3,
+                            stateVersion = 1,
+                        )
+                    val actorTroopDeltaTwo =
+                        GameStateDeltaEvent(
+                            lobbyCode = lobbyCode,
+                            fromVersion = 2,
+                            toVersion = 2,
+                            events =
+                                listOf(
+                                    TerritoryTroopsChangedEvent(
+                                        lobbyCode = lobbyCode,
+                                        territoryId = territoryB,
+                                        troopCount = 4,
+                                        stateVersion = 2,
+                                    ),
+                                ),
+                        )
+                    val actorTroopEventTwo =
+                        TerritoryTroopsChangedEvent(
+                            lobbyCode = lobbyCode,
+                            territoryId = territoryB,
+                            troopCount = 4,
+                            stateVersion = 2,
+                        )
+                    val pendingDelta =
+                        GameStateDeltaEvent(
+                            lobbyCode = lobbyCode,
+                            fromVersion = 3,
+                            toVersion = 3,
+                            events =
+                                listOf(
+                                    PendingReinforcementsChangedEvent(
+                                        lobbyCode = lobbyCode,
+                                        playerId = playerOne,
+                                        delta = -4,
+                                    ),
+                                ),
+                        )
+
+                    assertEquals(actorTroopDeltaOne, receiveAnyPayload(actorSession.first))
+                    assertEquals(actorTroopEventOne, receiveAnyPayload(actorSession.first))
+                    assertEquals(actorTroopDeltaTwo, receiveAnyPayload(actorSession.first))
+                    assertEquals(actorTroopEventTwo, receiveAnyPayload(actorSession.first))
+                    assertEquals(pendingDelta, receiveAnyPayload(actorSession.first))
+                    assertEquals(
+                        PlaceReinforcementsResponse(lobbyCode),
+                        receiveAnyPayload(actorSession.first),
+                    )
+
+                    assertEquals(actorTroopDeltaOne, receiveAnyPayload(watcherSession.first))
+                    assertEquals(actorTroopEventOne, receiveAnyPayload(watcherSession.first))
+                    assertEquals(actorTroopDeltaTwo, receiveAnyPayload(watcherSession.first))
+                    assertEquals(actorTroopEventTwo, receiveAnyPayload(watcherSession.first))
+                    assertEquals(pendingDelta, receiveAnyPayload(watcherSession.first))
+
+                    val updatedState =
+                        lobbyManager.getLobby(lobbyCode)?.currentState()
+                            ?: error("state missing")
+                    assertEquals(1, updatedState.pendingReinforcementsFor(playerOne))
+                    assertEquals(3, updatedState.troopCountOf(territoryA))
+                    assertEquals(4, updatedState.troopCountOf(territoryB))
+                    assertNull(receiveRelevantTestPayloadOrNull(actorSession.first))
+                    assertNull(receiveRelevantTestPayloadOrNull(watcherSession.first))
+
+                    actorSession.first.close()
+                    watcherSession.first.close()
+                }
+            } finally {
+                routingService.stop()
+                lobbyManager.shutdownAll()
+                serverScope.cancel()
+            }
+        }
+
+    @Test
+    fun `invalid request is rejected when requester does not own all territories`() =
+        testApplication {
+            val lobbyCode = LobbyCode("PRI2")
+            val playerOne = PlayerId(1)
+            val playerTwo = PlayerId(2)
+            val territoryA = defaultMapDefinition().territories[0].territoryId
+            val territoryC = defaultMapDefinition().territories[2].territoryId
+            val baseState =
+                reinforcementGame(
+                    lobbyCode = lobbyCode,
+                    players = listOf(playerOne, playerTwo),
+                    activePlayerId = playerOne,
+                    turnPhase = TurnPhase.REINFORCEMENTS,
+                    pendingPlayerId = playerOne,
+                    pendingAmount = 5,
+                    owners = mapOf(territoryA to playerOne, territoryC to playerTwo),
+                    troopCounts = mapOf(territoryA to 1, territoryC to 4),
+                )
+
+            val (error, snapshot) =
+                exerciseFailingPlacement(
+                    lobbyCode = lobbyCode,
+                    state = baseState,
+                    requesterPlayerId = playerOne,
+                    request =
+                        PlaceReinforcementsRequest(
+                            lobbyCode = lobbyCode,
+                            playerId = playerOne,
+                            placements = listOf(TerritoryPlacement(territoryC, 1)),
+                        ),
+                )
+
+            assertEquals(PlaceReinforcementsErrorCode.TERRITORY_NOT_OWNED, error.code)
+            assertEquals(baseState.stateVersion, snapshot.stateVersion)
+            assertEquals(baseState.pendingReinforcementsFor(playerOne), snapshot.pendingReinforcementsFor(playerOne))
+        }
+
+    @Test
+    fun `invalid request is rejected when requester is not active player`() =
+        testApplication {
+            val lobbyCode = LobbyCode("PRI3")
+            val playerOne = PlayerId(1)
+            val playerTwo = PlayerId(2)
+            val territoryA = defaultMapDefinition().territories[0].territoryId
+            val baseState =
+                reinforcementGame(
+                    lobbyCode = lobbyCode,
+                    players = listOf(playerOne, playerTwo),
+                    activePlayerId = playerTwo,
+                    turnPhase = TurnPhase.REINFORCEMENTS,
+                    pendingPlayerId = playerTwo,
+                    pendingAmount = 5,
+                    owners = mapOf(territoryA to playerOne),
+                    troopCounts = mapOf(territoryA to 1),
+                )
+
+            val (error, snapshot) =
+                exerciseFailingPlacement(
+                    lobbyCode = lobbyCode,
+                    state = baseState,
+                    requesterPlayerId = playerOne,
+                    request =
+                        PlaceReinforcementsRequest(
+                            lobbyCode = lobbyCode,
+                            playerId = playerOne,
+                            placements = listOf(TerritoryPlacement(territoryA, 1)),
+                        ),
+                )
+
+            assertEquals(PlaceReinforcementsErrorCode.NOT_ACTIVE_PLAYER, error.code)
+            assertEquals(baseState.stateVersion, snapshot.stateVersion)
+        }
+
+    @Test
+    fun `invalid request is rejected when phase is not reinforcements`() =
+        testApplication {
+            val lobbyCode = LobbyCode("PRI4")
+            val playerOne = PlayerId(1)
+            val playerTwo = PlayerId(2)
+            val territoryA = defaultMapDefinition().territories[0].territoryId
+            val baseState =
+                reinforcementGame(
+                    lobbyCode = lobbyCode,
+                    players = listOf(playerOne, playerTwo),
+                    activePlayerId = playerOne,
+                    turnPhase = TurnPhase.ATTACK,
+                    pendingPlayerId = playerOne,
+                    pendingAmount = 5,
+                    owners = mapOf(territoryA to playerOne),
+                    troopCounts = mapOf(territoryA to 1),
+                )
+
+            val (error, snapshot) =
+                exerciseFailingPlacement(
+                    lobbyCode = lobbyCode,
+                    state = baseState,
+                    requesterPlayerId = playerOne,
+                    request =
+                        PlaceReinforcementsRequest(
+                            lobbyCode = lobbyCode,
+                            playerId = playerOne,
+                            placements = listOf(TerritoryPlacement(territoryA, 1)),
+                        ),
+                )
+
+            assertEquals(PlaceReinforcementsErrorCode.PHASE_MISMATCH, error.code)
+            assertEquals(baseState.stateVersion, snapshot.stateVersion)
+        }
+
+    @Test
+    fun `invalid request is rejected when placements overspend pending pool`() =
+        testApplication {
+            val lobbyCode = LobbyCode("PRI5")
+            val playerOne = PlayerId(1)
+            val playerTwo = PlayerId(2)
+            val territoryA = defaultMapDefinition().territories[0].territoryId
+            val baseState =
+                reinforcementGame(
+                    lobbyCode = lobbyCode,
+                    players = listOf(playerOne, playerTwo),
+                    activePlayerId = playerOne,
+                    turnPhase = TurnPhase.REINFORCEMENTS,
+                    pendingPlayerId = playerOne,
+                    pendingAmount = 2,
+                    owners = mapOf(territoryA to playerOne),
+                    troopCounts = mapOf(territoryA to 1),
+                )
+
+            val (error, snapshot) =
+                exerciseFailingPlacement(
+                    lobbyCode = lobbyCode,
+                    state = baseState,
+                    requesterPlayerId = playerOne,
+                    request =
+                        PlaceReinforcementsRequest(
+                            lobbyCode = lobbyCode,
+                            playerId = playerOne,
+                            placements = listOf(TerritoryPlacement(territoryA, 3)),
+                        ),
+                )
+
+            assertEquals(PlaceReinforcementsErrorCode.OVERSPEND, error.code)
+            assertEquals(2, snapshot.pendingReinforcementsFor(playerOne))
+            assertEquals(1, snapshot.troopCountOf(territoryA))
+        }
+
+    private suspend fun ApplicationTestBuilder.exerciseFailingPlacement(
+        lobbyCode: LobbyCode,
+        state: GameState,
+        requesterPlayerId: PlayerId,
+        request: PlaceReinforcementsRequest,
+    ): Pair<PlaceReinforcementsErrorResponse, GameState> {
+        val network = ServerNetwork()
+        val serverScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val lobbyManager = LobbyManager(serverScope)
+        val router =
+            MainServerRouter(
+                lobbyManager = lobbyManager,
+                mapper = DefaultNetworkToLobbyEventMapper(),
+            )
+        val playersByConnection = ConcurrentHashMap<ConnectionId, PlayerId>()
+        val connectionsByPlayer = ConcurrentHashMap<PlayerId, ConnectionId>()
+        val routingService =
+            MainServerLobbyRoutingService(
+                network = network,
+                router = router,
+                lobbyManager = lobbyManager,
+                playerIdResolver = { connectionId -> playersByConnection[connectionId] },
+                connectionIdResolver = { playerId -> connectionsByPlayer[playerId] },
+                hooks = MainServerLobbyRoutingServiceHooks(),
+            )
+
+        application {
+            module(network)
+        }
+        lobbyManager.createLobby(lobbyCode = lobbyCode, initialState = state)
+        routingService.start(serverScope)
+
+        val client =
+            createClient {
+                install(WebSockets)
+            }
+
+        return try {
+            coroutineScope {
+                val requesterSession =
+                    connectSessionWithConnection(
+                        client = client,
+                        network = network,
+                        playerId = requesterPlayerId,
+                        playersByConnection = playersByConnection,
+                        connectionsByPlayer = connectionsByPlayer,
+                    )
+
+                requesterSession.first.send(
+                    Frame.Binary(
+                        fin = true,
+                        data = MessageCodec.encode(request),
+                    ),
+                )
+
+                val error =
+                    assertIs<PlaceReinforcementsErrorResponse>(
+                        receiveRelevantTestPayload(requesterSession.first),
+                    )
+                assertNull(receiveRelevantTestPayloadOrNull(requesterSession.first))
+
+                val snapshot =
+                    lobbyManager.getLobby(lobbyCode)?.currentState()
+                        ?: error("snapshot missing")
+                requesterSession.first.close()
+                error to snapshot
+            }
+        } finally {
+            routingService.stop()
+            lobbyManager.shutdownAll()
+            serverScope.cancel()
+        }
+    }
+
+    private fun reinforcementGame(
+        lobbyCode: LobbyCode,
+        players: List<PlayerId>,
+        activePlayerId: PlayerId,
+        turnPhase: TurnPhase,
+        pendingPlayerId: PlayerId,
+        pendingAmount: Int,
+        owners: Map<TerritoryId, PlayerId>,
+        troopCounts: Map<TerritoryId, Int>,
+    ): GameState {
+        val baseState =
+            GameState.initial(
+                lobbyCode = lobbyCode,
+                mapDefinition = defaultMapDefinition(),
+                players = players,
+                playerDisplayNames = players.associateWith { "Player ${it.value}" },
+            )
+
+        return baseState.copy(
+            lobbyOwner = players.firstOrNull(),
+            activePlayer = activePlayerId,
+            turnOrder = players,
+            turnNumber = 1,
+            turnState =
+                TurnState(
+                    activePlayerId = activePlayerId,
+                    turnPhase = turnPhase,
+                    turnCount = 1,
+                    startPlayerId = players.first(),
+                ),
+            status = GameStatus.RUNNING,
+            territoryStates =
+                baseState.allTerritoryStates().associate { territoryState ->
+                    val territoryId = territoryState.territoryId
+                    territoryId to
+                        TerritoryState(
+                            territoryId = territoryId,
+                            ownerId = owners[territoryId],
+                            troopCount = troopCounts[territoryId] ?: 0,
+                        )
+                },
+            pendingReinforcements = PendingReinforcements(pendingPlayerId, pendingAmount),
+        )
+    }
+
+    private suspend fun connectSessionWithConnection(
+        client: io.ktor.client.HttpClient,
+        network: ServerNetwork,
+        playerId: PlayerId,
+        playersByConnection: ConcurrentHashMap<ConnectionId, PlayerId>,
+        connectionsByPlayer: ConcurrentHashMap<PlayerId, ConnectionId>,
+    ) = coroutineScope {
+        val session = client.webSocketSession("/ws")
+        val sessionToken = receiveTestConnectionToken(session)
+        val connectionId = awaitTestConnectionId(network, sessionToken)
+        playersByConnection[connectionId] = playerId
+        connectionsByPlayer[playerId] = connectionId
+        session to connectionId
+    }
+
+    private suspend fun receiveAnyPayload(
+        session: io.ktor.client.plugins.websocket.DefaultClientWebSocketSession,
+    ): Any = receiveRelevantTestPayload(session)
+
+    private inline fun <reified T> assertIs(value: Any?): T {
+        require(value is T) {
+            "Expected ${T::class.simpleName}, but was ${value?.let { it::class.simpleName }}."
+        }
+        return value
+    }
+
+    private fun defaultMapDefinition() =
+        at.aau.pulverfass.shared.map.config.MapConfigLoader.loadDefault()
+}

--- a/server/src/test/kotlin/at/aau/pulverfass/server/RoundHistoryIntegrationTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/RoundHistoryIntegrationTest.kt
@@ -139,12 +139,13 @@ class RoundHistoryIntegrationTest {
                                 listOf(
                                     ReinforcementsGrantedEvent(
                                         lobbyCode = lobbyCode,
-                                        playerId = lobbyManager
-                                            .getLobby(lobbyCode)
-                                            ?.currentState()
-                                            ?.turnState
-                                            ?.activePlayerId
-                                            ?: error("active player missing"),
+                                        playerId =
+                                            lobbyManager
+                                                .getLobby(lobbyCode)
+                                                ?.currentState()
+                                                ?.turnState
+                                                ?.activePlayerId
+                                                ?: error("active player missing"),
                                         amount = 3,
                                         territoryBonus = 3,
                                         continentBonus = 0,
@@ -172,12 +173,13 @@ class RoundHistoryIntegrationTest {
                                 listOf(
                                     ReinforcementsGrantedEvent(
                                         lobbyCode = lobbyCode,
-                                        playerId = lobbyManager
-                                            .getLobby(lobbyCode)
-                                            ?.currentState()
-                                            ?.turnState
-                                            ?.activePlayerId
-                                            ?: error("active player missing"),
+                                        playerId =
+                                            lobbyManager
+                                                .getLobby(lobbyCode)
+                                                ?.currentState()
+                                                ?.turnState
+                                                ?.activePlayerId
+                                                ?: error("active player missing"),
                                         amount = 3,
                                         territoryBonus = 3,
                                         continentBonus = 0,

--- a/server/src/test/kotlin/at/aau/pulverfass/server/RoundHistoryIntegrationTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/RoundHistoryIntegrationTest.kt
@@ -15,6 +15,7 @@ import at.aau.pulverfass.shared.lobby.state.TurnState
 import at.aau.pulverfass.shared.message.lobby.event.GameStateDeltaEvent
 import at.aau.pulverfass.shared.message.lobby.event.GameStateSnapshotBroadcast
 import at.aau.pulverfass.shared.message.lobby.event.PhaseBoundaryEvent
+import at.aau.pulverfass.shared.message.lobby.event.ReinforcementsGrantedEvent
 import at.aau.pulverfass.shared.message.lobby.request.TurnAdvanceRequest
 import at.aau.pulverfass.shared.message.lobby.response.TurnAdvanceResponse
 import at.aau.pulverfass.shared.network.codec.MessageCodec
@@ -132,6 +133,27 @@ class RoundHistoryIntegrationTest {
                         )
 
                         assertTrue(receivePayload(actor) is GameStateDeltaEvent)
+                        if (turnChange) {
+                            val grantedDelta = receivePayload(actor) as GameStateDeltaEvent
+                            assertEquals(
+                                listOf(
+                                    ReinforcementsGrantedEvent(
+                                        lobbyCode = lobbyCode,
+                                        playerId = lobbyManager
+                                            .getLobby(lobbyCode)
+                                            ?.currentState()
+                                            ?.turnState
+                                            ?.activePlayerId
+                                            ?: error("active player missing"),
+                                        amount = 3,
+                                        territoryBonus = 3,
+                                        continentBonus = 0,
+                                        cardBonus = 0,
+                                    ),
+                                ),
+                                grantedDelta.events,
+                            )
+                        }
                         assertEquals(TurnAdvanceResponse(lobbyCode), receivePayload(actor))
                         assertTrue(receivePayload(actor) is PhaseBoundaryEvent)
                         assertTrue(
@@ -144,6 +166,27 @@ class RoundHistoryIntegrationTest {
                         }
 
                         assertTrue(receivePayload(watcher) is GameStateDeltaEvent)
+                        if (turnChange) {
+                            val grantedDelta = receivePayload(watcher) as GameStateDeltaEvent
+                            assertEquals(
+                                listOf(
+                                    ReinforcementsGrantedEvent(
+                                        lobbyCode = lobbyCode,
+                                        playerId = lobbyManager
+                                            .getLobby(lobbyCode)
+                                            ?.currentState()
+                                            ?.turnState
+                                            ?.activePlayerId
+                                            ?: error("active player missing"),
+                                        amount = 3,
+                                        territoryBonus = 3,
+                                        continentBonus = 0,
+                                        cardBonus = 0,
+                                    ),
+                                ),
+                                grantedDelta.events,
+                            )
+                        }
                         assertTrue(receivePayload(watcher) is PhaseBoundaryEvent)
                         assertTrue(
                             receivePayload(

--- a/server/src/test/kotlin/at/aau/pulverfass/server/TradeInCardsIntegrationTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/TradeInCardsIntegrationTest.kt
@@ -254,6 +254,91 @@ class TradeInCardsIntegrationTest {
         }
 
     @Test
+    fun `invalid trade rejected when requester is not active player`() =
+        testApplication {
+            val playerOne = PlayerId(1)
+            val playerTwo = PlayerId(2)
+            val cardA = CardState(CardId("card-a"), CardType.A)
+            val cardB = CardState(CardId("card-b"), CardType.B)
+            val cardJ = CardState(CardId("card-j"), CardType.JOKER)
+            val state =
+                reinforcementTradeGame(
+                    lobbyCode = LobbyCode("TRNP"),
+                    players = listOf(playerOne, playerTwo),
+                    activePlayerId = playerTwo,
+                    pendingPlayerId = playerTwo,
+                    pendingAmount = 3,
+                    handState =
+                        HandState(
+                            cardsByPlayer =
+                                mapOf(
+                                    playerOne to listOf(cardA, cardB, cardJ),
+                                ),
+                        ),
+                )
+
+            val (error, snapshot) =
+                exerciseFailingTrade(
+                    lobbyCode = LobbyCode("TRNP"),
+                    state = state,
+                    requesterPlayerId = playerOne,
+                    request =
+                        TradeInCardsRequest(
+                            lobbyCode = LobbyCode("TRNP"),
+                            playerId = playerOne,
+                            cardIds = listOf(cardA.cardId, cardB.cardId, cardJ.cardId),
+                        ),
+                )
+
+            assertEquals(TradeInCardsErrorCode.NOT_ACTIVE_PLAYER, error.code)
+            assertEquals(state.stateVersion, snapshot.stateVersion)
+            assertEquals(0, snapshot.tradedInSetCount)
+        }
+
+    @Test
+    fun `invalid trade rejected when phase is not REINFORCEMENTS`() =
+        testApplication {
+            val playerOne = PlayerId(1)
+            val playerTwo = PlayerId(2)
+            val cardA = CardState(CardId("card-a"), CardType.A)
+            val cardB = CardState(CardId("card-b"), CardType.B)
+            val cardJ = CardState(CardId("card-j"), CardType.JOKER)
+            val state =
+                reinforcementTradeGame(
+                    lobbyCode = LobbyCode("TRPM"),
+                    players = listOf(playerOne, playerTwo),
+                    activePlayerId = playerOne,
+                    pendingPlayerId = playerOne,
+                    pendingAmount = 0,
+                    handState =
+                        HandState(
+                            cardsByPlayer =
+                                mapOf(
+                                    playerOne to listOf(cardA, cardB, cardJ),
+                                ),
+                        ),
+                    turnPhase = TurnPhase.ATTACK,
+                )
+
+            val (error, snapshot) =
+                exerciseFailingTrade(
+                    lobbyCode = LobbyCode("TRPM"),
+                    state = state,
+                    requesterPlayerId = playerOne,
+                    request =
+                        TradeInCardsRequest(
+                            lobbyCode = LobbyCode("TRPM"),
+                            playerId = playerOne,
+                            cardIds = listOf(cardA.cardId, cardB.cardId, cardJ.cardId),
+                        ),
+                )
+
+            assertEquals(TradeInCardsErrorCode.PHASE_MISMATCH, error.code)
+            assertEquals(state.stateVersion, snapshot.stateVersion)
+            assertEquals(0, snapshot.tradedInSetCount)
+        }
+
+    @Test
     fun `security rejects trade when cards are not owned by requester`() =
         testApplication {
             val playerOne = PlayerId(1)
@@ -372,12 +457,13 @@ class TradeInCardsIntegrationTest {
         pendingPlayerId: PlayerId,
         pendingAmount: Int,
         handState: HandState,
+        turnPhase: TurnPhase = TurnPhase.REINFORCEMENTS,
     ): GameState {
         val mapDefinition = at.aau.pulverfass.shared.map.config.MapConfigLoader.loadDefault()
         val turnState =
             TurnState(
                 activePlayerId = activePlayerId,
-                turnPhase = TurnPhase.REINFORCEMENTS,
+                turnPhase = turnPhase,
                 turnCount = 1,
                 startPlayerId = players.first(),
             )

--- a/server/src/test/kotlin/at/aau/pulverfass/server/TradeInCardsIntegrationTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/TradeInCardsIntegrationTest.kt
@@ -1,0 +1,414 @@
+package at.aau.pulverfass.server
+
+import at.aau.pulverfass.server.lobby.mapping.DefaultNetworkToLobbyEventMapper
+import at.aau.pulverfass.server.lobby.runtime.LobbyManager
+import at.aau.pulverfass.server.routing.MainServerLobbyRoutingService
+import at.aau.pulverfass.server.routing.MainServerLobbyRoutingServiceHooks
+import at.aau.pulverfass.server.routing.MainServerRouter
+import at.aau.pulverfass.shared.ids.CardId
+import at.aau.pulverfass.shared.ids.ConnectionId
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsChangedEvent
+import at.aau.pulverfass.shared.lobby.state.CardState
+import at.aau.pulverfass.shared.lobby.state.CardType
+import at.aau.pulverfass.shared.lobby.state.GameState
+import at.aau.pulverfass.shared.lobby.state.HandState
+import at.aau.pulverfass.shared.lobby.state.PendingReinforcements
+import at.aau.pulverfass.shared.lobby.state.TurnPhase
+import at.aau.pulverfass.shared.lobby.state.TurnState
+import at.aau.pulverfass.shared.message.lobby.event.GameStateDeltaEvent
+import at.aau.pulverfass.shared.message.lobby.event.PlayerHandUpdatedEvent
+import at.aau.pulverfass.shared.message.lobby.event.PrivateHandCardSnapshot
+import at.aau.pulverfass.shared.message.lobby.event.ReinforcementsGrantedEvent
+import at.aau.pulverfass.shared.message.lobby.request.TradeInCardsRequest
+import at.aau.pulverfass.shared.message.lobby.response.TradeInCardsResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.TradeInCardsErrorCode
+import at.aau.pulverfass.shared.message.lobby.response.error.TradeInCardsErrorResponse
+import at.aau.pulverfass.shared.network.codec.MessageCodec
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.client.plugins.websocket.webSocketSession
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import io.ktor.websocket.Frame
+import io.ktor.websocket.close
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import java.util.concurrent.ConcurrentHashMap
+
+class TradeInCardsIntegrationTest {
+    @Test
+    fun `valid trade increases pending updates hand privately and grants public bonus`() =
+        testApplication {
+            val network = ServerNetwork()
+            val serverScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            val lobbyManager = LobbyManager(serverScope)
+            val router =
+                MainServerRouter(
+                    lobbyManager = lobbyManager,
+                    mapper = DefaultNetworkToLobbyEventMapper(),
+                )
+            val playersByConnection = ConcurrentHashMap<ConnectionId, PlayerId>()
+            val connectionsByPlayer = ConcurrentHashMap<PlayerId, ConnectionId>()
+            val routingService =
+                MainServerLobbyRoutingService(
+                    network = network,
+                    router = router,
+                    lobbyManager = lobbyManager,
+                    playerIdResolver = { connectionId -> playersByConnection[connectionId] },
+                    connectionIdResolver = { playerId -> connectionsByPlayer[playerId] },
+                    hooks = MainServerLobbyRoutingServiceHooks(),
+                )
+
+            application {
+                module(network)
+            }
+
+            val lobbyCode = LobbyCode("TRI1")
+            val playerOne = PlayerId(1)
+            val playerTwo = PlayerId(2)
+            val cardA = CardState(CardId("card-a"), CardType.A)
+            val cardB = CardState(CardId("card-b"), CardType.B)
+            val cardJ = CardState(CardId("card-j"), CardType.JOKER)
+            val remainingCard = CardState(CardId("card-c"), CardType.C)
+            lobbyManager.createLobby(
+                lobbyCode = lobbyCode,
+                initialState =
+                    reinforcementTradeGame(
+                        lobbyCode = lobbyCode,
+                        players = listOf(playerOne, playerTwo),
+                        activePlayerId = playerOne,
+                        pendingPlayerId = playerOne,
+                        pendingAmount = 3,
+                        handState =
+                            HandState(
+                                cardsByPlayer =
+                                    mapOf(
+                                        playerOne to listOf(cardA, cardB, cardJ, remainingCard),
+                                    ),
+                            ),
+                    ),
+            )
+            routingService.start(serverScope)
+
+            val client =
+                createClient {
+                    install(WebSockets)
+                }
+
+            try {
+                coroutineScope {
+                    val actorSession =
+                        connectSessionWithConnection(
+                            client = client,
+                            network = network,
+                            playerId = playerOne,
+                            playersByConnection = playersByConnection,
+                            connectionsByPlayer = connectionsByPlayer,
+                        )
+                    val watcherSession =
+                        connectSessionWithConnection(
+                            client = client,
+                            network = network,
+                            playerId = playerTwo,
+                            playersByConnection = playersByConnection,
+                            connectionsByPlayer = connectionsByPlayer,
+                        )
+
+                    actorSession.first.send(
+                        Frame.Binary(
+                            fin = true,
+                            data =
+                                MessageCodec.encode(
+                                    TradeInCardsRequest(
+                                        lobbyCode = lobbyCode,
+                                        playerId = playerOne,
+                                        cardIds = listOf(cardA.cardId, cardB.cardId, cardJ.cardId),
+                                    ),
+                                ),
+                        ),
+                    )
+
+                    val grantDelta =
+                        GameStateDeltaEvent(
+                            lobbyCode = lobbyCode,
+                            fromVersion = 1,
+                            toVersion = 1,
+                            events =
+                                listOf(
+                                    ReinforcementsGrantedEvent(
+                                        lobbyCode = lobbyCode,
+                                        playerId = playerOne,
+                                        amount = 2,
+                                        territoryBonus = 0,
+                                        continentBonus = 0,
+                                        cardBonus = 2,
+                                    ),
+                                ),
+                        )
+                    val pendingDelta =
+                        GameStateDeltaEvent(
+                            lobbyCode = lobbyCode,
+                            fromVersion = 2,
+                            toVersion = 2,
+                            events =
+                                listOf(
+                                    PendingReinforcementsChangedEvent(
+                                        lobbyCode = lobbyCode,
+                                        playerId = playerOne,
+                                        delta = 2,
+                                    ),
+                                ),
+                        )
+
+                    assertEquals(grantDelta, receiveRelevantTestPayload(actorSession.first))
+                    assertEquals(pendingDelta, receiveRelevantTestPayload(actorSession.first))
+                    assertEquals(
+                        TradeInCardsResponse(lobbyCode),
+                        receiveRelevantTestPayload(actorSession.first),
+                    )
+                    assertEquals(
+                        PlayerHandUpdatedEvent(
+                            lobbyCode = lobbyCode,
+                            recipientPlayerId = playerOne,
+                            stateVersion = 3,
+                            handCards =
+                                listOf(
+                                    PrivateHandCardSnapshot(
+                                        remainingCard.cardId,
+                                        remainingCard.type,
+                                    ),
+                                ),
+                        ),
+                        receiveRelevantTestPayload(actorSession.first),
+                    )
+
+                    assertEquals(grantDelta, receiveRelevantTestPayload(watcherSession.first))
+                    assertEquals(pendingDelta, receiveRelevantTestPayload(watcherSession.first))
+
+                    val updatedState =
+                        lobbyManager.getLobby(lobbyCode)?.currentState()
+                            ?: error("state missing")
+                    assertEquals(5, updatedState.pendingReinforcementsFor(playerOne))
+                    assertEquals(1, updatedState.tradedInSetCount)
+                    assertEquals(listOf(remainingCard), updatedState.handOf(playerOne))
+                    assertNull(receiveRelevantTestPayloadOrNull(actorSession.first))
+                    assertNull(receiveRelevantTestPayloadOrNull(watcherSession.first))
+
+                    actorSession.first.close()
+                    watcherSession.first.close()
+                }
+            } finally {
+                routingService.stop()
+                lobbyManager.shutdownAll()
+                serverScope.cancel()
+            }
+        }
+
+    @Test
+    fun `invalid trade is rejected when set is not valid`() =
+        testApplication {
+            val playerOne = PlayerId(1)
+            val invalidA = CardState(CardId("card-a"), CardType.A)
+            val invalidB = CardState(CardId("card-b"), CardType.A)
+            val invalidC = CardState(CardId("card-c"), CardType.B)
+            val state =
+                reinforcementTradeGame(
+                    lobbyCode = LobbyCode("TRI2"),
+                    players = listOf(playerOne, PlayerId(2)),
+                    activePlayerId = playerOne,
+                    pendingPlayerId = playerOne,
+                    pendingAmount = 1,
+                    handState =
+                        HandState(
+                            cardsByPlayer =
+                                mapOf(
+                                    playerOne to listOf(invalidA, invalidB, invalidC),
+                                ),
+                        ),
+                )
+
+            val (error, snapshot) =
+                exerciseFailingTrade(
+                    lobbyCode = LobbyCode("TRI2"),
+                    state = state,
+                    requesterPlayerId = playerOne,
+                    request =
+                        TradeInCardsRequest(
+                            lobbyCode = LobbyCode("TRI2"),
+                            playerId = playerOne,
+                            cardIds = listOf(invalidA.cardId, invalidB.cardId, invalidC.cardId),
+                        ),
+                )
+
+            assertEquals(TradeInCardsErrorCode.INVALID_SET, error.code)
+            assertEquals(1, snapshot.pendingReinforcementsFor(playerOne))
+            assertEquals(0, snapshot.tradedInSetCount)
+            assertEquals(listOf(invalidA, invalidB, invalidC), snapshot.handOf(playerOne))
+        }
+
+    @Test
+    fun `security rejects trade when cards are not owned by requester`() =
+        testApplication {
+            val playerOne = PlayerId(1)
+            val playerTwo = PlayerId(2)
+            val ownA = CardState(CardId("card-a"), CardType.A)
+            val ownB = CardState(CardId("card-b"), CardType.B)
+            val foreignJ = CardState(CardId("card-j"), CardType.JOKER)
+            val state =
+                reinforcementTradeGame(
+                    lobbyCode = LobbyCode("TRI3"),
+                    players = listOf(playerOne, playerTwo),
+                    activePlayerId = playerOne,
+                    pendingPlayerId = playerOne,
+                    pendingAmount = 4,
+                    handState =
+                        HandState(
+                            cardsByPlayer =
+                                mapOf(
+                                    playerOne to listOf(ownA, ownB),
+                                    playerTwo to listOf(foreignJ),
+                                ),
+                        ),
+                )
+
+            val (error, snapshot) =
+                exerciseFailingTrade(
+                    lobbyCode = LobbyCode("TRI3"),
+                    state = state,
+                    requesterPlayerId = playerOne,
+                    request =
+                        TradeInCardsRequest(
+                            lobbyCode = LobbyCode("TRI3"),
+                            playerId = playerOne,
+                            cardIds = listOf(ownA.cardId, ownB.cardId, foreignJ.cardId),
+                        ),
+                )
+
+            assertEquals(TradeInCardsErrorCode.CARDS_NOT_OWNED, error.code)
+            assertEquals(4, snapshot.pendingReinforcementsFor(playerOne))
+            assertEquals(0, snapshot.tradedInSetCount)
+            assertEquals(listOf(ownA, ownB), snapshot.handOf(playerOne))
+            assertEquals(listOf(foreignJ), snapshot.handOf(playerTwo))
+        }
+
+    private suspend fun ApplicationTestBuilder.exerciseFailingTrade(
+        lobbyCode: LobbyCode,
+        state: GameState,
+        requesterPlayerId: PlayerId,
+        request: TradeInCardsRequest,
+    ): Pair<TradeInCardsErrorResponse, GameState> {
+        val network = ServerNetwork()
+        val serverScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val lobbyManager = LobbyManager(serverScope)
+        val router =
+            MainServerRouter(
+                lobbyManager = lobbyManager,
+                mapper = DefaultNetworkToLobbyEventMapper(),
+            )
+        val playersByConnection = ConcurrentHashMap<ConnectionId, PlayerId>()
+        val connectionsByPlayer = ConcurrentHashMap<PlayerId, ConnectionId>()
+        val routingService =
+            MainServerLobbyRoutingService(
+                network = network,
+                router = router,
+                lobbyManager = lobbyManager,
+                playerIdResolver = { connectionId -> playersByConnection[connectionId] },
+                connectionIdResolver = { playerId -> connectionsByPlayer[playerId] },
+                hooks = MainServerLobbyRoutingServiceHooks(),
+            )
+
+        application {
+            module(network)
+        }
+        lobbyManager.createLobby(lobbyCode = lobbyCode, initialState = state)
+        routingService.start(serverScope)
+
+        val client =
+            createClient {
+                install(WebSockets)
+            }
+
+        return try {
+            coroutineScope {
+                val requesterSession =
+                    connectSessionWithConnection(
+                        client = client,
+                        network = network,
+                        playerId = requesterPlayerId,
+                        playersByConnection = playersByConnection,
+                        connectionsByPlayer = connectionsByPlayer,
+                    )
+
+                requesterSession.first.send(
+                    Frame.Binary(
+                        fin = true,
+                        data = MessageCodec.encode(request),
+                    ),
+                )
+
+                val response =
+                    receiveRelevantTestPayload(requesterSession.first) as TradeInCardsErrorResponse
+                requesterSession.first.close()
+                response to (lobbyManager.getLobby(lobbyCode)?.currentState() ?: error("missing"))
+            }
+        } finally {
+            routingService.stop()
+            lobbyManager.shutdownAll()
+            serverScope.cancel()
+        }
+    }
+
+    private fun reinforcementTradeGame(
+        lobbyCode: LobbyCode,
+        players: List<PlayerId>,
+        activePlayerId: PlayerId,
+        pendingPlayerId: PlayerId,
+        pendingAmount: Int,
+        handState: HandState,
+    ): GameState {
+        val mapDefinition = at.aau.pulverfass.shared.map.config.MapConfigLoader.loadDefault()
+        val turnState =
+            TurnState(
+                activePlayerId = activePlayerId,
+                turnPhase = TurnPhase.REINFORCEMENTS,
+                turnCount = 1,
+                startPlayerId = players.first(),
+            )
+
+        return GameState.initial(
+            lobbyCode = lobbyCode,
+            mapDefinition = mapDefinition,
+            players = players,
+            playerDisplayNames = players.associateWith { playerId -> "Player ${playerId.value}" },
+        ).copy(
+            activePlayer = activePlayerId,
+            turnState = turnState,
+            turnNumber = turnState.turnCount,
+            status = at.aau.pulverfass.shared.lobby.state.GameStatus.RUNNING,
+            pendingReinforcements = PendingReinforcements(pendingPlayerId, pendingAmount),
+            handState = handState,
+        )
+    }
+
+    private suspend fun connectSessionWithConnection(
+        client: io.ktor.client.HttpClient,
+        network: ServerNetwork,
+        playerId: PlayerId,
+        playersByConnection: ConcurrentHashMap<ConnectionId, PlayerId>,
+        connectionsByPlayer: ConcurrentHashMap<PlayerId, ConnectionId>,
+    ) = coroutineScope {
+        val session = client.webSocketSession("/ws")
+        val sessionToken = receiveTestConnectionToken(session)
+        val connectionId = awaitTestConnectionId(network, sessionToken)
+        playersByConnection[connectionId] = playerId
+        connectionsByPlayer[playerId] = connectionId
+        session to connectionId
+    }
+}

--- a/server/src/test/kotlin/at/aau/pulverfass/server/TurnAdvanceIntegrationTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/TurnAdvanceIntegrationTest.kt
@@ -19,6 +19,7 @@ import at.aau.pulverfass.shared.message.lobby.event.GameStateSnapshotBroadcast
 import at.aau.pulverfass.shared.message.lobby.event.PhaseBoundaryEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostReason
+import at.aau.pulverfass.shared.message.lobby.event.ReinforcementsGrantedEvent
 import at.aau.pulverfass.shared.message.lobby.request.TurnAdvanceRequest
 import at.aau.pulverfass.shared.message.lobby.response.TurnAdvanceResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.TurnAdvanceErrorCode
@@ -478,9 +479,28 @@ class TurnAdvanceIntegrationTest {
                         receiveAnyPayload(playerTwoSession.first),
                     )
                     assertEquals(
+                        GameStateDeltaEvent(
+                            lobbyCode = lobbyCode,
+                            fromVersion = 2,
+                            toVersion = 2,
+                            events =
+                                listOf(
+                                    ReinforcementsGrantedEvent(
+                                        lobbyCode = lobbyCode,
+                                        playerId = playerTwo,
+                                        amount = 3,
+                                        territoryBonus = 3,
+                                        continentBonus = 0,
+                                        cardBonus = 0,
+                                    ),
+                                ),
+                        ),
+                        receiveAnyPayload(playerTwoSession.first),
+                    )
+                    assertEquals(
                         PhaseBoundaryEvent(
                             lobbyCode = lobbyCode,
-                            stateVersion = 1,
+                            stateVersion = 2,
                             previousPhase = TurnPhase.DRAW_CARD,
                             nextPhase = TurnPhase.REINFORCEMENTS,
                             activePlayerId = playerTwo,
@@ -504,7 +524,7 @@ class TurnAdvanceIntegrationTest {
                             receiveAnyPayload(playerTwoSession.first),
                         )
                     assertEquals(lobbyCode, snapshot.lobbyCode)
-                    assertEquals(1, snapshot.stateVersion)
+                    assertEquals(2, snapshot.stateVersion)
                     assertEquals(defaultMapDefinition().mapHash, snapshot.determinism.mapHash)
                     assertEquals(
                         defaultMapDefinition().schemaVersion,
@@ -810,7 +830,7 @@ class TurnAdvanceIntegrationTest {
                     assertEquals(
                         PhaseBoundaryEvent(
                             lobbyCode = lobbyCode,
-                            stateVersion = 1,
+                            stateVersion = 2,
                             previousPhase = TurnPhase.DRAW_CARD,
                             nextPhase = TurnPhase.REINFORCEMENTS,
                             activePlayerId = playerTwo,
@@ -841,6 +861,7 @@ class TurnAdvanceIntegrationTest {
                         snapshot.turnState?.pauseReason,
                     )
                     assertEquals(playerTwo, snapshot.turnState?.pausedPlayerId)
+                    assertEquals(3, snapshot.pendingReinforcementsFor(playerTwo))
 
                     playerOneSession.first.close()
                 }

--- a/server/src/test/kotlin/at/aau/pulverfass/server/lobby/CardSetValidatorTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/lobby/CardSetValidatorTest.kt
@@ -1,5 +1,7 @@
 package at.aau.pulverfass.server.lobby
 
+import at.aau.pulverfass.shared.ids.CardId
+import at.aau.pulverfass.shared.lobby.state.CardState
 import at.aau.pulverfass.shared.lobby.state.CardType
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -65,4 +67,65 @@ class CardSetValidatorTest {
             ),
         )
     }
+
+    @Test
+    fun `canMakeAnySet returns false for empty hand`() {
+        assertFalse(CardSetValidator.canMakeAnySet(emptyList()))
+    }
+
+    @Test
+    fun `canMakeAnySet returns false when fewer than three cards`() {
+        assertFalse(
+            CardSetValidator.canMakeAnySet(
+                listOf(card("x", CardType.A), card("y", CardType.B)),
+            ),
+        )
+    }
+
+    @Test
+    fun `canMakeAnySet returns false when no valid three-card combination exists`() {
+        assertFalse(
+            CardSetValidator.canMakeAnySet(
+                listOf(
+                    card("1", CardType.A),
+                    card("2", CardType.A),
+                    card("3", CardType.B),
+                    card("4", CardType.B),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `canMakeAnySet returns true when at least one valid set exists in the hand`() {
+        assertTrue(
+            CardSetValidator.canMakeAnySet(
+                listOf(
+                    card("1", CardType.A),
+                    card("2", CardType.A),
+                    card("3", CardType.B),
+                    card("4", CardType.B),
+                    card("5", CardType.C),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `canMakeAnySet returns true when joker completes a set`() {
+        assertTrue(
+            CardSetValidator.canMakeAnySet(
+                listOf(
+                    card("1", CardType.A),
+                    card("2", CardType.B),
+                    card("3", CardType.JOKER),
+                ),
+            ),
+        )
+    }
+
+    private fun card(
+        id: String,
+        type: CardType,
+    ) = CardState(CardId(id), type)
 }

--- a/server/src/test/kotlin/at/aau/pulverfass/server/lobby/CardSetValidatorTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/lobby/CardSetValidatorTest.kt
@@ -1,0 +1,68 @@
+package at.aau.pulverfass.server.lobby
+
+import at.aau.pulverfass.shared.lobby.state.CardType
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class CardSetValidatorTest {
+    @Test
+    fun `should accept three of a kind`() {
+        assertTrue(
+            CardSetValidator.isValidSet(
+                listOf(CardType.A, CardType.A, CardType.A),
+            ),
+        )
+    }
+
+    @Test
+    fun `should accept one of each symbol`() {
+        assertTrue(
+            CardSetValidator.isValidSet(
+                listOf(CardType.A, CardType.B, CardType.C),
+            ),
+        )
+    }
+
+    @Test
+    fun `should allow one joker to complete a mixed set`() {
+        assertTrue(
+            CardSetValidator.isValidSet(
+                listOf(CardType.A, CardType.B, CardType.JOKER),
+            ),
+        )
+    }
+
+    @Test
+    fun `should allow two jokers to complete a valid set`() {
+        assertTrue(
+            CardSetValidator.isValidSet(
+                listOf(CardType.A, CardType.JOKER, CardType.JOKER),
+            ),
+        )
+    }
+
+    @Test
+    fun `should reject invalid non joker combinations`() {
+        assertFalse(
+            CardSetValidator.isValidSet(
+                listOf(CardType.A, CardType.A, CardType.B),
+            ),
+        )
+    }
+
+    @Test
+    fun `should reject anything other than exactly three cards`() {
+        assertFalse(CardSetValidator.isValidSet(emptyList()))
+        assertFalse(
+            CardSetValidator.isValidSet(
+                listOf(CardType.A, CardType.B),
+            ),
+        )
+        assertFalse(
+            CardSetValidator.isValidSet(
+                listOf(CardType.A, CardType.B, CardType.C, CardType.JOKER),
+            ),
+        )
+    }
+}

--- a/server/src/test/kotlin/at/aau/pulverfass/server/persistence/LobbyRecoveryLoaderTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/persistence/LobbyRecoveryLoaderTest.kt
@@ -1,9 +1,11 @@
 package at.aau.pulverfass.server.persistence
 
 import at.aau.pulverfass.server.map.ClasspathMapDefinitionRepository
+import at.aau.pulverfass.shared.ids.CardId
 import at.aau.pulverfass.shared.ids.LobbyCode
 import at.aau.pulverfass.shared.ids.PlayerId
 import at.aau.pulverfass.shared.ids.TerritoryId
+import at.aau.pulverfass.shared.lobby.event.CardSetTradedInEvent
 import at.aau.pulverfass.shared.lobby.event.GameStarted
 import at.aau.pulverfass.shared.lobby.event.InvalidActionDetected
 import at.aau.pulverfass.shared.lobby.event.LobbyClosed
@@ -18,8 +20,13 @@ import at.aau.pulverfass.shared.lobby.event.TerritoryTroopsChangedEvent
 import at.aau.pulverfass.shared.lobby.event.TimeoutTriggered
 import at.aau.pulverfass.shared.lobby.event.TurnEnded
 import at.aau.pulverfass.shared.lobby.event.TurnStateUpdatedEvent
+import at.aau.pulverfass.shared.lobby.state.CardState
+import at.aau.pulverfass.shared.lobby.state.CardType
+import at.aau.pulverfass.shared.lobby.state.DeckState
+import at.aau.pulverfass.shared.lobby.state.DiscardPileState
 import at.aau.pulverfass.shared.lobby.state.GameState
 import at.aau.pulverfass.shared.lobby.state.GameStatus
+import at.aau.pulverfass.shared.lobby.state.HandState
 import at.aau.pulverfass.shared.lobby.state.TurnPauseReasons
 import at.aau.pulverfass.shared.lobby.state.TurnPhase
 import at.aau.pulverfass.shared.message.lobby.response.PublicDeterminismMetadataSnapshot
@@ -49,7 +56,45 @@ class LobbyRecoveryLoaderTest {
                 gameStarted = true,
                 stateVersion = 7,
                 processedEventCount = 7,
+                tradedInSetCount = 2,
                 lastInvalidActionReason = "none",
+                handState =
+                    HandState(
+                        cardsByPlayer =
+                            mapOf(
+                                hostId to
+                                    listOf(
+                                        CardState(
+                                            cardId = CardId("card-a"),
+                                            type = CardType.A,
+                                        ),
+                                        CardState(
+                                            cardId = CardId("card-joker"),
+                                            type = CardType.JOKER,
+                                        ),
+                                    ),
+                            ),
+                    ),
+                deckState =
+                    DeckState(
+                        cards =
+                            listOf(
+                                CardState(
+                                    cardId = CardId("deck-1"),
+                                    type = CardType.B,
+                                ),
+                            ),
+                    ),
+                discardPileState =
+                    DiscardPileState(
+                        cards =
+                            listOf(
+                                CardState(
+                                    cardId = CardId("discard-1"),
+                                    type = CardType.C,
+                                ),
+                            ),
+                    ),
             )
 
         val restored = PersistedLobbyRecoverySnapshot.fromGameState(state).toGameState()
@@ -83,6 +128,22 @@ class LobbyRecoveryLoaderTest {
     fun `toLobbyEvent maps all supported persisted event types`() {
         val createdAt = Instant.parse("2026-01-01T00:00:00Z")
 
+        assertEquals(
+            CardSetTradedInEvent(
+                lobbyCode = lobbyCode,
+                playerId = PlayerId(5),
+                cardIds = listOf(CardId("card-a"), CardId("card-b"), CardId("card-c")),
+                value = 6,
+                tradeIndex = 3,
+            ),
+            record(
+                "card_set_traded_in",
+                """
+                {"lobbyCode":"LR11","playerId":5,"cardIds":["card-a","card-b","card-c"],"value":6,"tradeIndex":3}
+                """.trimIndent(),
+                createdAt,
+            ).toLobbyEvent(),
+        )
         assertEquals(
             LobbyCreated(lobbyCode),
             record(

--- a/server/src/test/kotlin/at/aau/pulverfass/server/routing/PublicGameStateBuilderTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/routing/PublicGameStateBuilderTest.kt
@@ -2,10 +2,15 @@ package at.aau.pulverfass.server.routing
 
 import at.aau.pulverfass.shared.ids.LobbyCode
 import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsSetEvent
 import at.aau.pulverfass.shared.lobby.state.GameState
+import at.aau.pulverfass.shared.lobby.state.PendingReinforcements
+import at.aau.pulverfass.shared.lobby.state.TurnPhase
+import at.aau.pulverfass.shared.lobby.state.TurnState
 import at.aau.pulverfass.shared.message.lobby.event.PrivateGameEvent
 import at.aau.pulverfass.shared.message.lobby.event.PublicGameEvent
 import at.aau.pulverfass.shared.message.lobby.response.PublicGameStateSnapshot
+import at.aau.pulverfass.shared.message.lobby.event.ReinforcementsGrantedEvent
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -81,6 +86,48 @@ class PublicGameStateBuilderTest {
             "GameStateDeltaEvent darf nur PublicGameEvent enthalten. " +
                 "Nicht-oeffentliche Payloads: FakePrivateEvent.",
             exception.message,
+        )
+    }
+
+    @Test
+    fun `pending reinforcement set projects to public reinforcement grant event`() {
+        val previousState =
+            sampleGameState().copy(
+                activePlayer = PlayerId(2),
+                turnState =
+                    TurnState(
+                        activePlayerId = PlayerId(2),
+                        turnPhase = TurnPhase.REINFORCEMENTS,
+                        turnCount = 1,
+                        startPlayerId = PlayerId(1),
+                    ),
+            )
+        val currentState =
+            previousState.copy(
+                pendingReinforcements = PendingReinforcements(PlayerId(2), 3),
+                stateVersion = 5,
+            )
+
+        val delta =
+            builder.buildDelta(
+                lobbyCode = previousState.lobbyCode,
+                event = PendingReinforcementsSetEvent(previousState.lobbyCode, PlayerId(2), 3),
+                previousState = previousState,
+                currentState = currentState,
+            )
+
+        assertEquals(
+            listOf(
+                ReinforcementsGrantedEvent(
+                    lobbyCode = previousState.lobbyCode,
+                    playerId = PlayerId(2),
+                    amount = 3,
+                    territoryBonus = 3,
+                    continentBonus = 0,
+                    cardBonus = 0,
+                ),
+            ),
+            delta?.events,
         )
     }
 

--- a/server/src/test/kotlin/at/aau/pulverfass/server/routing/PublicGameStateBuilderTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/routing/PublicGameStateBuilderTest.kt
@@ -1,7 +1,9 @@
 package at.aau.pulverfass.server.routing
 
+import at.aau.pulverfass.shared.ids.CardId
 import at.aau.pulverfass.shared.ids.LobbyCode
 import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.lobby.event.CardSetTradedInEvent
 import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsSetEvent
 import at.aau.pulverfass.shared.lobby.state.GameState
 import at.aau.pulverfass.shared.lobby.state.PendingReinforcements
@@ -125,6 +127,41 @@ class PublicGameStateBuilderTest {
                     territoryBonus = 3,
                     continentBonus = 0,
                     cardBonus = 0,
+                ),
+            ),
+            delta?.events,
+        )
+    }
+
+    @Test
+    fun `card trade in projects to public reinforcement grant with card bonus only`() {
+        val previousState = sampleGameState()
+        val currentState = previousState.copy(stateVersion = 1, tradedInSetCount = 1)
+
+        val delta =
+            builder.buildDelta(
+                lobbyCode = previousState.lobbyCode,
+                event =
+                    CardSetTradedInEvent(
+                        lobbyCode = previousState.lobbyCode,
+                        playerId = PlayerId(2),
+                        cardIds = listOf(CardId("card-a"), CardId("card-b"), CardId("card-c")),
+                        value = 2,
+                        tradeIndex = 1,
+                    ),
+                previousState = previousState,
+                currentState = currentState,
+            )
+
+        assertEquals(
+            listOf(
+                ReinforcementsGrantedEvent(
+                    lobbyCode = previousState.lobbyCode,
+                    playerId = PlayerId(2),
+                    amount = 2,
+                    territoryBonus = 0,
+                    continentBonus = 0,
+                    cardBonus = 2,
                 ),
             ),
             delta?.events,

--- a/server/src/test/kotlin/at/aau/pulverfass/server/routing/PublicGameStateBuilderTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/routing/PublicGameStateBuilderTest.kt
@@ -9,8 +9,8 @@ import at.aau.pulverfass.shared.lobby.state.TurnPhase
 import at.aau.pulverfass.shared.lobby.state.TurnState
 import at.aau.pulverfass.shared.message.lobby.event.PrivateGameEvent
 import at.aau.pulverfass.shared.message.lobby.event.PublicGameEvent
-import at.aau.pulverfass.shared.message.lobby.response.PublicGameStateSnapshot
 import at.aau.pulverfass.shared.message.lobby.event.ReinforcementsGrantedEvent
+import at.aau.pulverfass.shared.message.lobby.response.PublicGameStateSnapshot
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/server/src/test/kotlin/at/aau/pulverfass/server/routing/PublicGameStateBuilderTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/routing/PublicGameStateBuilderTest.kt
@@ -168,6 +168,29 @@ class PublicGameStateBuilderTest {
         )
     }
 
+    @Test
+    fun `buildSnapshot throws when game state has no turn state`() {
+        val gameState =
+            GameState.initial(
+                lobbyCode = LobbyCode("PGB2"),
+                mapDefinition = at.aau.pulverfass.shared.map.config.MapConfigLoader.loadDefault(),
+            ).copy(
+                turnState = null,
+                activePlayer = null,
+                turnOrder = emptyList(),
+                turnNumber = 0,
+            )
+
+        val exception =
+            assertThrows(IllegalStateException::class.java) {
+                builder.buildSnapshot(gameState)
+            }
+        assertEquals(
+            "GameState enthält keinen TurnState für einen Snapshot.",
+            exception.message,
+        )
+    }
+
     private fun sampleGameState(): GameState =
         GameState.initial(
             lobbyCode = LobbyCode("PGB0"),

--- a/server/src/test/kotlin/at/aau/pulverfass/server/routing/PublicGameStateBuilderTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/routing/PublicGameStateBuilderTest.kt
@@ -27,7 +27,19 @@ class PublicGameStateBuilderTest {
 
     @Test
     fun `snapshot builder exposes all required public fields consistently`() {
-        val gameState = sampleGameState().copy(stateVersion = 9)
+        val gameState =
+            sampleGameState().copy(
+                stateVersion = 9,
+                activePlayer = PlayerId(2),
+                turnState =
+                    TurnState(
+                        activePlayerId = PlayerId(2),
+                        turnPhase = TurnPhase.REINFORCEMENTS,
+                        turnCount = 2,
+                        startPlayerId = PlayerId(1),
+                    ),
+                pendingReinforcements = PendingReinforcements(PlayerId(2), 4),
+            )
 
         val snapshot = builder.buildSnapshot(gameState)
         val mapGet = builder.buildMapGetResponse(gameState)
@@ -39,6 +51,7 @@ class PublicGameStateBuilderTest {
         assertEquals(gameState.mapDefinition?.mapHash, snapshot.determinism.mapHash)
         assertEquals(gameState.mapDefinition?.schemaVersion, snapshot.determinism.schemaVersion)
         assertNotNull(snapshot.turnState)
+        assertEquals(4, snapshot.turnState.pendingReinforcements)
         assertEquals(gameState.allTerritoryStates().size, snapshot.territoryStates.size)
 
         assertEquals(snapshot.lobbyCode, mapGet.lobbyCode)

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/ids/CardId.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/ids/CardId.kt
@@ -1,0 +1,16 @@
+package at.aau.pulverfass.shared.ids
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Eindeutige ID einer Spielkarte.
+ */
+@Serializable
+@JvmInline
+value class CardId(val value: String) {
+    init {
+        require(value.isNotBlank()) {
+            "CardId darf nicht leer sein."
+        }
+    }
+}

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/event/CardSetTradedInEvent.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/event/CardSetTradedInEvent.kt
@@ -1,0 +1,31 @@
+package at.aau.pulverfass.shared.lobby.event
+
+import at.aau.pulverfass.shared.ids.CardId
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.ids.PlayerId
+
+/**
+ * Repräsentiert den erfolgreichen Trade-In eines Dreier-Sets durch einen Spieler.
+ */
+data class CardSetTradedInEvent(
+    override val lobbyCode: LobbyCode,
+    val playerId: PlayerId,
+    val cardIds: List<CardId>,
+    val value: Int,
+    val tradeIndex: Int,
+) : InternalLobbyEvent {
+    init {
+        require(cardIds.size == 3) {
+            "CardSetTradedInEvent.cardIds muss genau 3 Karten enthalten."
+        }
+        require(cardIds.distinct().size == cardIds.size) {
+            "CardSetTradedInEvent.cardIds darf keine Duplikate enthalten."
+        }
+        require(value > 0) {
+            "CardSetTradedInEvent.value muss positiv sein, war aber $value."
+        }
+        require(tradeIndex > 0) {
+            "CardSetTradedInEvent.tradeIndex muss positiv sein, war aber $tradeIndex."
+        }
+    }
+}

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/event/PendingReinforcementsChangedEvent.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/event/PendingReinforcementsChangedEvent.kt
@@ -30,7 +30,8 @@ data class PendingReinforcementsChangedEvent(
     }
 }
 
-object PendingReinforcementsChangedEventSerializer : KSerializer<PendingReinforcementsChangedEvent> {
+object PendingReinforcementsChangedEventSerializer :
+    KSerializer<PendingReinforcementsChangedEvent> {
     override val descriptor =
         buildClassSerialDescriptor(
             "at.aau.pulverfass.shared.network.message.PendingReinforcementsChangedEvent",

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/event/PendingReinforcementsChangedEvent.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/event/PendingReinforcementsChangedEvent.kt
@@ -1,0 +1,91 @@
+package at.aau.pulverfass.shared.lobby.event
+
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.message.lobby.event.PublicGameEvent
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.MissingFieldException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * Verändert den ausstehenden Verstärkungspool eines Spielers um ein Delta.
+ *
+ * Positive Deltas erhöhen den Pool, negative Deltas verringern ihn.
+ */
+@Serializable(with = PendingReinforcementsChangedEventSerializer::class)
+data class PendingReinforcementsChangedEvent(
+    override val lobbyCode: LobbyCode,
+    val playerId: PlayerId,
+    val delta: Int,
+) : InternalLobbyEvent, PublicGameEvent {
+    init {
+        require(delta != 0) {
+            "PendingReinforcementsChangedEvent.delta darf nicht 0 sein."
+        }
+    }
+}
+
+object PendingReinforcementsChangedEventSerializer : KSerializer<PendingReinforcementsChangedEvent> {
+    override val descriptor =
+        buildClassSerialDescriptor(
+            "at.aau.pulverfass.shared.network.message.PendingReinforcementsChangedEvent",
+        ) {
+            element("lobbyCode", LobbyCode.serializer().descriptor)
+            element("playerId", PlayerId.serializer().descriptor)
+            element<Int>("delta")
+        }
+
+    override fun serialize(
+        encoder: Encoder,
+        value: PendingReinforcementsChangedEvent,
+    ) {
+        val composite = encoder.beginStructure(descriptor)
+        composite.encodeSerializableElement(descriptor, 0, LobbyCode.serializer(), value.lobbyCode)
+        composite.encodeSerializableElement(descriptor, 1, PlayerId.serializer(), value.playerId)
+        composite.encodeIntElement(descriptor, 2, value.delta)
+        composite.endStructure(descriptor)
+    }
+
+    override fun deserialize(decoder: Decoder): PendingReinforcementsChangedEvent {
+        val composite = decoder.beginStructure(descriptor)
+        var lobbyCode: LobbyCode? = null
+        var playerId: PlayerId? = null
+        var delta: Int? = null
+
+        loop@ while (true) {
+            when (val index = composite.decodeElementIndex(descriptor)) {
+                0 ->
+                    lobbyCode =
+                        composite.decodeSerializableElement(
+                            descriptor,
+                            0,
+                            LobbyCode.serializer(),
+                        )
+                1 ->
+                    playerId =
+                        composite.decodeSerializableElement(
+                            descriptor,
+                            1,
+                            PlayerId.serializer(),
+                        )
+                2 -> delta = composite.decodeIntElement(descriptor, 2)
+                CompositeDecoder.DECODE_DONE -> break@loop
+                else -> throw IllegalArgumentException("Unexpected index $index")
+            }
+        }
+
+        composite.endStructure(descriptor)
+        return PendingReinforcementsChangedEvent(
+            lobbyCode =
+                lobbyCode
+                    ?: throw MissingFieldException("lobbyCode", descriptor.serialName),
+            playerId = playerId ?: throw MissingFieldException("playerId", descriptor.serialName),
+            delta = delta ?: throw MissingFieldException("delta", descriptor.serialName),
+        )
+    }
+}

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/event/PendingReinforcementsSetEvent.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/event/PendingReinforcementsSetEvent.kt
@@ -1,0 +1,19 @@
+package at.aau.pulverfass.shared.lobby.event
+
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.ids.PlayerId
+
+/**
+ * Setzt den ausstehenden Verstärkungspool eines Spielers auf einen absoluten Wert.
+ */
+data class PendingReinforcementsSetEvent(
+    override val lobbyCode: LobbyCode,
+    val playerId: PlayerId,
+    val amount: Int,
+) : InternalLobbyEvent {
+    init {
+        require(amount >= 0) {
+            "PendingReinforcementsSetEvent.amount darf nicht negativ sein, war aber $amount."
+        }
+    }
+}

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/event/PlayerCardsRemovedEvent.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/event/PlayerCardsRemovedEvent.kt
@@ -1,0 +1,23 @@
+package at.aau.pulverfass.shared.lobby.event
+
+import at.aau.pulverfass.shared.ids.CardId
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.ids.PlayerId
+
+/**
+ * Entfernt autoritativ Karten aus der Hand eines Spielers.
+ */
+data class PlayerCardsRemovedEvent(
+    override val lobbyCode: LobbyCode,
+    val playerId: PlayerId,
+    val cardIds: List<CardId>,
+) : InternalLobbyEvent {
+    init {
+        require(cardIds.isNotEmpty()) {
+            "PlayerCardsRemovedEvent.cardIds darf nicht leer sein."
+        }
+        require(cardIds.distinct().size == cardIds.size) {
+            "PlayerCardsRemovedEvent.cardIds darf keine Duplikate enthalten."
+        }
+    }
+}

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/reducer/DefaultLobbyEventReducer.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/reducer/DefaultLobbyEventReducer.kt
@@ -2,6 +2,7 @@ package at.aau.pulverfass.shared.lobby.reducer
 
 import at.aau.pulverfass.shared.event.EventContext
 import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.lobby.event.CardSetTradedInEvent
 import at.aau.pulverfass.shared.lobby.event.GameStarted
 import at.aau.pulverfass.shared.lobby.event.InvalidActionDetected
 import at.aau.pulverfass.shared.lobby.event.LobbyClosed
@@ -9,6 +10,7 @@ import at.aau.pulverfass.shared.lobby.event.LobbyCreated
 import at.aau.pulverfass.shared.lobby.event.LobbyEvent
 import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsChangedEvent
 import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsSetEvent
+import at.aau.pulverfass.shared.lobby.event.PlayerCardsRemovedEvent
 import at.aau.pulverfass.shared.lobby.event.PlayerJoined
 import at.aau.pulverfass.shared.lobby.event.PlayerKicked
 import at.aau.pulverfass.shared.lobby.event.PlayerLeft
@@ -22,6 +24,7 @@ import at.aau.pulverfass.shared.lobby.event.TurnStateUpdatedEvent
 import at.aau.pulverfass.shared.lobby.state.GameStartPreparation
 import at.aau.pulverfass.shared.lobby.state.GameState
 import at.aau.pulverfass.shared.lobby.state.GameStatus
+import at.aau.pulverfass.shared.lobby.state.TradeInProgression
 import at.aau.pulverfass.shared.lobby.state.TurnOrderPolicy
 import at.aau.pulverfass.shared.lobby.state.TurnPauseReasons
 import at.aau.pulverfass.shared.lobby.state.TurnState
@@ -70,9 +73,11 @@ class DefaultLobbyEventReducer : LobbyEventReducer {
                         pendingReinforcements = null,
                     )
 
+                is CardSetTradedInEvent -> onCardSetTradedIn(state, event)
                 is PendingReinforcementsChangedEvent ->
                     onPendingReinforcementsChanged(state, event)
                 is PendingReinforcementsSetEvent -> onPendingReinforcementsSet(state, event)
+                is PlayerCardsRemovedEvent -> onPlayerCardsRemoved(state, event)
                 is PlayerJoined -> onPlayerJoined(state, event.playerId, event.playerDisplayName)
                 is PlayerLeft -> onPlayerLeft(state, event.playerId)
                 is PlayerKicked ->
@@ -463,6 +468,42 @@ class DefaultLobbyEventReducer : LobbyEventReducer {
             )
         }
         return state.withPendingReinforcements(event.playerId, updatedAmount)
+    }
+
+    private fun onCardSetTradedIn(
+        state: GameState,
+        event: CardSetTradedInEvent,
+    ): GameState {
+        requireKnownPlayer(state, event.playerId)
+
+        val expectedTradeIndex = state.tradedInSetCount + 1
+        if (event.tradeIndex != expectedTradeIndex) {
+            throw InvalidLobbyEventException(
+                "CardSetTradedInEvent.tradeIndex muss den naechsten globalen " +
+                    "Trade-In abbilden: erwartet=$expectedTradeIndex, war=${event.tradeIndex}.",
+            )
+        }
+
+        val expectedValue = TradeInProgression.tradeInValue(event.tradeIndex)
+        if (event.value != expectedValue) {
+            throw InvalidLobbyEventException(
+                "CardSetTradedInEvent.value passt nicht zur Progression: " +
+                    "erwartet=$expectedValue, war=${event.value}.",
+            )
+        }
+
+        return state.withTradedInSetCount(event.tradeIndex)
+    }
+
+    private fun onPlayerCardsRemoved(
+        state: GameState,
+        event: PlayerCardsRemovedEvent,
+    ): GameState {
+        requireKnownPlayer(state, event.playerId)
+
+        return event.cardIds.fold(state) { currentState, cardId ->
+            currentState.withoutCardFromHand(event.playerId, cardId)
+        }
     }
 
     private fun applyTurnStateUpdate(

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/reducer/DefaultLobbyEventReducer.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/reducer/DefaultLobbyEventReducer.kt
@@ -170,7 +170,8 @@ class DefaultLobbyEventReducer : LobbyEventReducer {
                 playerDisplayNames = state.playerDisplayNames - playerId,
                 lobbyOwner = updatedLobbyOwner,
                 activePlayer = state.activePlayer?.takeIf(updatedPlayers::contains),
-                pendingReinforcements = state.pendingReinforcements?.takeIf { it.playerId != playerId },
+                pendingReinforcements =
+                    state.pendingReinforcements?.takeIf { it.playerId != playerId },
                 setupTroopsToPlaceByPlayer = state.setupTroopsToPlaceByPlayer - playerId,
                 configuredStartPlayerId = updatedTurnState?.startPlayerId,
                 turnOrder = updatedTurnOrder,
@@ -445,7 +446,16 @@ class DefaultLobbyEventReducer : LobbyEventReducer {
     ): GameState {
         requireKnownPlayer(state, event.playerId)
         val currentAmount = pendingReinforcementsAmountFor(state, event.playerId)
-        val updatedAmount = currentAmount + event.delta
+        val updatedAmount =
+            try {
+                Math.addExact(currentAmount, event.delta)
+            } catch (_: ArithmeticException) {
+                throw InvalidLobbyEventException(
+                    "PendingReinforcements für Spieler '${event.playerId.value}' dürfen den " +
+                        "Int-Bereich nicht verlassen: aktuell=$currentAmount, " +
+                        "delta=${event.delta}.",
+                )
+            }
         if (updatedAmount < 0) {
             throw InvalidLobbyEventException(
                 "PendingReinforcements für Spieler '${event.playerId.value}' dürfen nicht " +
@@ -623,7 +633,7 @@ class DefaultLobbyEventReducer : LobbyEventReducer {
         if (state.territoryStateOf(territoryId) == null) {
             throw InvalidLobbyEventException(
                 "Territory '${territoryId.value}' ist nicht Teil der Map " +
-                "von Lobby '${state.lobbyCode}'.",
+                    "von Lobby '${state.lobbyCode}'.",
             )
         }
     }

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/reducer/DefaultLobbyEventReducer.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/reducer/DefaultLobbyEventReducer.kt
@@ -7,6 +7,8 @@ import at.aau.pulverfass.shared.lobby.event.InvalidActionDetected
 import at.aau.pulverfass.shared.lobby.event.LobbyClosed
 import at.aau.pulverfass.shared.lobby.event.LobbyCreated
 import at.aau.pulverfass.shared.lobby.event.LobbyEvent
+import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsChangedEvent
+import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsSetEvent
 import at.aau.pulverfass.shared.lobby.event.PlayerJoined
 import at.aau.pulverfass.shared.lobby.event.PlayerKicked
 import at.aau.pulverfass.shared.lobby.event.PlayerLeft
@@ -56,6 +58,7 @@ class DefaultLobbyEventReducer : LobbyEventReducer {
                     state.copy(
                         status = GameStatus.CLOSED,
                         activePlayer = null,
+                        pendingReinforcements = null,
                         turnState = null,
                         closedReason = event.reason,
                     )
@@ -64,8 +67,12 @@ class DefaultLobbyEventReducer : LobbyEventReducer {
                     state.copy(
                         status = GameStatus.WAITING_FOR_PLAYERS,
                         closedReason = null,
+                        pendingReinforcements = null,
                     )
 
+                is PendingReinforcementsChangedEvent ->
+                    onPendingReinforcementsChanged(state, event)
+                is PendingReinforcementsSetEvent -> onPendingReinforcementsSet(state, event)
                 is PlayerJoined -> onPlayerJoined(state, event.playerId, event.playerDisplayName)
                 is PlayerLeft -> onPlayerLeft(state, event.playerId)
                 is PlayerKicked ->
@@ -114,6 +121,7 @@ class DefaultLobbyEventReducer : LobbyEventReducer {
                 players = updatedPlayers,
                 playerDisplayNames = state.playerDisplayNames + (playerId to playerDisplayName),
                 lobbyOwner = updatedLobbyOwner,
+                pendingReinforcements = state.pendingReinforcements,
                 setupTroopsToPlaceByPlayer = state.setupTroopsToPlaceByPlayer + (playerId to 0),
                 configuredStartPlayerId = updatedTurnState?.startPlayerId,
                 turnOrder = updatedTurnOrder,
@@ -162,6 +170,7 @@ class DefaultLobbyEventReducer : LobbyEventReducer {
                 playerDisplayNames = state.playerDisplayNames - playerId,
                 lobbyOwner = updatedLobbyOwner,
                 activePlayer = state.activePlayer?.takeIf(updatedPlayers::contains),
+                pendingReinforcements = state.pendingReinforcements?.takeIf { it.playerId != playerId },
                 setupTroopsToPlaceByPlayer = state.setupTroopsToPlaceByPlayer - playerId,
                 configuredStartPlayerId = updatedTurnState?.startPlayerId,
                 turnOrder = updatedTurnOrder,
@@ -216,6 +225,8 @@ class DefaultLobbyEventReducer : LobbyEventReducer {
                 players = updatedPlayers,
                 playerDisplayNames = state.playerDisplayNames - targetPlayerId,
                 activePlayer = state.activePlayer?.takeIf(updatedPlayers::contains),
+                pendingReinforcements =
+                    state.pendingReinforcements?.takeIf { it.playerId != targetPlayerId },
                 setupTroopsToPlaceByPlayer = state.setupTroopsToPlaceByPlayer - targetPlayerId,
                 configuredStartPlayerId = updatedTurnState?.startPlayerId,
                 turnOrder = updatedTurnOrder,
@@ -402,6 +413,7 @@ class DefaultLobbyEventReducer : LobbyEventReducer {
                 configuredStartPlayerId = initializedTurnState?.startPlayerId,
                 gameStarted = true,
                 gameRandomSeed = event.randomSeed,
+                pendingReinforcements = null,
                 status = GameStatus.RUNNING,
                 turnOrder = preparedStart.randomizedTurnOrder,
                 territoryStates = preparedStart.preparedTerritoryStates,
@@ -418,6 +430,30 @@ class DefaultLobbyEventReducer : LobbyEventReducer {
         state: GameState,
         event: TurnStateUpdatedEvent,
     ): GameState = applyTurnStateUpdate(state, event)
+
+    private fun onPendingReinforcementsSet(
+        state: GameState,
+        event: PendingReinforcementsSetEvent,
+    ): GameState {
+        requireKnownPlayer(state, event.playerId)
+        return state.withPendingReinforcements(event.playerId, event.amount)
+    }
+
+    private fun onPendingReinforcementsChanged(
+        state: GameState,
+        event: PendingReinforcementsChangedEvent,
+    ): GameState {
+        requireKnownPlayer(state, event.playerId)
+        val currentAmount = pendingReinforcementsAmountFor(state, event.playerId)
+        val updatedAmount = currentAmount + event.delta
+        if (updatedAmount < 0) {
+            throw InvalidLobbyEventException(
+                "PendingReinforcements für Spieler '${event.playerId.value}' dürfen nicht " +
+                    "negativ werden: aktuell=$currentAmount, delta=${event.delta}.",
+            )
+        }
+        return state.withPendingReinforcements(event.playerId, updatedAmount)
+    }
 
     private fun applyTurnStateUpdate(
         state: GameState,
@@ -569,6 +605,17 @@ class DefaultLobbyEventReducer : LobbyEventReducer {
         }
     }
 
+    private fun requireKnownPlayer(
+        state: GameState,
+        playerId: PlayerId,
+    ) {
+        if (!state.hasPlayer(playerId)) {
+            throw InvalidLobbyEventException(
+                "Spieler '${playerId.value}' ist nicht Teil der Lobby '${state.lobbyCode.value}'.",
+            )
+        }
+    }
+
     private fun requireKnownTerritory(
         state: GameState,
         territoryId: at.aau.pulverfass.shared.ids.TerritoryId,
@@ -576,8 +623,22 @@ class DefaultLobbyEventReducer : LobbyEventReducer {
         if (state.territoryStateOf(territoryId) == null) {
             throw InvalidLobbyEventException(
                 "Territory '${territoryId.value}' ist nicht Teil der Map " +
-                    "von Lobby '${state.lobbyCode}'.",
+                "von Lobby '${state.lobbyCode}'.",
             )
         }
+    }
+
+    private fun pendingReinforcementsAmountFor(
+        state: GameState,
+        playerId: PlayerId,
+    ): Int {
+        val current = state.pendingReinforcements ?: return 0
+        if (current.playerId != playerId) {
+            throw InvalidLobbyEventException(
+                "PendingReinforcements gehören Spieler '${current.playerId.value}' und " +
+                    "können nicht für '${playerId.value}' verändert werden.",
+            )
+        }
+        return current.amount
     }
 }

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/BaseReinforcementRuleEngine.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/BaseReinforcementRuleEngine.kt
@@ -1,0 +1,33 @@
+package at.aau.pulverfass.shared.lobby.state
+
+import at.aau.pulverfass.shared.ids.PlayerId
+import kotlin.math.max
+
+/**
+ * Deterministische Berechnung der Basis-Verstärkungen zu Beginn von Phase 1.
+ */
+object BaseReinforcementRuleEngine {
+    fun computeBaseReinforcements(
+        playerId: PlayerId,
+        state: GameState,
+    ): BaseReinforcementBreakdown {
+        val ownedTerritories = state.ownedTerritoryCount(playerId)
+        val territoryBonus = max(3, ownedTerritories / 3)
+        val continentBonus =
+            state
+                .continentsOwnedBy(playerId)
+                .sumOf(state::continentBonus)
+
+        return BaseReinforcementBreakdown(
+            territoryBonus = territoryBonus,
+            continentBonus = continentBonus,
+            total = territoryBonus + continentBonus,
+        )
+    }
+}
+
+data class BaseReinforcementBreakdown(
+    val territoryBonus: Int,
+    val continentBonus: Int,
+    val total: Int,
+)

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/CardState.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/CardState.kt
@@ -1,0 +1,13 @@
+package at.aau.pulverfass.shared.lobby.state
+
+import at.aau.pulverfass.shared.ids.CardId
+import kotlinx.serialization.Serializable
+
+/**
+ * Autoritative Laufzeitrepräsentation einer einzelnen Spielkarte.
+ */
+@Serializable
+data class CardState(
+    val cardId: CardId,
+    val type: CardType,
+)

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/CardStateValidation.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/CardStateValidation.kt
@@ -1,0 +1,18 @@
+package at.aau.pulverfass.shared.lobby.state
+
+internal fun validateDistinctCardIds(
+    cards: List<CardState>,
+    containerName: String,
+) {
+    val duplicateCardIds =
+        cards
+            .groupingBy { card -> card.cardId }
+            .eachCount()
+            .filterValues { count -> count > 1 }
+            .keys
+
+    require(duplicateCardIds.isEmpty()) {
+        val duplicateIds = duplicateCardIds.joinToString { cardId -> cardId.value }
+        "$containerName darf keine doppelten CardIds enthalten: $duplicateIds."
+    }
+}

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/CardType.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/CardType.kt
@@ -1,0 +1,14 @@
+package at.aau.pulverfass.shared.lobby.state
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Grundtypen der Risiko-Karten für Trade-In und Draw.
+ */
+@Serializable
+enum class CardType {
+    A,
+    B,
+    C,
+    JOKER,
+}

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/DeckState.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/DeckState.kt
@@ -1,0 +1,15 @@
+package at.aau.pulverfass.shared.lobby.state
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Platzhalter für den serverseitigen Kartenstapel.
+ */
+@Serializable
+data class DeckState(
+    val cards: List<CardState> = emptyList(),
+) {
+    init {
+        validateDistinctCardIds(cards, "DeckState")
+    }
+}

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/DiscardPileState.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/DiscardPileState.kt
@@ -1,0 +1,15 @@
+package at.aau.pulverfass.shared.lobby.state
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Platzhalter für den serverseitigen Ablagestapel.
+ */
+@Serializable
+data class DiscardPileState(
+    val cards: List<CardState> = emptyList(),
+) {
+    init {
+        validateDistinctCardIds(cards, "DiscardPileState")
+    }
+}

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/GameState.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/GameState.kt
@@ -471,7 +471,10 @@ data class GameState(
     internal fun withPendingReinforcements(
         playerId: PlayerId,
         amount: Int,
-    ): GameState = copy(pendingReinforcements = PendingReinforcements(playerId = playerId, amount = amount))
+    ): GameState =
+        copy(
+            pendingReinforcements = PendingReinforcements(playerId = playerId, amount = amount),
+        )
 
     /**
      * Entfernt den ausstehenden Verstärkungspool vollständig.

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/GameState.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/GameState.kt
@@ -36,6 +36,7 @@ import at.aau.pulverfass.shared.map.config.TerritoryEdgeDefinition
  * @property mapDefinition readonly Definition der Spielmap, falls bereits gesetzt
  * @property territoryStates mutierbarer Laufzeitzustand aller Territorien
  * @property setupTroopsToPlaceByPlayer verbleibende Starttruppen pro Spieler nach der initialen Gebietsverteilung
+ * @property pendingReinforcements verbleibender Verstärkungspool eines Spielers für Phase 1
  */
 data class GameState(
     val lobbyCode: LobbyCode,
@@ -58,6 +59,7 @@ data class GameState(
     val mapDefinition: MapDefinition? = null,
     val territoryStates: Map<TerritoryId, TerritoryState> = emptyMap(),
     val setupTroopsToPlaceByPlayer: Map<PlayerId, Int> = players.associateWith { 0 },
+    val pendingReinforcements: PendingReinforcements? = null,
 ) {
     init {
         require(turnNumber >= 0) {
@@ -80,6 +82,9 @@ data class GameState(
         }
         require(setupTroopsToPlaceByPlayer.values.all { it >= 0 }) {
             "GameState.setupTroopsToPlaceByPlayer darf keine negativen Werte enthalten."
+        }
+        require(pendingReinforcements == null || players.contains(pendingReinforcements.playerId)) {
+            "GameState.pendingReinforcements.playerId muss Teil der Spielerliste sein."
         }
         require(turnOrder == turnOrder.distinct()) {
             "GameState.turnOrder darf keine Duplikate enthalten."
@@ -194,6 +199,20 @@ data class GameState(
     fun hasPendingSetupTroops(): Boolean = setupTroopsToPlaceByPlayer.values.any { it > 0 }
 
     /**
+     * Liefert den verbleibenden Verstärkungspool eines Spielers.
+     */
+    fun pendingReinforcementsFor(playerId: PlayerId): Int =
+        pendingReinforcements
+            ?.takeIf { it.playerId == playerId }
+            ?.amount
+            ?: 0
+
+    /**
+     * Prüft, ob aktuell noch ausstehende Verstärkungen vorhanden sind.
+     */
+    fun hasPendingReinforcements(): Boolean = (pendingReinforcements?.amount ?: 0) > 0
+
+    /**
      * Liefert alle Laufzeit-Territorien in stabiler Map-Reihenfolge.
      */
     fun allTerritoryStates(): List<TerritoryState> =
@@ -275,6 +294,11 @@ data class GameState(
         allTerritoryStates().filter { it.ownerId == playerId }
 
     /**
+     * Liefert die Anzahl aller aktuell vom Spieler kontrollierten Territorien.
+     */
+    fun ownedTerritoryCount(playerId: PlayerId): Int = territoriesOwnedBy(playerId).size
+
+    /**
      * Liefert den Spieler, der einen Kontinent vollständig kontrolliert, sonst null.
      */
     fun continentOwner(continentId: ContinentId): PlayerId? {
@@ -300,6 +324,25 @@ data class GameState(
         playerId: PlayerId,
         continentId: ContinentId,
     ): Boolean = continentOwner(continentId) == playerId
+
+    /**
+     * Alias für die Abfrage, ob ein Spieler einen Kontinent vollständig kontrolliert.
+     */
+    fun ownsContinent(
+        playerId: PlayerId,
+        continentId: ContinentId,
+    ): Boolean = playerOwnsContinent(playerId, continentId)
+
+    /**
+     * Liefert den konfigurierten Bonuswert eines Kontinents.
+     */
+    fun continentBonus(continentId: ContinentId): Int =
+        requireMapDefinition()
+            .continentsById[continentId]
+            ?.bonusValue
+            ?: throw IllegalArgumentException(
+                "Continent '$continentId' ist in der MapDefinition nicht vorhanden.",
+            )
 
     /**
      * Liefert alle vollständig kontrollierten Kontinente eines Spielers.
@@ -361,8 +404,8 @@ data class GameState(
     fun bonusFor(playerId: PlayerId): Int =
         mapDefinition
             ?.continents
-            ?.filter { continent -> continentOwner(continent.continentId) == playerId }
-            ?.sumOf { continent -> continent.bonusValue }
+            ?.filter { continent -> ownsContinent(playerId, continent.continentId) }
+            ?.sumOf { continent -> continentBonus(continent.continentId) }
             ?: 0
 
     /**
@@ -421,6 +464,19 @@ data class GameState(
             territoryStates = territoryStates + (territoryState.territoryId to territoryState),
         )
     }
+
+    /**
+     * Setzt den ausstehenden Verstärkungspool auf einen absoluten Wert.
+     */
+    internal fun withPendingReinforcements(
+        playerId: PlayerId,
+        amount: Int,
+    ): GameState = copy(pendingReinforcements = PendingReinforcements(playerId = playerId, amount = amount))
+
+    /**
+     * Entfernt den ausstehenden Verstärkungspool vollständig.
+     */
+    internal fun withoutPendingReinforcements(): GameState = copy(pendingReinforcements = null)
 
     /**
      * Liefert einen initialen State für eine einzelne Lobby.

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/GameState.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/GameState.kt
@@ -1,6 +1,7 @@
 package at.aau.pulverfass.shared.lobby.state
 
 import at.aau.pulverfass.shared.event.EventContext
+import at.aau.pulverfass.shared.ids.CardId
 import at.aau.pulverfass.shared.ids.ContinentId
 import at.aau.pulverfass.shared.ids.LobbyCode
 import at.aau.pulverfass.shared.ids.PlayerId
@@ -37,6 +38,10 @@ import at.aau.pulverfass.shared.map.config.TerritoryEdgeDefinition
  * @property territoryStates mutierbarer Laufzeitzustand aller Territorien
  * @property setupTroopsToPlaceByPlayer verbleibende Starttruppen pro Spieler nach der initialen Gebietsverteilung
  * @property pendingReinforcements verbleibender Verstärkungspool eines Spielers für Phase 1
+ * @property handState autoritative Kartenhände aller Spieler
+ * @property deckState Platzhalter für den serverseitigen Kartenstapel
+ * @property discardPileState Platzhalter für den serverseitigen Ablagestapel
+ * @property tradedInSetCount globaler Zähler aller bereits eingetauschten Kartensets dieser Lobby
  */
 data class GameState(
     val lobbyCode: LobbyCode,
@@ -60,6 +65,10 @@ data class GameState(
     val territoryStates: Map<TerritoryId, TerritoryState> = emptyMap(),
     val setupTroopsToPlaceByPlayer: Map<PlayerId, Int> = players.associateWith { 0 },
     val pendingReinforcements: PendingReinforcements? = null,
+    val handState: HandState = HandState(),
+    val deckState: DeckState = DeckState(),
+    val discardPileState: DiscardPileState = DiscardPileState(),
+    val tradedInSetCount: Int = 0,
 ) {
     init {
         require(turnNumber >= 0) {
@@ -70,6 +79,9 @@ data class GameState(
         }
         require(processedEventCount >= 0) {
             "GameState.processedEventCount darf nicht negativ sein, war aber $processedEventCount."
+        }
+        require(tradedInSetCount >= 0) {
+            "GameState.tradedInSetCount darf nicht negativ sein, war aber $tradedInSetCount."
         }
         require(players == players.distinct()) {
             "GameState.players darf keine Duplikate enthalten."
@@ -85,6 +97,9 @@ data class GameState(
         }
         require(pendingReinforcements == null || players.contains(pendingReinforcements.playerId)) {
             "GameState.pendingReinforcements.playerId muss Teil der Spielerliste sein."
+        }
+        require(handState.cardsByPlayer.keys.all(players::contains)) {
+            "GameState.handState darf nur Karten für bekannte Spieler enthalten."
         }
         require(turnOrder == turnOrder.distinct()) {
             "GameState.turnOrder darf keine Duplikate enthalten."
@@ -129,6 +144,10 @@ data class GameState(
         require((mapDefinition == null) == territoryStates.isEmpty()) {
             "GameState.mapDefinition und GameState.territoryStates müssen " +
                 "gemeinsam gesetzt oder leer sein."
+        }
+        require(allCardIds().distinct().size == allCardIds().size) {
+            "GameState.handState, deckState und discardPileState dürfen " +
+                "keine CardIds mehrfach enthalten."
         }
 
         if (mapDefinition != null) {
@@ -211,6 +230,24 @@ data class GameState(
      * Prüft, ob aktuell noch ausstehende Verstärkungen vorhanden sind.
      */
     fun hasPendingReinforcements(): Boolean = (pendingReinforcements?.amount ?: 0) > 0
+
+    /**
+     * Liefert die Kartenhand eines Spielers in stabiler Einfügereihenfolge.
+     */
+    fun handOf(playerId: PlayerId): List<CardState> = handState.cardsOf(playerId)
+
+    /**
+     * Liefert die aktuelle Handgröße eines Spielers.
+     */
+    fun handSizeOf(playerId: PlayerId): Int = handState.handSizeOf(playerId)
+
+    /**
+     * Prüft, ob ein Spieler eine konkrete Karte besitzt.
+     */
+    fun playerHasCard(
+        playerId: PlayerId,
+        cardId: CardId,
+    ): Boolean = handState.contains(playerId, cardId)
 
     /**
      * Liefert alle Laufzeit-Territorien in stabiler Map-Reihenfolge.
@@ -482,6 +519,49 @@ data class GameState(
     internal fun withoutPendingReinforcements(): GameState = copy(pendingReinforcements = null)
 
     /**
+     * Fügt der Hand eines Spielers eine Karte hinzu.
+     */
+    internal fun withCardAddedToHand(
+        playerId: PlayerId,
+        card: CardState,
+    ): GameState {
+        require(hasPlayer(playerId)) {
+            "Spieler '${playerId.value}' ist nicht Teil der Lobby '${lobbyCode.value}'."
+        }
+        require(card.cardId !in deckState.cards.map(CardState::cardId)) {
+            "Card '${card.cardId.value}' ist noch im Deck vorhanden."
+        }
+        require(card.cardId !in discardPileState.cards.map(CardState::cardId)) {
+            "Card '${card.cardId.value}' ist bereits im DiscardPile vorhanden."
+        }
+
+        return copy(
+            handState = handState.withCardAdded(playerId, card),
+        )
+    }
+
+    /**
+     * Entfernt genau eine Karte aus der Hand eines Spielers.
+     */
+    internal fun withoutCardFromHand(
+        playerId: PlayerId,
+        cardId: CardId,
+    ): GameState {
+        require(hasPlayer(playerId)) {
+            "Spieler '${playerId.value}' ist nicht Teil der Lobby '${lobbyCode.value}'."
+        }
+
+        return copy(
+            handState = handState.withoutCard(playerId, cardId),
+        )
+    }
+
+    /**
+     * Setzt den globalen Trade-In-Zähler auf einen absoluten Wert.
+     */
+    internal fun withTradedInSetCount(count: Int): GameState = copy(tradedInSetCount = count)
+
+    /**
      * Liefert einen initialen State für eine einzelne Lobby.
      */
     companion object {
@@ -531,6 +611,11 @@ data class GameState(
             processedEventCount = processedEventCount + 1,
             lastEventContext = context,
         )
+
+    private fun allCardIds(): List<CardId> =
+        handState.cardsByPlayer.values.flatten().map(CardState::cardId) +
+            deckState.cards.map(CardState::cardId) +
+            discardPileState.cards.map(CardState::cardId)
 
     private fun requireMapDefinition(): MapDefinition =
         mapDefinition

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/HandState.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/HandState.kt
@@ -1,0 +1,64 @@
+package at.aau.pulverfass.shared.lobby.state
+
+import at.aau.pulverfass.shared.ids.CardId
+import at.aau.pulverfass.shared.ids.PlayerId
+import kotlinx.serialization.Serializable
+
+/**
+ * Kartenhände aller Spieler.
+ */
+@Serializable
+data class HandState(
+    val cardsByPlayer: Map<PlayerId, List<CardState>> = emptyMap(),
+) {
+    init {
+        validateDistinctCardIds(cardsByPlayer.values.flatten(), "HandState")
+    }
+
+    fun cardsOf(playerId: PlayerId): List<CardState> = cardsByPlayer[playerId].orEmpty()
+
+    fun contains(
+        playerId: PlayerId,
+        cardId: CardId,
+    ): Boolean {
+        return cardsOf(playerId).any { card -> card.cardId == cardId }
+    }
+
+    fun handSizeOf(playerId: PlayerId): Int = cardsOf(playerId).size
+
+    internal fun withCardAdded(
+        playerId: PlayerId,
+        card: CardState,
+    ): HandState {
+        require(
+            cardsByPlayer.values.flatten().none { existing ->
+                existing.cardId == card.cardId
+            },
+        ) {
+            "Card '${card.cardId.value}' ist bereits in einer Hand vorhanden."
+        }
+
+        return copy(
+            cardsByPlayer = cardsByPlayer + (playerId to (cardsOf(playerId) + card)),
+        )
+    }
+
+    internal fun withoutCard(
+        playerId: PlayerId,
+        cardId: CardId,
+    ): HandState {
+        require(contains(playerId, cardId)) {
+            "Card '${cardId.value}' ist nicht in der Hand von Spieler '${playerId.value}'."
+        }
+
+        val remainingCards = cardsOf(playerId).filterNot { card -> card.cardId == cardId }
+        val updatedCardsByPlayer =
+            if (remainingCards.isEmpty()) {
+                cardsByPlayer - playerId
+            } else {
+                cardsByPlayer + (playerId to remainingCards)
+            }
+
+        return copy(cardsByPlayer = updatedCardsByPlayer)
+    }
+}

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/PendingReinforcements.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/PendingReinforcements.kt
@@ -1,0 +1,19 @@
+package at.aau.pulverfass.shared.lobby.state
+
+import at.aau.pulverfass.shared.ids.PlayerId
+import kotlinx.serialization.Serializable
+
+/**
+ * Verbleibender Verstärkungspool eines Spielers für die Reinforcement-Phase.
+ */
+@Serializable
+data class PendingReinforcements(
+    val playerId: PlayerId,
+    val amount: Int,
+) {
+    init {
+        require(amount >= 0) {
+            "PendingReinforcements.amount darf nicht negativ sein, war aber $amount."
+        }
+    }
+}

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/TradeInProgression.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/TradeInProgression.kt
@@ -1,0 +1,20 @@
+package at.aau.pulverfass.shared.lobby.state
+
+/**
+ * Deterministische Progression der Verstärkungswerte für global eingetauschte Kartensets.
+ */
+object TradeInProgression {
+    fun tradeInValue(tradeIndex1Based: Int): Int =
+        when (tradeIndex1Based) {
+            1 -> 2
+            2 -> 4
+            3 -> 6
+            4 -> 8
+            else -> {
+                require(tradeIndex1Based >= 5) {
+                    "tradeIndex1Based muss positiv sein, war aber $tradeIndex1Based."
+                }
+                10
+            }
+        }
+}

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/map/config/MapConfig.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/map/config/MapConfig.kt
@@ -46,11 +46,5 @@ data class TerritoryEdgeConfig(
 data class ContinentConfig(
     val continentId: ContinentId,
     val territoryIds: List<TerritoryId>,
-    val bonusValue: Int,
-) {
-    init {
-        require(bonusValue >= 0) {
-            "ContinentConfig.bonusValue darf nicht negativ sein, war aber $bonusValue."
-        }
-    }
-}
+    val bonus: Int,
+)

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/map/config/MapConfig.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/map/config/MapConfig.kt
@@ -17,7 +17,7 @@ data class MapConfig(
     val continents: List<ContinentConfig>,
 ) {
     companion object {
-        const val CURRENT_SCHEMA_VERSION: Int = 1
+        const val CURRENT_SCHEMA_VERSION: Int = 2
     }
 }
 

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/map/config/MapConfigValidator.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/map/config/MapConfigValidator.kt
@@ -69,6 +69,12 @@ object MapConfigValidator {
                             "mindestens ein Territory enthalten.",
                     )
                 }
+                if (continent.bonus < 0) {
+                    throw MapConfigValidationException(
+                        "Continent '${continent.continentId.value}' darf keinen negativen " +
+                            "Bonus haben, war aber ${continent.bonus}.",
+                    )
+                }
 
                 val localTerritories = LinkedHashSet<TerritoryId>()
                 continent.territoryIds.forEach { territoryId ->
@@ -102,7 +108,7 @@ object MapConfigValidator {
                 ContinentDefinition(
                     continentId = continent.continentId,
                     territoryIds = continent.territoryIds,
-                    bonusValue = continent.bonusValue,
+                    bonusValue = continent.bonus,
                 )
             }
 

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/codec/NetworkPayloadRegistry.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/codec/NetworkPayloadRegistry.kt
@@ -12,6 +12,7 @@ import at.aau.pulverfass.shared.message.lobby.event.GameStateDeltaEvent
 import at.aau.pulverfass.shared.message.lobby.event.GameStateSnapshotBroadcast
 import at.aau.pulverfass.shared.message.lobby.event.PhaseBoundaryEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostEvent
+import at.aau.pulverfass.shared.message.lobby.event.PlayerHandUpdatedEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerJoinedLobbyEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerKickedLobbyEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerLeftLobbyEvent
@@ -28,6 +29,7 @@ import at.aau.pulverfass.shared.message.lobby.request.MapGetRequest
 import at.aau.pulverfass.shared.message.lobby.request.PlaceReinforcementsRequest
 import at.aau.pulverfass.shared.message.lobby.request.StartGameRequest
 import at.aau.pulverfass.shared.message.lobby.request.StartPlayerSetRequest
+import at.aau.pulverfass.shared.message.lobby.request.TradeInCardsRequest
 import at.aau.pulverfass.shared.message.lobby.request.TurnAdvanceRequest
 import at.aau.pulverfass.shared.message.lobby.request.TurnStateGetRequest
 import at.aau.pulverfass.shared.message.lobby.response.ConfirmReinforcementsDoneResponse
@@ -42,6 +44,7 @@ import at.aau.pulverfass.shared.message.lobby.response.MapGetResponse
 import at.aau.pulverfass.shared.message.lobby.response.PlaceReinforcementsResponse
 import at.aau.pulverfass.shared.message.lobby.response.StartGameResponse
 import at.aau.pulverfass.shared.message.lobby.response.StartPlayerSetResponse
+import at.aau.pulverfass.shared.message.lobby.response.TradeInCardsResponse
 import at.aau.pulverfass.shared.message.lobby.response.TurnAdvanceResponse
 import at.aau.pulverfass.shared.message.lobby.response.TurnStateGetResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.ConfirmReinforcementsDoneErrorResponse
@@ -55,6 +58,7 @@ import at.aau.pulverfass.shared.message.lobby.response.error.MapGetErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.PlaceReinforcementsErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.StartGameErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.StartPlayerSetErrorResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.TradeInCardsErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.TurnAdvanceErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.TurnStateGetErrorResponse
 import at.aau.pulverfass.shared.message.protocol.MessageType
@@ -108,6 +112,7 @@ internal object NetworkPayloadRegistry {
             StartGameResponse::class.java to MessageType.LOBBY_START_RESPONSE,
             StartGameErrorResponse::class.java to MessageType.LOBBY_START_ERROR_RESPONSE,
             GameStartedEvent::class.java to MessageType.LOBBY_GAME_STARTED_BROADCAST,
+            PlayerHandUpdatedEvent::class.java to MessageType.LOBBY_PLAYER_HAND_UPDATED_EVENT,
             GameStateDeltaEvent::class.java to MessageType.LOBBY_GAME_STATE_DELTA_BROADCAST,
             PhaseBoundaryEvent::class.java to MessageType.LOBBY_PHASE_BOUNDARY_BROADCAST,
             GameStateSnapshotBroadcast::class.java to
@@ -133,6 +138,10 @@ internal object NetworkPayloadRegistry {
                 MessageType.LOBBY_PLACE_REINFORCEMENTS_RESPONSE,
             PlaceReinforcementsErrorResponse::class.java to
                 MessageType.LOBBY_PLACE_REINFORCEMENTS_ERROR_RESPONSE,
+            TradeInCardsRequest::class.java to MessageType.LOBBY_TRADE_IN_CARDS_REQUEST,
+            TradeInCardsResponse::class.java to MessageType.LOBBY_TRADE_IN_CARDS_RESPONSE,
+            TradeInCardsErrorResponse::class.java to
+                MessageType.LOBBY_TRADE_IN_CARDS_ERROR_RESPONSE,
             StartPlayerSetRequest::class.java to
                 MessageType.LOBBY_START_PLAYER_SET_REQUEST,
             StartPlayerSetResponse::class.java to
@@ -199,6 +208,7 @@ internal object NetworkPayloadRegistry {
             StartGameResponse::class.java to encodeWith(StartGameResponse.serializer()),
             StartGameErrorResponse::class.java to encodeWith(StartGameErrorResponse.serializer()),
             GameStartedEvent::class.java to encodeWith(GameStartedEvent.serializer()),
+            PlayerHandUpdatedEvent::class.java to encodeWith(PlayerHandUpdatedEvent.serializer()),
             GameStateDeltaEvent::class.java to encodeWith(GameStateDeltaEvent.serializer()),
             PhaseBoundaryEvent::class.java to encodeWith(PhaseBoundaryEvent.serializer()),
             GameStateSnapshotBroadcast::class.java to
@@ -223,6 +233,10 @@ internal object NetworkPayloadRegistry {
                 encodeWith(PlaceReinforcementsResponse.serializer()),
             PlaceReinforcementsErrorResponse::class.java to
                 encodeWith(PlaceReinforcementsErrorResponse.serializer()),
+            TradeInCardsRequest::class.java to encodeWith(TradeInCardsRequest.serializer()),
+            TradeInCardsResponse::class.java to encodeWith(TradeInCardsResponse.serializer()),
+            TradeInCardsErrorResponse::class.java to
+                encodeWith(TradeInCardsErrorResponse.serializer()),
             StartPlayerSetRequest::class.java to encodeWith(StartPlayerSetRequest.serializer()),
             StartPlayerSetResponse::class.java to encodeWith(StartPlayerSetResponse.serializer()),
             StartPlayerSetErrorResponse::class.java to
@@ -292,6 +306,8 @@ internal object NetworkPayloadRegistry {
             MessageType.LOBBY_START_ERROR_RESPONSE to
                 decodeWith(StartGameErrorResponse.serializer()),
             MessageType.LOBBY_GAME_STARTED_BROADCAST to decodeWith(GameStartedEvent.serializer()),
+            MessageType.LOBBY_PLAYER_HAND_UPDATED_EVENT to
+                decodeWith(PlayerHandUpdatedEvent.serializer()),
             MessageType.LOBBY_GAME_STATE_DELTA_BROADCAST to
                 decodeWith(GameStateDeltaEvent.serializer()),
             MessageType.LOBBY_PHASE_BOUNDARY_BROADCAST to
@@ -320,6 +336,12 @@ internal object NetworkPayloadRegistry {
                 decodeWith(PlaceReinforcementsResponse.serializer()),
             MessageType.LOBBY_PLACE_REINFORCEMENTS_ERROR_RESPONSE to
                 decodeWith(PlaceReinforcementsErrorResponse.serializer()),
+            MessageType.LOBBY_TRADE_IN_CARDS_REQUEST to
+                decodeWith(TradeInCardsRequest.serializer()),
+            MessageType.LOBBY_TRADE_IN_CARDS_RESPONSE to
+                decodeWith(TradeInCardsResponse.serializer()),
+            MessageType.LOBBY_TRADE_IN_CARDS_ERROR_RESPONSE to
+                decodeWith(TradeInCardsErrorResponse.serializer()),
             MessageType.LOBBY_START_PLAYER_SET_REQUEST to
                 decodeWith(StartPlayerSetRequest.serializer()),
             MessageType.LOBBY_START_PLAYER_SET_RESPONSE to

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/codec/NetworkPayloadRegistry.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/codec/NetworkPayloadRegistry.kt
@@ -1,5 +1,6 @@
 package at.aau.pulverfass.shared.message.codec
 
+import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsChangedEvent
 import at.aau.pulverfass.shared.lobby.event.TerritoryOwnerChangedEvent
 import at.aau.pulverfass.shared.lobby.event.TerritoryTroopsChangedEvent
 import at.aau.pulverfass.shared.lobby.event.TurnStateUpdatedEvent
@@ -14,6 +15,8 @@ import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerJoinedLobbyEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerKickedLobbyEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerLeftLobbyEvent
+import at.aau.pulverfass.shared.message.lobby.event.ReinforcementsGrantedEvent
+import at.aau.pulverfass.shared.message.lobby.request.ConfirmReinforcementsDoneRequest
 import at.aau.pulverfass.shared.message.lobby.request.CreateLobbyRequest
 import at.aau.pulverfass.shared.message.lobby.request.GameStateCatchUpRequest
 import at.aau.pulverfass.shared.message.lobby.request.GameStatePrivateGetRequest
@@ -22,10 +25,12 @@ import at.aau.pulverfass.shared.message.lobby.request.KickPlayerRequest
 import at.aau.pulverfass.shared.message.lobby.request.LeaveLobbyRequest
 import at.aau.pulverfass.shared.message.lobby.request.LobbyPlayerCountRequest
 import at.aau.pulverfass.shared.message.lobby.request.MapGetRequest
+import at.aau.pulverfass.shared.message.lobby.request.PlaceReinforcementsRequest
 import at.aau.pulverfass.shared.message.lobby.request.StartGameRequest
 import at.aau.pulverfass.shared.message.lobby.request.StartPlayerSetRequest
 import at.aau.pulverfass.shared.message.lobby.request.TurnAdvanceRequest
 import at.aau.pulverfass.shared.message.lobby.request.TurnStateGetRequest
+import at.aau.pulverfass.shared.message.lobby.response.ConfirmReinforcementsDoneResponse
 import at.aau.pulverfass.shared.message.lobby.response.CreateLobbyResponse
 import at.aau.pulverfass.shared.message.lobby.response.GameStateCatchUpResponse
 import at.aau.pulverfass.shared.message.lobby.response.GameStatePrivateGetResponse
@@ -34,10 +39,12 @@ import at.aau.pulverfass.shared.message.lobby.response.KickPlayerResponse
 import at.aau.pulverfass.shared.message.lobby.response.LeaveLobbyResponse
 import at.aau.pulverfass.shared.message.lobby.response.LobbyPlayerCountResponse
 import at.aau.pulverfass.shared.message.lobby.response.MapGetResponse
+import at.aau.pulverfass.shared.message.lobby.response.PlaceReinforcementsResponse
 import at.aau.pulverfass.shared.message.lobby.response.StartGameResponse
 import at.aau.pulverfass.shared.message.lobby.response.StartPlayerSetResponse
 import at.aau.pulverfass.shared.message.lobby.response.TurnAdvanceResponse
 import at.aau.pulverfass.shared.message.lobby.response.TurnStateGetResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.ConfirmReinforcementsDoneErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.CreateLobbyErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.GameStateCatchUpErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.GameStatePrivateGetErrorResponse
@@ -45,6 +52,7 @@ import at.aau.pulverfass.shared.message.lobby.response.error.JoinLobbyErrorRespo
 import at.aau.pulverfass.shared.message.lobby.response.error.KickPlayerErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.LobbyPlayerCountErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.MapGetErrorResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.PlaceReinforcementsErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.StartGameErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.StartPlayerSetErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.TurnAdvanceErrorResponse
@@ -66,6 +74,12 @@ internal object NetworkPayloadRegistry {
             ConnectionResponse::class.java to MessageType.CONNECTION_RESPONSE,
             ReconnectRequest::class.java to MessageType.CONNECTION_RECONNECT_REQUEST,
             ReconnectResponse::class.java to MessageType.CONNECTION_RECONNECT_RESPONSE,
+            ConfirmReinforcementsDoneRequest::class.java to
+                MessageType.LOBBY_CONFIRM_REINFORCEMENTS_DONE_REQUEST,
+            ConfirmReinforcementsDoneResponse::class.java to
+                MessageType.LOBBY_CONFIRM_REINFORCEMENTS_DONE_RESPONSE,
+            ConfirmReinforcementsDoneErrorResponse::class.java to
+                MessageType.LOBBY_CONFIRM_REINFORCEMENTS_DONE_ERROR_RESPONSE,
             CreateLobbyRequest::class.java to MessageType.LOBBY_CREATE_REQUEST,
             CreateLobbyErrorResponse::class.java to MessageType.LOBBY_CREATE_ERROR_RESPONSE,
             CreateLobbyResponse::class.java to MessageType.LOBBY_CREATE_RESPONSE,
@@ -79,6 +93,10 @@ internal object NetworkPayloadRegistry {
             LobbyPlayerCountResponse::class.java to MessageType.LOBBY_PLAYER_COUNT_RESPONSE,
             LobbyPlayerCountErrorResponse::class.java to
                 MessageType.LOBBY_PLAYER_COUNT_ERROR_RESPONSE,
+            PendingReinforcementsChangedEvent::class.java to
+                MessageType.LOBBY_PENDING_REINFORCEMENTS_CHANGED_BROADCAST,
+            ReinforcementsGrantedEvent::class.java to
+                MessageType.LOBBY_REINFORCEMENTS_GRANTED_BROADCAST,
             LeaveLobbyRequest::class.java to MessageType.LOBBY_LEAVE_REQUEST,
             LeaveLobbyResponse::class.java to MessageType.LOBBY_LEAVE_RESPONSE,
             PlayerLeftLobbyEvent::class.java to MessageType.LOBBY_PLAYER_LEFT_BROADCAST,
@@ -109,6 +127,12 @@ internal object NetworkPayloadRegistry {
             MapGetRequest::class.java to MessageType.LOBBY_MAP_GET_REQUEST,
             MapGetResponse::class.java to MessageType.LOBBY_MAP_GET_RESPONSE,
             MapGetErrorResponse::class.java to MessageType.LOBBY_MAP_GET_ERROR_RESPONSE,
+            PlaceReinforcementsRequest::class.java to
+                MessageType.LOBBY_PLACE_REINFORCEMENTS_REQUEST,
+            PlaceReinforcementsResponse::class.java to
+                MessageType.LOBBY_PLACE_REINFORCEMENTS_RESPONSE,
+            PlaceReinforcementsErrorResponse::class.java to
+                MessageType.LOBBY_PLACE_REINFORCEMENTS_ERROR_RESPONSE,
             StartPlayerSetRequest::class.java to
                 MessageType.LOBBY_START_PLAYER_SET_REQUEST,
             StartPlayerSetResponse::class.java to
@@ -136,6 +160,12 @@ internal object NetworkPayloadRegistry {
             ConnectionResponse::class.java to encodeWith(ConnectionResponse.serializer()),
             ReconnectRequest::class.java to encodeWith(ReconnectRequest.serializer()),
             ReconnectResponse::class.java to encodeWith(ReconnectResponse.serializer()),
+            ConfirmReinforcementsDoneRequest::class.java to
+                encodeWith(ConfirmReinforcementsDoneRequest.serializer()),
+            ConfirmReinforcementsDoneResponse::class.java to
+                encodeWith(ConfirmReinforcementsDoneResponse.serializer()),
+            ConfirmReinforcementsDoneErrorResponse::class.java to
+                encodeWith(ConfirmReinforcementsDoneErrorResponse.serializer()),
             CreateLobbyRequest::class.java to encodeWith(CreateLobbyRequest.serializer()),
             CreateLobbyErrorResponse::class.java to
                 encodeWith(CreateLobbyErrorResponse.serializer()),
@@ -153,6 +183,10 @@ internal object NetworkPayloadRegistry {
                 encodeWith(LobbyPlayerCountResponse.serializer()),
             LobbyPlayerCountErrorResponse::class.java to
                 encodeWith(LobbyPlayerCountErrorResponse.serializer()),
+            PendingReinforcementsChangedEvent::class.java to
+                encodeWith(PendingReinforcementsChangedEvent.serializer()),
+            ReinforcementsGrantedEvent::class.java to
+                encodeWith(ReinforcementsGrantedEvent.serializer()),
             LeaveLobbyRequest::class.java to encodeWith(LeaveLobbyRequest.serializer()),
             LeaveLobbyResponse::class.java to encodeWith(LeaveLobbyResponse.serializer()),
             PlayerLeftLobbyEvent::class.java to encodeWith(PlayerLeftLobbyEvent.serializer()),
@@ -183,6 +217,12 @@ internal object NetworkPayloadRegistry {
             MapGetRequest::class.java to encodeWith(MapGetRequest.serializer()),
             MapGetResponse::class.java to encodeWith(MapGetResponse.serializer()),
             MapGetErrorResponse::class.java to encodeWith(MapGetErrorResponse.serializer()),
+            PlaceReinforcementsRequest::class.java to
+                encodeWith(PlaceReinforcementsRequest.serializer()),
+            PlaceReinforcementsResponse::class.java to
+                encodeWith(PlaceReinforcementsResponse.serializer()),
+            PlaceReinforcementsErrorResponse::class.java to
+                encodeWith(PlaceReinforcementsErrorResponse.serializer()),
             StartPlayerSetRequest::class.java to encodeWith(StartPlayerSetRequest.serializer()),
             StartPlayerSetResponse::class.java to encodeWith(StartPlayerSetResponse.serializer()),
             StartPlayerSetErrorResponse::class.java to
@@ -209,6 +249,12 @@ internal object NetworkPayloadRegistry {
                 decodeWith(ReconnectRequest.serializer()),
             MessageType.CONNECTION_RECONNECT_RESPONSE to
                 decodeWith(ReconnectResponse.serializer()),
+            MessageType.LOBBY_CONFIRM_REINFORCEMENTS_DONE_REQUEST to
+                decodeWith(ConfirmReinforcementsDoneRequest.serializer()),
+            MessageType.LOBBY_CONFIRM_REINFORCEMENTS_DONE_RESPONSE to
+                decodeWith(ConfirmReinforcementsDoneResponse.serializer()),
+            MessageType.LOBBY_CONFIRM_REINFORCEMENTS_DONE_ERROR_RESPONSE to
+                decodeWith(ConfirmReinforcementsDoneErrorResponse.serializer()),
             MessageType.LOBBY_CREATE_REQUEST to decodeWith(CreateLobbyRequest.serializer()),
             MessageType.LOBBY_CREATE_ERROR_RESPONSE to
                 decodeWith(CreateLobbyErrorResponse.serializer()),
@@ -227,6 +273,10 @@ internal object NetworkPayloadRegistry {
                 decodeWith(LobbyPlayerCountResponse.serializer()),
             MessageType.LOBBY_PLAYER_COUNT_ERROR_RESPONSE to
                 decodeWith(LobbyPlayerCountErrorResponse.serializer()),
+            MessageType.LOBBY_PENDING_REINFORCEMENTS_CHANGED_BROADCAST to
+                decodeWith(PendingReinforcementsChangedEvent.serializer()),
+            MessageType.LOBBY_REINFORCEMENTS_GRANTED_BROADCAST to
+                decodeWith(ReinforcementsGrantedEvent.serializer()),
             MessageType.LOBBY_LEAVE_REQUEST to decodeWith(LeaveLobbyRequest.serializer()),
             MessageType.LOBBY_LEAVE_RESPONSE to decodeWith(LeaveLobbyResponse.serializer()),
             MessageType.LOBBY_PLAYER_LEFT_BROADCAST to
@@ -264,6 +314,12 @@ internal object NetworkPayloadRegistry {
             MessageType.LOBBY_MAP_GET_RESPONSE to decodeWith(MapGetResponse.serializer()),
             MessageType.LOBBY_MAP_GET_ERROR_RESPONSE to
                 decodeWith(MapGetErrorResponse.serializer()),
+            MessageType.LOBBY_PLACE_REINFORCEMENTS_REQUEST to
+                decodeWith(PlaceReinforcementsRequest.serializer()),
+            MessageType.LOBBY_PLACE_REINFORCEMENTS_RESPONSE to
+                decodeWith(PlaceReinforcementsResponse.serializer()),
+            MessageType.LOBBY_PLACE_REINFORCEMENTS_ERROR_RESPONSE to
+                decodeWith(PlaceReinforcementsErrorResponse.serializer()),
             MessageType.LOBBY_START_PLAYER_SET_REQUEST to
                 decodeWith(StartPlayerSetRequest.serializer()),
             MessageType.LOBBY_START_PLAYER_SET_RESPONSE to

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/event/PlayerHandUpdatedEvent.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/event/PlayerHandUpdatedEvent.kt
@@ -1,0 +1,192 @@
+package at.aau.pulverfass.shared.message.lobby.event
+
+import at.aau.pulverfass.shared.ids.CardId
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.lobby.state.CardState
+import at.aau.pulverfass.shared.lobby.state.CardType
+import at.aau.pulverfass.shared.lobby.state.GameState
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.MissingFieldException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+@Serializable(with = PlayerHandUpdatedEventSerializer::class)
+data class PlayerHandUpdatedEvent(
+    val lobbyCode: LobbyCode,
+    override val recipientPlayerId: PlayerId,
+    val stateVersion: Long,
+    val handCards: List<PrivateHandCardSnapshot>,
+) : PrivateGameEvent {
+    companion object {
+        fun fromGameState(
+            gameState: GameState,
+            recipientPlayerId: PlayerId,
+        ): PlayerHandUpdatedEvent {
+            require(gameState.hasPlayer(recipientPlayerId)) {
+                "Spieler '${recipientPlayerId.value}' ist nicht Teil der Lobby " +
+                    "'${gameState.lobbyCode.value}'."
+            }
+
+            return PlayerHandUpdatedEvent(
+                lobbyCode = gameState.lobbyCode,
+                recipientPlayerId = recipientPlayerId,
+                stateVersion = gameState.stateVersion,
+                handCards = gameState.handOf(recipientPlayerId).map(PrivateHandCardSnapshot::from),
+            )
+        }
+    }
+}
+
+@Serializable(with = PrivateHandCardSnapshotSerializer::class)
+data class PrivateHandCardSnapshot(
+    val cardId: CardId,
+    val type: CardType,
+) {
+    companion object {
+        fun from(card: CardState): PrivateHandCardSnapshot =
+            PrivateHandCardSnapshot(cardId = card.cardId, type = card.type)
+    }
+}
+
+object PlayerHandUpdatedEventSerializer : KSerializer<PlayerHandUpdatedEvent> {
+    private val handCardsSerializer = ListSerializer(PrivateHandCardSnapshot.serializer())
+
+    override val descriptor =
+        buildClassSerialDescriptor(
+            "at.aau.pulverfass.shared.network.message.PlayerHandUpdatedEvent",
+        ) {
+            element("lobbyCode", LobbyCode.serializer().descriptor)
+            element("recipientPlayerId", PlayerId.serializer().descriptor)
+            element<Long>("stateVersion")
+            element("handCards", handCardsSerializer.descriptor)
+        }
+
+    override fun serialize(
+        encoder: Encoder,
+        value: PlayerHandUpdatedEvent,
+    ) {
+        val composite = encoder.beginStructure(descriptor)
+        composite.encodeSerializableElement(descriptor, 0, LobbyCode.serializer(), value.lobbyCode)
+        composite.encodeSerializableElement(
+            descriptor,
+            1,
+            PlayerId.serializer(),
+            value.recipientPlayerId,
+        )
+        composite.encodeLongElement(descriptor, 2, value.stateVersion)
+        composite.encodeSerializableElement(descriptor, 3, handCardsSerializer, value.handCards)
+        composite.endStructure(descriptor)
+    }
+
+    override fun deserialize(decoder: Decoder): PlayerHandUpdatedEvent {
+        val composite = decoder.beginStructure(descriptor)
+        var lobbyCode: LobbyCode? = null
+        var recipientPlayerId: PlayerId? = null
+        var stateVersion: Long? = null
+        var handCards: List<PrivateHandCardSnapshot>? = null
+
+        loop@ while (true) {
+            when (val index = composite.decodeElementIndex(descriptor)) {
+                0 ->
+                    lobbyCode =
+                        composite.decodeSerializableElement(
+                            descriptor,
+                            0,
+                            LobbyCode.serializer(),
+                        )
+                1 ->
+                    recipientPlayerId =
+                        composite.decodeSerializableElement(
+                            descriptor,
+                            1,
+                            PlayerId.serializer(),
+                        )
+                2 -> stateVersion = composite.decodeLongElement(descriptor, 2)
+                3 ->
+                    handCards =
+                        composite.decodeSerializableElement(
+                            descriptor,
+                            3,
+                            handCardsSerializer,
+                        )
+                CompositeDecoder.DECODE_DONE -> break@loop
+                else -> throw IllegalArgumentException("Unexpected index $index")
+            }
+        }
+
+        composite.endStructure(descriptor)
+        return PlayerHandUpdatedEvent(
+            lobbyCode =
+                lobbyCode
+                    ?: throw MissingFieldException("lobbyCode", descriptor.serialName),
+            recipientPlayerId =
+                recipientPlayerId
+                    ?: throw MissingFieldException("recipientPlayerId", descriptor.serialName),
+            stateVersion =
+                stateVersion
+                    ?: throw MissingFieldException("stateVersion", descriptor.serialName),
+            handCards =
+                handCards
+                    ?: throw MissingFieldException("handCards", descriptor.serialName),
+        )
+    }
+}
+
+object PrivateHandCardSnapshotSerializer : KSerializer<PrivateHandCardSnapshot> {
+    override val descriptor =
+        buildClassSerialDescriptor(
+            "at.aau.pulverfass.shared.network.message.PrivateHandCardSnapshot",
+        ) {
+            element("cardId", CardId.serializer().descriptor)
+            element("type", CardType.serializer().descriptor)
+        }
+
+    override fun serialize(
+        encoder: Encoder,
+        value: PrivateHandCardSnapshot,
+    ) {
+        val composite = encoder.beginStructure(descriptor)
+        composite.encodeSerializableElement(descriptor, 0, CardId.serializer(), value.cardId)
+        composite.encodeSerializableElement(descriptor, 1, CardType.serializer(), value.type)
+        composite.endStructure(descriptor)
+    }
+
+    override fun deserialize(decoder: Decoder): PrivateHandCardSnapshot {
+        val composite = decoder.beginStructure(descriptor)
+        var cardId: CardId? = null
+        var type: CardType? = null
+
+        loop@ while (true) {
+            when (val index = composite.decodeElementIndex(descriptor)) {
+                0 ->
+                    cardId =
+                        composite.decodeSerializableElement(
+                            descriptor,
+                            0,
+                            CardId.serializer(),
+                        )
+                1 ->
+                    type =
+                        composite.decodeSerializableElement(
+                            descriptor,
+                            1,
+                            CardType.serializer(),
+                        )
+                CompositeDecoder.DECODE_DONE -> break@loop
+                else -> throw IllegalArgumentException("Unexpected index $index")
+            }
+        }
+
+        composite.endStructure(descriptor)
+        return PrivateHandCardSnapshot(
+            cardId = cardId ?: throw MissingFieldException("cardId", descriptor.serialName),
+            type = type ?: throw MissingFieldException("type", descriptor.serialName),
+        )
+    }
+}

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/event/ReinforcementsGrantedEvent.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/event/ReinforcementsGrantedEvent.kt
@@ -1,0 +1,116 @@
+package at.aau.pulverfass.shared.message.lobby.event
+
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.ids.PlayerId
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.MissingFieldException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+@Serializable(with = ReinforcementsGrantedEventSerializer::class)
+data class ReinforcementsGrantedEvent(
+    val lobbyCode: LobbyCode,
+    val playerId: PlayerId,
+    val amount: Int,
+    val territoryBonus: Int,
+    val continentBonus: Int,
+    val cardBonus: Int,
+) : PublicGameEvent {
+    init {
+        require(amount >= 0) {
+            "ReinforcementsGrantedEvent.amount darf nicht negativ sein, war aber $amount."
+        }
+        require(territoryBonus >= 0) {
+            "ReinforcementsGrantedEvent.territoryBonus darf nicht negativ sein, " +
+                "war aber $territoryBonus."
+        }
+        require(continentBonus >= 0) {
+            "ReinforcementsGrantedEvent.continentBonus darf nicht negativ sein, " +
+                "war aber $continentBonus."
+        }
+        require(cardBonus >= 0) {
+            "ReinforcementsGrantedEvent.cardBonus darf nicht negativ sein, war aber $cardBonus."
+        }
+        require(amount == territoryBonus + continentBonus + cardBonus) {
+            "ReinforcementsGrantedEvent.amount muss der Summe der Boni entsprechen."
+        }
+    }
+}
+
+object ReinforcementsGrantedEventSerializer : KSerializer<ReinforcementsGrantedEvent> {
+    override val descriptor =
+        buildClassSerialDescriptor(
+            "at.aau.pulverfass.shared.network.message.ReinforcementsGrantedEvent",
+        ) {
+            element("lobbyCode", LobbyCode.serializer().descriptor)
+            element("playerId", PlayerId.serializer().descriptor)
+            element<Int>("amount")
+            element<Int>("territoryBonus")
+            element<Int>("continentBonus")
+            element<Int>("cardBonus")
+        }
+
+    override fun serialize(
+        encoder: Encoder,
+        value: ReinforcementsGrantedEvent,
+    ) {
+        val composite = encoder.beginStructure(descriptor)
+        composite.encodeSerializableElement(descriptor, 0, LobbyCode.serializer(), value.lobbyCode)
+        composite.encodeSerializableElement(descriptor, 1, PlayerId.serializer(), value.playerId)
+        composite.encodeIntElement(descriptor, 2, value.amount)
+        composite.encodeIntElement(descriptor, 3, value.territoryBonus)
+        composite.encodeIntElement(descriptor, 4, value.continentBonus)
+        composite.encodeIntElement(descriptor, 5, value.cardBonus)
+        composite.endStructure(descriptor)
+    }
+
+    override fun deserialize(decoder: Decoder): ReinforcementsGrantedEvent {
+        val composite = decoder.beginStructure(descriptor)
+        var lobbyCode: LobbyCode? = null
+        var playerId: PlayerId? = null
+        var amount: Int? = null
+        var territoryBonus: Int? = null
+        var continentBonus: Int? = null
+        var cardBonus: Int? = null
+
+        loop@ while (true) {
+            when (val index = composite.decodeElementIndex(descriptor)) {
+                0 ->
+                    lobbyCode =
+                        composite.decodeSerializableElement(descriptor, 0, LobbyCode.serializer())
+                1 ->
+                    playerId =
+                        composite.decodeSerializableElement(descriptor, 1, PlayerId.serializer())
+                2 -> amount = composite.decodeIntElement(descriptor, 2)
+                3 -> territoryBonus = composite.decodeIntElement(descriptor, 3)
+                4 -> continentBonus = composite.decodeIntElement(descriptor, 4)
+                5 -> cardBonus = composite.decodeIntElement(descriptor, 5)
+                CompositeDecoder.DECODE_DONE -> break@loop
+                else -> throw IllegalArgumentException("Unexpected index $index")
+            }
+        }
+
+        composite.endStructure(descriptor)
+        return ReinforcementsGrantedEvent(
+            lobbyCode =
+                lobbyCode
+                    ?: throw MissingFieldException("lobbyCode", descriptor.serialName),
+            playerId =
+                playerId
+                    ?: throw MissingFieldException("playerId", descriptor.serialName),
+            amount = amount ?: throw MissingFieldException("amount", descriptor.serialName),
+            territoryBonus =
+                territoryBonus
+                    ?: throw MissingFieldException("territoryBonus", descriptor.serialName),
+            continentBonus =
+                continentBonus
+                    ?: throw MissingFieldException("continentBonus", descriptor.serialName),
+            cardBonus =
+                cardBonus ?: throw MissingFieldException("cardBonus", descriptor.serialName),
+        )
+    }
+}

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/request/ConfirmReinforcementsDoneRequest.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/request/ConfirmReinforcementsDoneRequest.kt
@@ -1,0 +1,74 @@
+package at.aau.pulverfass.shared.message.lobby.request
+
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.message.protocol.NetworkMessagePayload
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.MissingFieldException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+@Serializable(with = ConfirmReinforcementsDoneRequestSerializer::class)
+data class ConfirmReinforcementsDoneRequest(
+    val lobbyCode: LobbyCode,
+    val playerId: PlayerId,
+) : NetworkMessagePayload
+
+object ConfirmReinforcementsDoneRequestSerializer : KSerializer<ConfirmReinforcementsDoneRequest> {
+    override val descriptor =
+        buildClassSerialDescriptor(
+            "at.aau.pulverfass.shared.network.message.ConfirmReinforcementsDoneRequest",
+        ) {
+            element("lobbyCode", LobbyCode.serializer().descriptor)
+            element("playerId", PlayerId.serializer().descriptor)
+        }
+
+    override fun serialize(
+        encoder: Encoder,
+        value: ConfirmReinforcementsDoneRequest,
+    ) {
+        val composite = encoder.beginStructure(descriptor)
+        composite.encodeSerializableElement(descriptor, 0, LobbyCode.serializer(), value.lobbyCode)
+        composite.encodeSerializableElement(descriptor, 1, PlayerId.serializer(), value.playerId)
+        composite.endStructure(descriptor)
+    }
+
+    override fun deserialize(decoder: Decoder): ConfirmReinforcementsDoneRequest {
+        val composite = decoder.beginStructure(descriptor)
+        var lobbyCode: LobbyCode? = null
+        var playerId: PlayerId? = null
+
+        loop@ while (true) {
+            when (val index = composite.decodeElementIndex(descriptor)) {
+                0 ->
+                    lobbyCode =
+                        composite.decodeSerializableElement(
+                            descriptor,
+                            0,
+                            LobbyCode.serializer(),
+                        )
+                1 ->
+                    playerId =
+                        composite.decodeSerializableElement(
+                            descriptor,
+                            1,
+                            PlayerId.serializer(),
+                        )
+                CompositeDecoder.DECODE_DONE -> break@loop
+                else -> throw IllegalArgumentException("Unexpected index $index")
+            }
+        }
+
+        composite.endStructure(descriptor)
+        return ConfirmReinforcementsDoneRequest(
+            lobbyCode =
+                lobbyCode
+                    ?: throw MissingFieldException("lobbyCode", descriptor.serialName),
+            playerId = playerId ?: throw MissingFieldException("playerId", descriptor.serialName),
+        )
+    }
+}

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/request/PlaceReinforcementsRequest.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/request/PlaceReinforcementsRequest.kt
@@ -1,0 +1,161 @@
+package at.aau.pulverfass.shared.message.lobby.request
+
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.ids.TerritoryId
+import at.aau.pulverfass.shared.message.protocol.NetworkMessagePayload
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.MissingFieldException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+@Serializable(with = PlaceReinforcementsRequestSerializer::class)
+data class PlaceReinforcementsRequest(
+    val lobbyCode: LobbyCode,
+    val playerId: PlayerId,
+    val placements: List<TerritoryPlacement>,
+) : NetworkMessagePayload
+
+@Serializable(with = TerritoryPlacementSerializer::class)
+data class TerritoryPlacement(
+    val territoryId: TerritoryId,
+    val amount: Int,
+) {
+    init {
+        require(amount > 0) {
+            "TerritoryPlacement.amount muss positiv sein, war aber $amount."
+        }
+    }
+}
+
+object PlaceReinforcementsRequestSerializer : KSerializer<PlaceReinforcementsRequest> {
+    private val placementsSerializer = ListSerializer(TerritoryPlacement.serializer())
+
+    override val descriptor =
+        buildClassSerialDescriptor(
+            "at.aau.pulverfass.shared.network.message.PlaceReinforcementsRequest",
+        ) {
+            element("lobbyCode", LobbyCode.serializer().descriptor)
+            element("playerId", PlayerId.serializer().descriptor)
+            element("placements", placementsSerializer.descriptor)
+        }
+
+    override fun serialize(
+        encoder: Encoder,
+        value: PlaceReinforcementsRequest,
+    ) {
+        val composite = encoder.beginStructure(descriptor)
+        composite.encodeSerializableElement(descriptor, 0, LobbyCode.serializer(), value.lobbyCode)
+        composite.encodeSerializableElement(descriptor, 1, PlayerId.serializer(), value.playerId)
+        composite.encodeSerializableElement(
+            descriptor,
+            2,
+            placementsSerializer,
+            value.placements,
+        )
+        composite.endStructure(descriptor)
+    }
+
+    override fun deserialize(decoder: Decoder): PlaceReinforcementsRequest {
+        val composite = decoder.beginStructure(descriptor)
+        var lobbyCode: LobbyCode? = null
+        var playerId: PlayerId? = null
+        var placements: List<TerritoryPlacement>? = null
+
+        loop@ while (true) {
+            when (val index = composite.decodeElementIndex(descriptor)) {
+                0 ->
+                    lobbyCode =
+                        composite.decodeSerializableElement(
+                            descriptor,
+                            0,
+                            LobbyCode.serializer(),
+                        )
+                1 ->
+                    playerId =
+                        composite.decodeSerializableElement(
+                            descriptor,
+                            1,
+                            PlayerId.serializer(),
+                        )
+                2 ->
+                    placements =
+                        composite.decodeSerializableElement(
+                            descriptor,
+                            2,
+                            placementsSerializer,
+                        )
+                CompositeDecoder.DECODE_DONE -> break@loop
+                else -> throw IllegalArgumentException("Unexpected index $index")
+            }
+        }
+
+        composite.endStructure(descriptor)
+        return PlaceReinforcementsRequest(
+            lobbyCode =
+                lobbyCode
+                    ?: throw MissingFieldException("lobbyCode", descriptor.serialName),
+            playerId = playerId ?: throw MissingFieldException("playerId", descriptor.serialName),
+            placements =
+                placements
+                    ?: throw MissingFieldException("placements", descriptor.serialName),
+        )
+    }
+}
+
+object TerritoryPlacementSerializer : KSerializer<TerritoryPlacement> {
+    override val descriptor =
+        buildClassSerialDescriptor("at.aau.pulverfass.shared.network.message.TerritoryPlacement") {
+            element("territoryId", TerritoryId.serializer().descriptor)
+            element<Int>("amount")
+        }
+
+    override fun serialize(
+        encoder: Encoder,
+        value: TerritoryPlacement,
+    ) {
+        val composite = encoder.beginStructure(descriptor)
+        composite.encodeSerializableElement(
+            descriptor,
+            0,
+            TerritoryId.serializer(),
+            value.territoryId,
+        )
+        composite.encodeIntElement(descriptor, 1, value.amount)
+        composite.endStructure(descriptor)
+    }
+
+    override fun deserialize(decoder: Decoder): TerritoryPlacement {
+        val composite = decoder.beginStructure(descriptor)
+        var territoryId: TerritoryId? = null
+        var amount: Int? = null
+
+        loop@ while (true) {
+            when (val index = composite.decodeElementIndex(descriptor)) {
+                0 ->
+                    territoryId =
+                        composite.decodeSerializableElement(
+                            descriptor,
+                            0,
+                            TerritoryId.serializer(),
+                        )
+                1 -> amount = composite.decodeIntElement(descriptor, 1)
+                CompositeDecoder.DECODE_DONE -> break@loop
+                else -> throw IllegalArgumentException("Unexpected index $index")
+            }
+        }
+
+        composite.endStructure(descriptor)
+        return TerritoryPlacement(
+            territoryId =
+                territoryId
+                    ?: throw MissingFieldException("territoryId", descriptor.serialName),
+            amount = amount ?: throw MissingFieldException("amount", descriptor.serialName),
+        )
+    }
+}

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/request/TradeInCardsRequest.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/request/TradeInCardsRequest.kt
@@ -1,0 +1,99 @@
+package at.aau.pulverfass.shared.message.lobby.request
+
+import at.aau.pulverfass.shared.ids.CardId
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.message.protocol.NetworkMessagePayload
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.MissingFieldException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+@Serializable(with = TradeInCardsRequestSerializer::class)
+data class TradeInCardsRequest(
+    val lobbyCode: LobbyCode,
+    val playerId: PlayerId,
+    val cardIds: List<CardId>,
+) : NetworkMessagePayload {
+    init {
+        require(cardIds.size == 3) {
+            "TradeInCardsRequest.cardIds muss genau 3 Karten enthalten."
+        }
+        require(cardIds.distinct().size == cardIds.size) {
+            "TradeInCardsRequest.cardIds darf keine Duplikate enthalten."
+        }
+    }
+}
+
+object TradeInCardsRequestSerializer : KSerializer<TradeInCardsRequest> {
+    private val cardIdsSerializer = ListSerializer(CardId.serializer())
+
+    override val descriptor =
+        buildClassSerialDescriptor(
+            "at.aau.pulverfass.shared.network.message.TradeInCardsRequest",
+        ) {
+            element("lobbyCode", LobbyCode.serializer().descriptor)
+            element("playerId", PlayerId.serializer().descriptor)
+            element("cardIds", cardIdsSerializer.descriptor)
+        }
+
+    override fun serialize(
+        encoder: Encoder,
+        value: TradeInCardsRequest,
+    ) {
+        val composite = encoder.beginStructure(descriptor)
+        composite.encodeSerializableElement(descriptor, 0, LobbyCode.serializer(), value.lobbyCode)
+        composite.encodeSerializableElement(descriptor, 1, PlayerId.serializer(), value.playerId)
+        composite.encodeSerializableElement(descriptor, 2, cardIdsSerializer, value.cardIds)
+        composite.endStructure(descriptor)
+    }
+
+    override fun deserialize(decoder: Decoder): TradeInCardsRequest {
+        val composite = decoder.beginStructure(descriptor)
+        var lobbyCode: LobbyCode? = null
+        var playerId: PlayerId? = null
+        var cardIds: List<CardId>? = null
+
+        loop@ while (true) {
+            when (val index = composite.decodeElementIndex(descriptor)) {
+                0 ->
+                    lobbyCode =
+                        composite.decodeSerializableElement(
+                            descriptor,
+                            0,
+                            LobbyCode.serializer(),
+                        )
+                1 ->
+                    playerId =
+                        composite.decodeSerializableElement(
+                            descriptor,
+                            1,
+                            PlayerId.serializer(),
+                        )
+                2 ->
+                    cardIds =
+                        composite.decodeSerializableElement(
+                            descriptor,
+                            2,
+                            cardIdsSerializer,
+                        )
+                CompositeDecoder.DECODE_DONE -> break@loop
+                else -> throw IllegalArgumentException("Unexpected index $index")
+            }
+        }
+
+        composite.endStructure(descriptor)
+        return TradeInCardsRequest(
+            lobbyCode =
+                lobbyCode
+                    ?: throw MissingFieldException("lobbyCode", descriptor.serialName),
+            playerId = playerId ?: throw MissingFieldException("playerId", descriptor.serialName),
+            cardIds = cardIds ?: throw MissingFieldException("cardIds", descriptor.serialName),
+        )
+    }
+}

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/ConfirmReinforcementsDoneResponse.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/ConfirmReinforcementsDoneResponse.kt
@@ -1,0 +1,62 @@
+package at.aau.pulverfass.shared.message.lobby.response
+
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.message.protocol.NetworkMessagePayload
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.MissingFieldException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+@Serializable(with = ConfirmReinforcementsDoneResponseSerializer::class)
+data class ConfirmReinforcementsDoneResponse(
+    val lobbyCode: LobbyCode,
+) : NetworkMessagePayload
+
+object ConfirmReinforcementsDoneResponseSerializer :
+    KSerializer<ConfirmReinforcementsDoneResponse> {
+    override val descriptor =
+        buildClassSerialDescriptor(
+            "at.aau.pulverfass.shared.network.message.ConfirmReinforcementsDoneResponse",
+        ) {
+            element("lobbyCode", LobbyCode.serializer().descriptor)
+        }
+
+    override fun serialize(
+        encoder: Encoder,
+        value: ConfirmReinforcementsDoneResponse,
+    ) {
+        val composite = encoder.beginStructure(descriptor)
+        composite.encodeSerializableElement(descriptor, 0, LobbyCode.serializer(), value.lobbyCode)
+        composite.endStructure(descriptor)
+    }
+
+    override fun deserialize(decoder: Decoder): ConfirmReinforcementsDoneResponse {
+        val composite = decoder.beginStructure(descriptor)
+        var lobbyCode: LobbyCode? = null
+
+        loop@ while (true) {
+            when (val index = composite.decodeElementIndex(descriptor)) {
+                0 ->
+                    lobbyCode =
+                        composite.decodeSerializableElement(
+                            descriptor,
+                            0,
+                            LobbyCode.serializer(),
+                        )
+                CompositeDecoder.DECODE_DONE -> break@loop
+                else -> throw IllegalArgumentException("Unexpected index $index")
+            }
+        }
+
+        composite.endStructure(descriptor)
+        return ConfirmReinforcementsDoneResponse(
+            lobbyCode =
+                lobbyCode
+                    ?: throw MissingFieldException("lobbyCode", descriptor.serialName),
+        )
+    }
+}

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/MapSnapshotModels.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/MapSnapshotModels.kt
@@ -109,9 +109,13 @@ data class PublicTurnStateSnapshot(
     val isPaused: Boolean = false,
     val pauseReason: String? = null,
     val pausedPlayerId: PlayerId? = null,
+    val pendingReinforcements: Int = 0,
 ) {
     companion object {
-        fun from(turnState: TurnState): PublicTurnStateSnapshot =
+        fun from(
+            turnState: TurnState,
+            pendingReinforcements: Int = 0,
+        ): PublicTurnStateSnapshot =
             PublicTurnStateSnapshot(
                 activePlayerId = turnState.activePlayerId,
                 turnPhase = turnState.turnPhase,
@@ -120,6 +124,7 @@ data class PublicTurnStateSnapshot(
                 isPaused = turnState.isPaused,
                 pauseReason = turnState.pauseReason,
                 pausedPlayerId = turnState.pausedPlayerId,
+                pendingReinforcements = pendingReinforcements,
             )
     }
 }

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/PlaceReinforcementsResponse.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/PlaceReinforcementsResponse.kt
@@ -1,0 +1,61 @@
+package at.aau.pulverfass.shared.message.lobby.response
+
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.message.protocol.NetworkMessagePayload
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.MissingFieldException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+@Serializable(with = PlaceReinforcementsResponseSerializer::class)
+data class PlaceReinforcementsResponse(
+    val lobbyCode: LobbyCode,
+) : NetworkMessagePayload
+
+object PlaceReinforcementsResponseSerializer : KSerializer<PlaceReinforcementsResponse> {
+    override val descriptor =
+        buildClassSerialDescriptor(
+            "at.aau.pulverfass.shared.network.message.PlaceReinforcementsResponse",
+        ) {
+            element("lobbyCode", LobbyCode.serializer().descriptor)
+        }
+
+    override fun serialize(
+        encoder: Encoder,
+        value: PlaceReinforcementsResponse,
+    ) {
+        val composite = encoder.beginStructure(descriptor)
+        composite.encodeSerializableElement(descriptor, 0, LobbyCode.serializer(), value.lobbyCode)
+        composite.endStructure(descriptor)
+    }
+
+    override fun deserialize(decoder: Decoder): PlaceReinforcementsResponse {
+        val composite = decoder.beginStructure(descriptor)
+        var lobbyCode: LobbyCode? = null
+
+        loop@ while (true) {
+            when (val index = composite.decodeElementIndex(descriptor)) {
+                0 ->
+                    lobbyCode =
+                        composite.decodeSerializableElement(
+                            descriptor,
+                            0,
+                            LobbyCode.serializer(),
+                        )
+                CompositeDecoder.DECODE_DONE -> break@loop
+                else -> throw IllegalArgumentException("Unexpected index $index")
+            }
+        }
+
+        composite.endStructure(descriptor)
+        return PlaceReinforcementsResponse(
+            lobbyCode =
+                lobbyCode
+                    ?: throw MissingFieldException("lobbyCode", descriptor.serialName),
+        )
+    }
+}

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/TradeInCardsResponse.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/TradeInCardsResponse.kt
@@ -1,0 +1,61 @@
+package at.aau.pulverfass.shared.message.lobby.response
+
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.message.protocol.NetworkMessagePayload
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.MissingFieldException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+@Serializable(with = TradeInCardsResponseSerializer::class)
+data class TradeInCardsResponse(
+    val lobbyCode: LobbyCode,
+) : NetworkMessagePayload
+
+object TradeInCardsResponseSerializer : KSerializer<TradeInCardsResponse> {
+    override val descriptor =
+        buildClassSerialDescriptor(
+            "at.aau.pulverfass.shared.network.message.TradeInCardsResponse",
+        ) {
+            element("lobbyCode", LobbyCode.serializer().descriptor)
+        }
+
+    override fun serialize(
+        encoder: Encoder,
+        value: TradeInCardsResponse,
+    ) {
+        val composite = encoder.beginStructure(descriptor)
+        composite.encodeSerializableElement(descriptor, 0, LobbyCode.serializer(), value.lobbyCode)
+        composite.endStructure(descriptor)
+    }
+
+    override fun deserialize(decoder: Decoder): TradeInCardsResponse {
+        val composite = decoder.beginStructure(descriptor)
+        var lobbyCode: LobbyCode? = null
+
+        loop@ while (true) {
+            when (val index = composite.decodeElementIndex(descriptor)) {
+                0 ->
+                    lobbyCode =
+                        composite.decodeSerializableElement(
+                            descriptor,
+                            0,
+                            LobbyCode.serializer(),
+                        )
+                CompositeDecoder.DECODE_DONE -> break@loop
+                else -> throw IllegalArgumentException("Unexpected index $index")
+            }
+        }
+
+        composite.endStructure(descriptor)
+        return TradeInCardsResponse(
+            lobbyCode =
+                lobbyCode
+                    ?: throw MissingFieldException("lobbyCode", descriptor.serialName),
+        )
+    }
+}

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/error/ConfirmReinforcementsDoneErrorResponse.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/error/ConfirmReinforcementsDoneErrorResponse.kt
@@ -1,0 +1,81 @@
+package at.aau.pulverfass.shared.message.lobby.response.error
+
+import at.aau.pulverfass.shared.message.protocol.NetworkMessagePayload
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.MissingFieldException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+@Serializable
+enum class ConfirmReinforcementsDoneErrorCode {
+    REQUESTER_MISMATCH,
+    NOT_ACTIVE_PLAYER,
+    GAME_PAUSED,
+    PHASE_MISMATCH,
+    GAME_NOT_FOUND,
+    PENDING_REINFORCEMENTS_REMAINING,
+    FORCED_TRADE_REQUIRED,
+}
+
+@Serializable(with = ConfirmReinforcementsDoneErrorResponseSerializer::class)
+data class ConfirmReinforcementsDoneErrorResponse(
+    val code: ConfirmReinforcementsDoneErrorCode,
+    val reason: String,
+) : NetworkMessagePayload
+
+object ConfirmReinforcementsDoneErrorResponseSerializer :
+    KSerializer<ConfirmReinforcementsDoneErrorResponse> {
+    override val descriptor =
+        buildClassSerialDescriptor(
+            "at.aau.pulverfass.shared.network.message.ConfirmReinforcementsDoneErrorResponse",
+        ) {
+            element("code", ConfirmReinforcementsDoneErrorCode.serializer().descriptor)
+            element<String>("reason")
+        }
+
+    override fun serialize(
+        encoder: Encoder,
+        value: ConfirmReinforcementsDoneErrorResponse,
+    ) {
+        val composite = encoder.beginStructure(descriptor)
+        composite.encodeSerializableElement(
+            descriptor,
+            0,
+            ConfirmReinforcementsDoneErrorCode.serializer(),
+            value.code,
+        )
+        composite.encodeStringElement(descriptor, 1, value.reason)
+        composite.endStructure(descriptor)
+    }
+
+    override fun deserialize(decoder: Decoder): ConfirmReinforcementsDoneErrorResponse {
+        val composite = decoder.beginStructure(descriptor)
+        var code: ConfirmReinforcementsDoneErrorCode? = null
+        var reason: String? = null
+
+        loop@ while (true) {
+            when (val index = composite.decodeElementIndex(descriptor)) {
+                0 ->
+                    code =
+                        composite.decodeSerializableElement(
+                            descriptor,
+                            0,
+                            ConfirmReinforcementsDoneErrorCode.serializer(),
+                        )
+                1 -> reason = composite.decodeStringElement(descriptor, 1)
+                CompositeDecoder.DECODE_DONE -> break@loop
+                else -> throw IllegalArgumentException("Unexpected index $index")
+            }
+        }
+
+        composite.endStructure(descriptor)
+        return ConfirmReinforcementsDoneErrorResponse(
+            code = code ?: throw MissingFieldException("code", descriptor.serialName),
+            reason = reason ?: throw MissingFieldException("reason", descriptor.serialName),
+        )
+    }
+}

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/error/PlaceReinforcementsErrorResponse.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/error/PlaceReinforcementsErrorResponse.kt
@@ -1,0 +1,81 @@
+package at.aau.pulverfass.shared.message.lobby.response.error
+
+import at.aau.pulverfass.shared.message.protocol.NetworkMessagePayload
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.MissingFieldException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+@Serializable
+enum class PlaceReinforcementsErrorCode {
+    REQUESTER_MISMATCH,
+    NOT_ACTIVE_PLAYER,
+    GAME_PAUSED,
+    PHASE_MISMATCH,
+    GAME_NOT_FOUND,
+    TERRITORY_NOT_OWNED,
+    OVERSPEND,
+    INVALID_PLACEMENT,
+}
+
+@Serializable(with = PlaceReinforcementsErrorResponseSerializer::class)
+data class PlaceReinforcementsErrorResponse(
+    val code: PlaceReinforcementsErrorCode,
+    val reason: String,
+) : NetworkMessagePayload
+
+object PlaceReinforcementsErrorResponseSerializer : KSerializer<PlaceReinforcementsErrorResponse> {
+    override val descriptor =
+        buildClassSerialDescriptor(
+            "at.aau.pulverfass.shared.network.message.PlaceReinforcementsErrorResponse",
+        ) {
+            element("code", PlaceReinforcementsErrorCode.serializer().descriptor)
+            element<String>("reason")
+        }
+
+    override fun serialize(
+        encoder: Encoder,
+        value: PlaceReinforcementsErrorResponse,
+    ) {
+        val composite = encoder.beginStructure(descriptor)
+        composite.encodeSerializableElement(
+            descriptor,
+            0,
+            PlaceReinforcementsErrorCode.serializer(),
+            value.code,
+        )
+        composite.encodeStringElement(descriptor, 1, value.reason)
+        composite.endStructure(descriptor)
+    }
+
+    override fun deserialize(decoder: Decoder): PlaceReinforcementsErrorResponse {
+        val composite = decoder.beginStructure(descriptor)
+        var code: PlaceReinforcementsErrorCode? = null
+        var reason: String? = null
+
+        loop@ while (true) {
+            when (val index = composite.decodeElementIndex(descriptor)) {
+                0 ->
+                    code =
+                        composite.decodeSerializableElement(
+                            descriptor,
+                            0,
+                            PlaceReinforcementsErrorCode.serializer(),
+                        )
+                1 -> reason = composite.decodeStringElement(descriptor, 1)
+                CompositeDecoder.DECODE_DONE -> break@loop
+                else -> throw IllegalArgumentException("Unexpected index $index")
+            }
+        }
+
+        composite.endStructure(descriptor)
+        return PlaceReinforcementsErrorResponse(
+            code = code ?: throw MissingFieldException("code", descriptor.serialName),
+            reason = reason ?: throw MissingFieldException("reason", descriptor.serialName),
+        )
+    }
+}

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/error/PlaceReinforcementsErrorResponse.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/error/PlaceReinforcementsErrorResponse.kt
@@ -20,6 +20,7 @@ enum class PlaceReinforcementsErrorCode {
     TERRITORY_NOT_OWNED,
     OVERSPEND,
     INVALID_PLACEMENT,
+    FORCED_TRADE_REQUIRED,
 }
 
 @Serializable(with = PlaceReinforcementsErrorResponseSerializer::class)

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/error/TradeInCardsErrorResponse.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/error/TradeInCardsErrorResponse.kt
@@ -1,0 +1,81 @@
+package at.aau.pulverfass.shared.message.lobby.response.error
+
+import at.aau.pulverfass.shared.message.protocol.NetworkMessagePayload
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.MissingFieldException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+@Serializable
+enum class TradeInCardsErrorCode {
+    REQUESTER_MISMATCH,
+    NOT_ACTIVE_PLAYER,
+    GAME_PAUSED,
+    PHASE_MISMATCH,
+    GAME_NOT_FOUND,
+    CARDS_NOT_OWNED,
+    INVALID_SET,
+    INVALID_REQUEST,
+}
+
+@Serializable(with = TradeInCardsErrorResponseSerializer::class)
+data class TradeInCardsErrorResponse(
+    val code: TradeInCardsErrorCode,
+    val reason: String,
+) : NetworkMessagePayload
+
+object TradeInCardsErrorResponseSerializer : KSerializer<TradeInCardsErrorResponse> {
+    override val descriptor =
+        buildClassSerialDescriptor(
+            "at.aau.pulverfass.shared.network.message.TradeInCardsErrorResponse",
+        ) {
+            element("code", TradeInCardsErrorCode.serializer().descriptor)
+            element<String>("reason")
+        }
+
+    override fun serialize(
+        encoder: Encoder,
+        value: TradeInCardsErrorResponse,
+    ) {
+        val composite = encoder.beginStructure(descriptor)
+        composite.encodeSerializableElement(
+            descriptor,
+            0,
+            TradeInCardsErrorCode.serializer(),
+            value.code,
+        )
+        composite.encodeStringElement(descriptor, 1, value.reason)
+        composite.endStructure(descriptor)
+    }
+
+    override fun deserialize(decoder: Decoder): TradeInCardsErrorResponse {
+        val composite = decoder.beginStructure(descriptor)
+        var code: TradeInCardsErrorCode? = null
+        var reason: String? = null
+
+        loop@ while (true) {
+            when (val index = composite.decodeElementIndex(descriptor)) {
+                0 ->
+                    code =
+                        composite.decodeSerializableElement(
+                            descriptor,
+                            0,
+                            TradeInCardsErrorCode.serializer(),
+                        )
+                1 -> reason = composite.decodeStringElement(descriptor, 1)
+                CompositeDecoder.DECODE_DONE -> break@loop
+                else -> throw IllegalArgumentException("Unexpected index $index")
+            }
+        }
+
+        composite.endStructure(descriptor)
+        return TradeInCardsErrorResponse(
+            code = code ?: throw MissingFieldException("code", descriptor.serialName),
+            reason = reason ?: throw MissingFieldException("reason", descriptor.serialName),
+        )
+    }
+}

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/protocol/MessageType.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/protocol/MessageType.kt
@@ -37,6 +37,30 @@ enum class MessageType(val id: Int) {
     /** Fehlantwort auf eine PlayerCount-Anfrage. */
     LOBBY_PLAYER_COUNT_ERROR_RESPONSE(55),
 
+    /** Öffentlicher Broadcast für neu gewährte Verstärkungen eines Spielers. */
+    LOBBY_REINFORCEMENTS_GRANTED_BROADCAST(56),
+
+    /** Öffentliches Delta-Event für Veränderungen am Pending-Reinforcement-Pool. */
+    LOBBY_PENDING_REINFORCEMENTS_CHANGED_BROADCAST(57),
+
+    /** Anfrage zum Platzieren von Verstärkungen in der Reinforcements-Phase. */
+    LOBBY_PLACE_REINFORCEMENTS_REQUEST(58),
+
+    /** Erfolgsantwort auf eine Platzierungsanfrage für Verstärkungen. */
+    LOBBY_PLACE_REINFORCEMENTS_RESPONSE(59),
+
+    /** Fehlantwort auf eine Platzierungsanfrage für Verstärkungen. */
+    LOBBY_PLACE_REINFORCEMENTS_ERROR_RESPONSE(60),
+
+    /** Anfrage zum expliziten Beenden der Reinforcements-Phase. */
+    LOBBY_CONFIRM_REINFORCEMENTS_DONE_REQUEST(61),
+
+    /** Erfolgsantwort auf das Beenden der Reinforcements-Phase. */
+    LOBBY_CONFIRM_REINFORCEMENTS_DONE_RESPONSE(62),
+
+    /** Fehlantwort auf das Beenden der Reinforcements-Phase. */
+    LOBBY_CONFIRM_REINFORCEMENTS_DONE_ERROR_RESPONSE(63),
+
     /** Logout-Anfrage eines Clients. */
     LOGOUT_REQUEST(3),
 

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/protocol/MessageType.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/protocol/MessageType.kt
@@ -61,6 +61,18 @@ enum class MessageType(val id: Int) {
     /** Fehlantwort auf das Beenden der Reinforcements-Phase. */
     LOBBY_CONFIRM_REINFORCEMENTS_DONE_ERROR_RESPONSE(63),
 
+    /** Anfrage zum Trade-In eines Kartensets waehrend der Reinforcements-Phase. */
+    LOBBY_TRADE_IN_CARDS_REQUEST(64),
+
+    /** Erfolgsantwort auf einen Karten-Trade-In. */
+    LOBBY_TRADE_IN_CARDS_RESPONSE(65),
+
+    /** Fehlantwort auf einen Karten-Trade-In. */
+    LOBBY_TRADE_IN_CARDS_ERROR_RESPONSE(66),
+
+    /** Private S2C-Aktualisierung der autoritativen Kartenhand eines Spielers. */
+    LOBBY_PLAYER_HAND_UPDATED_EVENT(67),
+
     /** Logout-Anfrage eines Clients. */
     LOGOUT_REQUEST(3),
 

--- a/shared/src/main/resources/config/maps/default-map.json
+++ b/shared/src/main/resources/config/maps/default-map.json
@@ -202,7 +202,7 @@
         "brasilien",
         "andengemeinschaft"
       ],
-      "bonusValue": 2
+      "bonus": 1
     },
     {
       "continentId": "nordamerika",
@@ -213,7 +213,7 @@
         "kanada",
         "groenland"
       ],
-      "bonusValue": 3
+      "bonus": 2
     },
     {
       "continentId": "europa",
@@ -223,7 +223,7 @@
         "skandinavien",
         "mitteleuropa"
       ],
-      "bonusValue": 2
+      "bonus": 2
     },
     {
       "continentId": "afrika",
@@ -233,7 +233,7 @@
         "zentral_afrika",
         "sued_afrika"
       ],
-      "bonusValue": 2
+      "bonus": 2
     },
     {
       "continentId": "asien",
@@ -245,7 +245,7 @@
         "japan",
         "ferner_osten"
       ],
-      "bonusValue": 4
+      "bonus": 3
     },
     {
       "continentId": "ozeanien",
@@ -253,7 +253,7 @@
         "australien",
         "ozeanien"
       ],
-      "bonusValue": 1
+      "bonus": 1
     }
   ]
 }

--- a/shared/src/main/resources/config/maps/default-map.json
+++ b/shared/src/main/resources/config/maps/default-map.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "territories": [
     {
       "territoryId": "argentinien",
@@ -202,7 +202,7 @@
         "brasilien",
         "andengemeinschaft"
       ],
-      "bonus": 1
+      "bonus": 2
     },
     {
       "continentId": "nordamerika",
@@ -213,7 +213,7 @@
         "kanada",
         "groenland"
       ],
-      "bonus": 2
+      "bonus": 3
     },
     {
       "continentId": "europa",
@@ -245,7 +245,7 @@
         "japan",
         "ferner_osten"
       ],
-      "bonus": 3
+      "bonus": 4
     },
     {
       "continentId": "ozeanien",

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/event/LobbyEventTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/event/LobbyEventTest.kt
@@ -1,5 +1,6 @@
 package at.aau.pulverfass.shared.lobby.event
 
+import at.aau.pulverfass.shared.ids.CardId
 import at.aau.pulverfass.shared.ids.LobbyCode
 import at.aau.pulverfass.shared.ids.PlayerId
 import at.aau.pulverfass.shared.ids.TerritoryId
@@ -23,8 +24,20 @@ class LobbyEventTest {
                 TurnEnded(lobbyCode, playerId),
                 LobbyCreated(lobbyCode),
                 LobbyClosed(lobbyCode, "finished"),
+                CardSetTradedInEvent(
+                    lobbyCode = lobbyCode,
+                    playerId = playerId,
+                    cardIds = listOf(CardId("card-1"), CardId("card-2"), CardId("card-3")),
+                    value = 2,
+                    tradeIndex = 1,
+                ),
                 PendingReinforcementsSetEvent(lobbyCode, playerId, 5),
                 PendingReinforcementsChangedEvent(lobbyCode, playerId, 2),
+                PlayerCardsRemovedEvent(
+                    lobbyCode,
+                    playerId,
+                    listOf(CardId("card-7"), CardId("card-8")),
+                ),
                 SystemTick(lobbyCode, tick = 5),
                 TurnStateUpdatedEvent(
                     lobbyCode = lobbyCode,
@@ -39,7 +52,7 @@ class LobbyEventTest {
                 InvalidActionDetected(lobbyCode, playerId, "move rejected"),
             )
 
-        assertEquals(14, events.size)
+        assertEquals(16, events.size)
         assertEquals(lobbyCode, events.first().lobbyCode)
         assertEquals("finished", (events[5] as LobbyClosed).reason)
     }
@@ -66,11 +79,13 @@ class LobbyEventTest {
 
         val internalResult =
             when (val event: InternalLobbyEvent = LobbyClosed(lobbyCode, "done")) {
+                is CardSetTradedInEvent -> event.value.toString()
                 is InvalidActionDetected -> event.reason
                 is LobbyClosed -> event.reason.orEmpty()
                 is LobbyCreated -> "created"
                 is PendingReinforcementsChangedEvent -> event.delta.toString()
                 is PendingReinforcementsSetEvent -> event.amount.toString()
+                is PlayerCardsRemovedEvent -> event.cardIds.size.toString()
                 is SystemTick -> event.tick.toString()
                 is TerritoryOwnerChangedEvent -> event.territoryId.value
                 is TerritoryTroopsChangedEvent -> event.troopCount.toString()
@@ -96,8 +111,20 @@ class LobbyEventTest {
                 TurnEnded(lobbyCode, playerId),
                 LobbyCreated(lobbyCode),
                 LobbyClosed(lobbyCode),
+                CardSetTradedInEvent(
+                    lobbyCode = lobbyCode,
+                    playerId = playerId,
+                    cardIds = listOf(CardId("card-a"), CardId("card-b"), CardId("card-c")),
+                    value = 2,
+                    tradeIndex = 1,
+                ),
                 PendingReinforcementsSetEvent(lobbyCode, playerId, 4),
                 PendingReinforcementsChangedEvent(lobbyCode, playerId, -1),
+                PlayerCardsRemovedEvent(
+                    lobbyCode,
+                    playerId,
+                    listOf(CardId("card-x"), CardId("card-y")),
+                ),
                 SystemTick(lobbyCode, 0),
                 TurnStateUpdatedEvent(
                     lobbyCode = lobbyCode,
@@ -139,6 +166,38 @@ class LobbyEventTest {
 
     @Test
     fun `should validate technical event arguments`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            CardSetTradedInEvent(
+                lobbyCode = LobbyCode("CC44"),
+                playerId = PlayerId(1),
+                cardIds = listOf(CardId("card-a"), CardId("card-b")),
+                value = 2,
+                tradeIndex = 1,
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            CardSetTradedInEvent(
+                lobbyCode = LobbyCode("CC55"),
+                playerId = PlayerId(1),
+                cardIds = listOf(CardId("card-a"), CardId("card-a"), CardId("card-b")),
+                value = 2,
+                tradeIndex = 1,
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            PlayerCardsRemovedEvent(
+                lobbyCode = LobbyCode("CC56"),
+                playerId = PlayerId(1),
+                cardIds = emptyList(),
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            PlayerCardsRemovedEvent(
+                lobbyCode = LobbyCode("CC57"),
+                playerId = PlayerId(1),
+                cardIds = listOf(CardId("card-a"), CardId("card-a")),
+            )
+        }
         assertThrows(IllegalArgumentException::class.java) {
             InvalidActionDetected(LobbyCode("DD44"), reason = " ")
         }

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/event/LobbyEventTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/event/LobbyEventTest.kt
@@ -23,6 +23,8 @@ class LobbyEventTest {
                 TurnEnded(lobbyCode, playerId),
                 LobbyCreated(lobbyCode),
                 LobbyClosed(lobbyCode, "finished"),
+                PendingReinforcementsSetEvent(lobbyCode, playerId, 5),
+                PendingReinforcementsChangedEvent(lobbyCode, playerId, 2),
                 SystemTick(lobbyCode, tick = 5),
                 TurnStateUpdatedEvent(
                     lobbyCode = lobbyCode,
@@ -37,7 +39,7 @@ class LobbyEventTest {
                 InvalidActionDetected(lobbyCode, playerId, "move rejected"),
             )
 
-        assertEquals(12, events.size)
+        assertEquals(14, events.size)
         assertEquals(lobbyCode, events.first().lobbyCode)
         assertEquals("finished", (events[5] as LobbyClosed).reason)
     }
@@ -67,6 +69,8 @@ class LobbyEventTest {
                 is InvalidActionDetected -> event.reason
                 is LobbyClosed -> event.reason.orEmpty()
                 is LobbyCreated -> "created"
+                is PendingReinforcementsChangedEvent -> event.delta.toString()
+                is PendingReinforcementsSetEvent -> event.amount.toString()
                 is SystemTick -> event.tick.toString()
                 is TerritoryOwnerChangedEvent -> event.territoryId.value
                 is TerritoryTroopsChangedEvent -> event.troopCount.toString()
@@ -92,6 +96,8 @@ class LobbyEventTest {
                 TurnEnded(lobbyCode, playerId),
                 LobbyCreated(lobbyCode),
                 LobbyClosed(lobbyCode),
+                PendingReinforcementsSetEvent(lobbyCode, playerId, 4),
+                PendingReinforcementsChangedEvent(lobbyCode, playerId, -1),
                 SystemTick(lobbyCode, 0),
                 TurnStateUpdatedEvent(
                     lobbyCode = lobbyCode,

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/reducer/DefaultLobbyEventReducerTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/reducer/DefaultLobbyEventReducerTest.kt
@@ -1064,7 +1064,40 @@ class DefaultLobbyEventReducerTest {
             }
 
         assertEquals(
-            "PendingReinforcements für Spieler '1' dürfen nicht negativ werden: aktuell=2, delta=-3.",
+            "PendingReinforcements für Spieler '1' dürfen nicht negativ werden: " +
+                "aktuell=2, delta=-3.",
+            exception.message,
+        )
+    }
+
+    @Test
+    fun `pending reinforcements change cannot overflow int`() {
+        val lobbyCode = LobbyCode("TM16")
+        val playerOne = PlayerId(1)
+        val initialState =
+            GameState.initial(
+                lobbyCode = lobbyCode,
+                mapDefinition = sampleMapDefinition(),
+                players = listOf(playerOne),
+            )
+
+        val withSet =
+            reducer.apply(
+                initialState,
+                PendingReinforcementsSetEvent(lobbyCode, playerOne, Int.MAX_VALUE),
+            )
+
+        val exception =
+            assertThrows(InvalidLobbyEventException::class.java) {
+                reducer.apply(
+                    withSet,
+                    PendingReinforcementsChangedEvent(lobbyCode, playerOne, 1),
+                )
+            }
+
+        assertEquals(
+            "PendingReinforcements für Spieler '1' dürfen den Int-Bereich nicht " +
+                "verlassen: aktuell=2147483647, delta=1.",
             exception.message,
         )
     }

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/reducer/DefaultLobbyEventReducerTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/reducer/DefaultLobbyEventReducerTest.kt
@@ -11,6 +11,8 @@ import at.aau.pulverfass.shared.lobby.event.GameStarted
 import at.aau.pulverfass.shared.lobby.event.InvalidActionDetected
 import at.aau.pulverfass.shared.lobby.event.LobbyClosed
 import at.aau.pulverfass.shared.lobby.event.LobbyCreated
+import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsChangedEvent
+import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsSetEvent
 import at.aau.pulverfass.shared.lobby.event.PlayerJoined
 import at.aau.pulverfass.shared.lobby.event.PlayerKicked
 import at.aau.pulverfass.shared.lobby.event.PlayerLeft
@@ -1002,6 +1004,69 @@ class DefaultLobbyEventReducerTest {
             )
 
         assertEquals(7, updated.troopCountOf(TerritoryId("alpha")))
+    }
+
+    @Test
+    fun `pending reinforcements set und change aktualisieren state deterministisch`() {
+        val lobbyCode = LobbyCode("TM13")
+        val playerOne = PlayerId(1)
+        val initialState =
+            GameState.initial(
+                lobbyCode = lobbyCode,
+                mapDefinition = sampleMapDefinition(),
+                players = listOf(playerOne),
+            )
+
+        val withSet =
+            reducer.apply(
+                initialState,
+                PendingReinforcementsSetEvent(lobbyCode, playerOne, 5),
+            )
+        val withAdd =
+            reducer.apply(
+                withSet,
+                PendingReinforcementsChangedEvent(lobbyCode, playerOne, 3),
+            )
+        val withSubtract =
+            reducer.apply(
+                withAdd,
+                PendingReinforcementsChangedEvent(lobbyCode, playerOne, -2),
+            )
+
+        assertEquals(5, withSet.pendingReinforcementsFor(playerOne))
+        assertEquals(8, withAdd.pendingReinforcementsFor(playerOne))
+        assertEquals(6, withSubtract.pendingReinforcementsFor(playerOne))
+    }
+
+    @Test
+    fun `pending reinforcements cannot go negative`() {
+        val lobbyCode = LobbyCode("TM15")
+        val playerOne = PlayerId(1)
+        val initialState =
+            GameState.initial(
+                lobbyCode = lobbyCode,
+                mapDefinition = sampleMapDefinition(),
+                players = listOf(playerOne),
+            )
+
+        val withSet =
+            reducer.apply(
+                initialState,
+                PendingReinforcementsSetEvent(lobbyCode, playerOne, 2),
+            )
+
+        val exception =
+            assertThrows(InvalidLobbyEventException::class.java) {
+                reducer.apply(
+                    withSet,
+                    PendingReinforcementsChangedEvent(lobbyCode, playerOne, -3),
+                )
+            }
+
+        assertEquals(
+            "PendingReinforcements für Spieler '1' dürfen nicht negativ werden: aktuell=2, delta=-3.",
+            exception.message,
+        )
     }
 
     @Test

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/reducer/DefaultLobbyEventReducerTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/reducer/DefaultLobbyEventReducerTest.kt
@@ -1383,6 +1383,111 @@ class DefaultLobbyEventReducerTest {
         assertEquals(GameStatus.FINISHED, finishedState.status)
     }
 
+    @Test
+    fun `card set traded in rejects wrong trade index and wrong value`() {
+        val lobbyCode = LobbyCode("TM19")
+        val playerOne = PlayerId(1)
+        val initialState =
+            GameState.initial(
+                lobbyCode = lobbyCode,
+                mapDefinition = sampleMapDefinition(),
+                players = listOf(playerOne),
+            )
+
+        val wrongIndexException =
+            assertThrows(InvalidLobbyEventException::class.java) {
+                reducer.apply(
+                    initialState,
+                    CardSetTradedInEvent(
+                        lobbyCode = lobbyCode,
+                        playerId = playerOne,
+                        cardIds = listOf(CardId("c1"), CardId("c2"), CardId("c3")),
+                        value = 4,
+                        tradeIndex = 2,
+                    ),
+                )
+            }
+        assertEquals(
+            "CardSetTradedInEvent.tradeIndex muss den naechsten globalen " +
+                "Trade-In abbilden: erwartet=1, war=2.",
+            wrongIndexException.message,
+        )
+
+        val wrongValueException =
+            assertThrows(InvalidLobbyEventException::class.java) {
+                reducer.apply(
+                    initialState,
+                    CardSetTradedInEvent(
+                        lobbyCode = lobbyCode,
+                        playerId = playerOne,
+                        cardIds = listOf(CardId("c1"), CardId("c2"), CardId("c3")),
+                        value = 99,
+                        tradeIndex = 1,
+                    ),
+                )
+            }
+        assertEquals(
+            "CardSetTradedInEvent.value passt nicht zur Progression: erwartet=2, war=99.",
+            wrongValueException.message,
+        )
+    }
+
+    @Test
+    fun `card set traded in rejects unknown player`() {
+        val lobbyCode = LobbyCode("TM20")
+        val playerOne = PlayerId(1)
+        val initialState =
+            GameState.initial(
+                lobbyCode = lobbyCode,
+                mapDefinition = sampleMapDefinition(),
+                players = listOf(playerOne),
+            )
+
+        assertThrows(InvalidLobbyEventException::class.java) {
+            reducer.apply(
+                initialState,
+                CardSetTradedInEvent(
+                    lobbyCode = lobbyCode,
+                    playerId = PlayerId(99),
+                    cardIds = listOf(CardId("c1"), CardId("c2"), CardId("c3")),
+                    value = 2,
+                    tradeIndex = 1,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `pending reinforcements changed rejects cross player modification`() {
+        val lobbyCode = LobbyCode("TM21")
+        val playerOne = PlayerId(1)
+        val playerTwo = PlayerId(2)
+        val initialState =
+            GameState.initial(
+                lobbyCode = lobbyCode,
+                mapDefinition = sampleMapDefinition(),
+                players = listOf(playerOne, playerTwo),
+            )
+        val withSet =
+            reducer.apply(
+                initialState,
+                PendingReinforcementsSetEvent(lobbyCode, playerOne, 5),
+            )
+
+        val exception =
+            assertThrows(InvalidLobbyEventException::class.java) {
+                reducer.apply(
+                    withSet,
+                    PendingReinforcementsChangedEvent(lobbyCode, playerTwo, 3),
+                )
+            }
+        assertEquals(
+            "PendingReinforcements gehören Spieler '1' und " +
+                "können nicht für '2' verändert werden.",
+            exception.message,
+        )
+    }
+
     private fun sampleMapDefinition(): MapDefinition =
         MapDefinition(
             schemaVersion = 1,

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/reducer/DefaultLobbyEventReducerTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/reducer/DefaultLobbyEventReducerTest.kt
@@ -2,17 +2,20 @@ package at.aau.pulverfass.shared.lobby.reducer
 
 import at.aau.pulverfass.shared.event.CorrelationId
 import at.aau.pulverfass.shared.event.EventContext
+import at.aau.pulverfass.shared.ids.CardId
 import at.aau.pulverfass.shared.ids.ConnectionId
 import at.aau.pulverfass.shared.ids.ContinentId
 import at.aau.pulverfass.shared.ids.LobbyCode
 import at.aau.pulverfass.shared.ids.PlayerId
 import at.aau.pulverfass.shared.ids.TerritoryId
+import at.aau.pulverfass.shared.lobby.event.CardSetTradedInEvent
 import at.aau.pulverfass.shared.lobby.event.GameStarted
 import at.aau.pulverfass.shared.lobby.event.InvalidActionDetected
 import at.aau.pulverfass.shared.lobby.event.LobbyClosed
 import at.aau.pulverfass.shared.lobby.event.LobbyCreated
 import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsChangedEvent
 import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsSetEvent
+import at.aau.pulverfass.shared.lobby.event.PlayerCardsRemovedEvent
 import at.aau.pulverfass.shared.lobby.event.PlayerJoined
 import at.aau.pulverfass.shared.lobby.event.PlayerKicked
 import at.aau.pulverfass.shared.lobby.event.PlayerLeft
@@ -23,6 +26,8 @@ import at.aau.pulverfass.shared.lobby.event.TerritoryTroopsChangedEvent
 import at.aau.pulverfass.shared.lobby.event.TimeoutTriggered
 import at.aau.pulverfass.shared.lobby.event.TurnEnded
 import at.aau.pulverfass.shared.lobby.event.TurnStateUpdatedEvent
+import at.aau.pulverfass.shared.lobby.state.CardState
+import at.aau.pulverfass.shared.lobby.state.CardType
 import at.aau.pulverfass.shared.lobby.state.GameState
 import at.aau.pulverfass.shared.lobby.state.GameStatus
 import at.aau.pulverfass.shared.lobby.state.TerritoryState
@@ -1100,6 +1105,74 @@ class DefaultLobbyEventReducerTest {
                 "verlassen: aktuell=2147483647, delta=1.",
             exception.message,
         )
+    }
+
+    @Test
+    fun `card set traded in increments global count deterministically`() {
+        val lobbyCode = LobbyCode("TM17")
+        val playerOne = PlayerId(1)
+        val initialState =
+            GameState.initial(
+                lobbyCode = lobbyCode,
+                mapDefinition = sampleMapDefinition(),
+                players = listOf(playerOne),
+            )
+
+        val firstTrade =
+            reducer.apply(
+                initialState,
+                CardSetTradedInEvent(
+                    lobbyCode = lobbyCode,
+                    playerId = playerOne,
+                    cardIds = listOf(CardId("card-1"), CardId("card-2"), CardId("card-3")),
+                    value = 2,
+                    tradeIndex = 1,
+                ),
+            )
+        val secondTrade =
+            reducer.apply(
+                firstTrade,
+                CardSetTradedInEvent(
+                    lobbyCode = lobbyCode,
+                    playerId = playerOne,
+                    cardIds = listOf(CardId("card-4"), CardId("card-5"), CardId("card-6")),
+                    value = 4,
+                    tradeIndex = 2,
+                ),
+            )
+
+        assertEquals(1, firstTrade.tradedInSetCount)
+        assertEquals(2, secondTrade.tradedInSetCount)
+    }
+
+    @Test
+    fun `player cards removed event updates hand deterministically`() {
+        val lobbyCode = LobbyCode("TM18")
+        val playerOne = PlayerId(1)
+        val cardOne = CardState(CardId("card-1"), CardType.A)
+        val cardTwo = CardState(CardId("card-2"), CardType.B)
+        val cardThree = CardState(CardId("card-3"), CardType.JOKER)
+        val initialState =
+            GameState.initial(
+                lobbyCode = lobbyCode,
+                mapDefinition = sampleMapDefinition(),
+                players = listOf(playerOne),
+            )
+                .withCardAddedToHand(playerOne, cardOne)
+                .withCardAddedToHand(playerOne, cardTwo)
+                .withCardAddedToHand(playerOne, cardThree)
+
+        val updatedState =
+            reducer.apply(
+                initialState,
+                PlayerCardsRemovedEvent(
+                    lobbyCode = lobbyCode,
+                    playerId = playerOne,
+                    cardIds = listOf(cardOne.cardId, cardThree.cardId),
+                ),
+            )
+
+        assertEquals(listOf(cardTwo), updatedState.handOf(playerOne))
     }
 
     @Test

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/state/BaseReinforcementRuleEngineTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/state/BaseReinforcementRuleEngineTest.kt
@@ -1,0 +1,117 @@
+package at.aau.pulverfass.shared.lobby.state
+
+import at.aau.pulverfass.shared.ids.ContinentId
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.ids.TerritoryId
+import at.aau.pulverfass.shared.lobby.event.TerritoryOwnerChangedEvent
+import at.aau.pulverfass.shared.lobby.reducer.DefaultLobbyEventReducer
+import at.aau.pulverfass.shared.map.config.ContinentDefinition
+import at.aau.pulverfass.shared.map.config.MapDefinition
+import at.aau.pulverfass.shared.map.config.TerritoryDefinition
+import at.aau.pulverfass.shared.map.config.TerritoryEdgeDefinition
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class BaseReinforcementRuleEngineTest {
+    private val reducer = DefaultLobbyEventReducer()
+
+    @Test
+    fun `owned smaller than nine yields minimum territory bonus of three`() {
+        val playerOne = PlayerId(1)
+        val playerTwo = PlayerId(2)
+        val lobbyCode = LobbyCode("RB13")
+        val baseState =
+            GameState.initial(
+                lobbyCode = lobbyCode,
+                mapDefinition = reinforcementMapDefinition(),
+                players = listOf(playerOne, playerTwo),
+            )
+
+        val ownedState =
+            listOf("alpha")
+                .fold(baseState) { state, territoryId ->
+                    reducer.apply(
+                        state,
+                        TerritoryOwnerChangedEvent(lobbyCode, TerritoryId(territoryId), playerOne),
+                    )
+                }
+
+        val breakdown =
+            BaseReinforcementRuleEngine.computeBaseReinforcements(playerOne, ownedState)
+
+        assertEquals(1, ownedState.ownedTerritoryCount(playerOne))
+        assertEquals(3, breakdown.territoryBonus)
+        assertEquals(0, breakdown.continentBonus)
+        assertEquals(3, breakdown.total)
+    }
+
+    @Test
+    fun `continent ownership contributes configured sum deterministically`() {
+        val playerOne = PlayerId(1)
+        val playerTwo = PlayerId(2)
+        val lobbyCode = LobbyCode("RB14")
+        val baseState =
+            GameState.initial(
+                lobbyCode = lobbyCode,
+                mapDefinition = reinforcementMapDefinition(),
+                players = listOf(playerOne, playerTwo),
+            )
+
+        val ownedState =
+            listOf("alpha", "beta", "gamma")
+                .fold(baseState) { state, territoryId ->
+                    reducer.apply(
+                        state,
+                        TerritoryOwnerChangedEvent(lobbyCode, TerritoryId(territoryId), playerOne),
+                    )
+                }
+
+        val breakdown =
+            BaseReinforcementRuleEngine.computeBaseReinforcements(playerOne, ownedState)
+
+        assertEquals(true, ownedState.ownsContinent(playerOne, ContinentId("north")))
+        assertEquals(3, ownedState.continentBonus(ContinentId("north")))
+        assertEquals(1, ownedState.continentBonus(ContinentId("south")))
+        assertEquals(3, breakdown.territoryBonus)
+        assertEquals(4, breakdown.continentBonus)
+        assertEquals(7, breakdown.total)
+    }
+
+    private fun reinforcementMapDefinition(): MapDefinition =
+        MapDefinition(
+            schemaVersion = 1,
+            territories =
+                listOf(
+                    TerritoryDefinition(
+                        territoryId = TerritoryId("alpha"),
+                        edges = listOf(TerritoryEdgeDefinition(TerritoryId("beta"))),
+                    ),
+                    TerritoryDefinition(
+                        territoryId = TerritoryId("beta"),
+                        edges =
+                            listOf(
+                                TerritoryEdgeDefinition(TerritoryId("alpha")),
+                                TerritoryEdgeDefinition(TerritoryId("gamma")),
+                            ),
+                    ),
+                    TerritoryDefinition(
+                        territoryId = TerritoryId("gamma"),
+                        edges = listOf(TerritoryEdgeDefinition(TerritoryId("beta"))),
+                    ),
+                ),
+            continents =
+                listOf(
+                    ContinentDefinition(
+                        continentId = ContinentId("north"),
+                        territoryIds = listOf(TerritoryId("alpha"), TerritoryId("beta")),
+                        bonusValue = 3,
+                    ),
+                    ContinentDefinition(
+                        continentId = ContinentId("south"),
+                        territoryIds = listOf(TerritoryId("gamma")),
+                        bonusValue = 1,
+                    ),
+                ),
+        )
+}

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/state/GameStateTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/state/GameStateTest.kt
@@ -36,6 +36,7 @@ class GameStateTest {
         assertEquals(0, state.processedEventCount)
         assertEquals(0, state.stateVersion)
         assertEquals(0, state.playerCount)
+        assertFalse(state.hasPendingReinforcements())
     }
 
     @Test
@@ -220,9 +221,13 @@ class GameStateTest {
         assertEquals(playerOne, state.continentOwner(ContinentId("north")))
         assertNull(state.continentOwner(ContinentId("south")))
         assertTrue(state.playerOwnsContinent(playerOne, ContinentId("north")))
+        assertTrue(state.ownsContinent(playerOne, ContinentId("north")))
         assertFalse(state.playerOwnsContinent(playerTwo, ContinentId("north")))
         assertEquals(listOf(ContinentId("north")), state.continentsOwnedBy(playerOne))
         assertTrue(state.continentsOwnedBy(playerTwo).isEmpty())
+        assertEquals(2, state.ownedTerritoryCount(playerOne))
+        assertEquals(3, state.continentBonus(ContinentId("north")))
+        assertEquals(1, state.continentBonus(ContinentId("south")))
         assertEquals(3, state.bonusFor(playerOne))
         assertEquals(0, state.bonusFor(playerTwo))
     }
@@ -501,6 +506,14 @@ class GameStateTest {
                 players = listOf(playerOne),
                 turnOrder = listOf(playerOne),
                 setupTroopsToPlaceByPlayer = mapOf(playerOne to -1),
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            GameState(
+                lobbyCode = LobbyCode("XZ12"),
+                players = listOf(playerOne),
+                turnOrder = listOf(playerOne),
+                pendingReinforcements = PendingReinforcements(playerOne, -1),
             )
         }
         assertThrows(IllegalArgumentException::class.java) {

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/state/GameStateTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/state/GameStateTest.kt
@@ -1,6 +1,7 @@
 package at.aau.pulverfass.shared.lobby.state
 
 import at.aau.pulverfass.shared.event.EventContext
+import at.aau.pulverfass.shared.ids.CardId
 import at.aau.pulverfass.shared.ids.ContinentId
 import at.aau.pulverfass.shared.ids.LobbyCode
 import at.aau.pulverfass.shared.ids.PlayerId
@@ -37,6 +38,7 @@ class GameStateTest {
         assertEquals(0, state.stateVersion)
         assertEquals(0, state.playerCount)
         assertFalse(state.hasPendingReinforcements())
+        assertEquals(0, state.tradedInSetCount)
     }
 
     @Test
@@ -306,6 +308,30 @@ class GameStateTest {
     }
 
     @Test
+    fun `should add and remove hand cards through game state helpers`() {
+        val playerOne = PlayerId(1)
+        val alphaCard = CardState(cardId = CardId("card-alpha"), type = CardType.A)
+        val jokerCard = CardState(cardId = CardId("card-joker"), type = CardType.JOKER)
+        val baseState =
+            GameState.initial(
+                lobbyCode = LobbyCode("HC12"),
+                mapDefinition = sampleMapDefinition(),
+                players = listOf(playerOne),
+            )
+        val withCards =
+            baseState
+                .withCardAddedToHand(playerOne, alphaCard)
+                .withCardAddedToHand(playerOne, jokerCard)
+        val withoutAlpha = withCards.withoutCardFromHand(playerOne, alphaCard.cardId)
+
+        assertEquals(listOf(alphaCard, jokerCard), withCards.handOf(playerOne))
+        assertEquals(2, withCards.handSizeOf(playerOne))
+        assertTrue(withCards.playerHasCard(playerOne, jokerCard.cardId))
+        assertEquals(listOf(jokerCard), withoutAlpha.handOf(playerOne))
+        assertFalse(withoutAlpha.playerHasCard(playerOne, alphaCard.cardId))
+    }
+
+    @Test
     fun `should resolve legacy turn state when only legacy fields are set`() {
         val playerOne = PlayerId(1)
         val playerTwo = PlayerId(2)
@@ -457,6 +483,9 @@ class GameStateTest {
             GameState(lobbyCode = LobbyCode("PQ56"), processedEventCount = -1)
         }
         assertThrows(IllegalArgumentException::class.java) {
+            GameState(lobbyCode = LobbyCode("PQ57"), tradedInSetCount = -1)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
             GameState(
                 lobbyCode = LobbyCode("RS78"),
                 players = listOf(playerOne, playerOne),
@@ -520,6 +549,56 @@ class GameStateTest {
             GameState(
                 lobbyCode = LobbyCode("XZ56"),
                 mapDefinition = sampleMapDefinition(),
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            GameState(
+                lobbyCode = LobbyCode("XZ78"),
+                players = listOf(playerOne),
+                turnOrder = listOf(playerOne),
+                handState =
+                    HandState(
+                        cardsByPlayer =
+                            mapOf(
+                                playerTwo to
+                                    listOf(
+                                        CardState(
+                                            cardId = CardId("card-foreign"),
+                                            type = CardType.C,
+                                        ),
+                                    ),
+                            ),
+                    ),
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            GameState(
+                lobbyCode = LobbyCode("YZ12"),
+                players = listOf(playerOne),
+                turnOrder = listOf(playerOne),
+                handState =
+                    HandState(
+                        cardsByPlayer =
+                            mapOf(
+                                playerOne to
+                                    listOf(
+                                        CardState(
+                                            cardId = CardId("shared-card"),
+                                            type = CardType.A,
+                                        ),
+                                    ),
+                            ),
+                    ),
+                deckState =
+                    DeckState(
+                        cards =
+                            listOf(
+                                CardState(
+                                    cardId = CardId("shared-card"),
+                                    type = CardType.B,
+                                ),
+                            ),
+                    ),
             )
         }
         assertThrows(IllegalArgumentException::class.java) {

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/state/HandStateTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/state/HandStateTest.kt
@@ -45,4 +45,40 @@ class HandStateTest {
             )
         }
     }
+
+    @Test
+    fun `withCardAdded rejects card whose id already exists in another hand`() {
+        val playerOne = PlayerId(1)
+        val playerTwo = PlayerId(2)
+        val card = CardState(cardId = CardId("shared-card"), type = CardType.A)
+        val hand = HandState().withCardAdded(playerOne, card)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            hand.withCardAdded(playerTwo, card)
+        }
+    }
+
+    @Test
+    fun `withoutCard rejects removal of card not held by player`() {
+        val playerId = PlayerId(1)
+        val card = CardState(cardId = CardId("present"), type = CardType.B)
+        val absentId = CardId("absent")
+        val hand = HandState().withCardAdded(playerId, card)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            hand.withoutCard(playerId, absentId)
+        }
+    }
+
+    @Test
+    fun `withoutCard removes player entry when last card is taken out`() {
+        val playerId = PlayerId(1)
+        val card = CardState(cardId = CardId("only-card"), type = CardType.C)
+        val hand = HandState().withCardAdded(playerId, card)
+
+        val empty = hand.withoutCard(playerId, card.cardId)
+
+        assertFalse(empty.cardsByPlayer.containsKey(playerId))
+        assertEquals(0, empty.handSizeOf(playerId))
+    }
 }

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/state/HandStateTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/state/HandStateTest.kt
@@ -1,0 +1,48 @@
+package at.aau.pulverfass.shared.lobby.state
+
+import at.aau.pulverfass.shared.ids.CardId
+import at.aau.pulverfass.shared.ids.PlayerId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class HandStateTest {
+    @Test
+    fun `should add and remove cards from a player hand`() {
+        val playerId = PlayerId(1)
+        val alphaCard = CardState(cardId = CardId("card-alpha"), type = CardType.A)
+        val jokerCard = CardState(cardId = CardId("card-joker"), type = CardType.JOKER)
+
+        val withCards =
+            HandState()
+                .withCardAdded(playerId, alphaCard)
+                .withCardAdded(playerId, jokerCard)
+        val withoutAlpha = withCards.withoutCard(playerId, alphaCard.cardId)
+
+        assertEquals(listOf(alphaCard, jokerCard), withCards.cardsOf(playerId))
+        assertEquals(2, withCards.handSizeOf(playerId))
+        assertTrue(withCards.contains(playerId, jokerCard.cardId))
+        assertEquals(listOf(jokerCard), withoutAlpha.cardsOf(playerId))
+        assertEquals(1, withoutAlpha.handSizeOf(playerId))
+        assertFalse(withoutAlpha.contains(playerId, alphaCard.cardId))
+    }
+
+    @Test
+    fun `should reject duplicate card ids across all player hands`() {
+        val playerOne = PlayerId(1)
+        val playerTwo = PlayerId(2)
+        val duplicatedCard = CardState(cardId = CardId("card-1"), type = CardType.B)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            HandState(
+                cardsByPlayer =
+                    mapOf(
+                        playerOne to listOf(duplicatedCard),
+                        playerTwo to listOf(duplicatedCard),
+                    ),
+            )
+        }
+    }
+}

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/state/TradeInProgressionTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/state/TradeInProgressionTest.kt
@@ -1,6 +1,7 @@
 package at.aau.pulverfass.shared.lobby.state
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 
 class TradeInProgressionTest {
@@ -12,5 +13,15 @@ class TradeInProgressionTest {
         assertEquals(8, TradeInProgression.tradeInValue(4))
         assertEquals(10, TradeInProgression.tradeInValue(5))
         assertEquals(10, TradeInProgression.tradeInValue(6))
+    }
+
+    @Test
+    fun `tradeInValue rejects zero and negative indices`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            TradeInProgression.tradeInValue(0)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            TradeInProgression.tradeInValue(-3)
+        }
     }
 }

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/state/TradeInProgressionTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/state/TradeInProgressionTest.kt
@@ -1,0 +1,16 @@
+package at.aau.pulverfass.shared.lobby.state
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class TradeInProgressionTest {
+    @Test
+    fun `trade in values for one to six are correct`() {
+        assertEquals(2, TradeInProgression.tradeInValue(1))
+        assertEquals(4, TradeInProgression.tradeInValue(2))
+        assertEquals(6, TradeInProgression.tradeInValue(3))
+        assertEquals(8, TradeInProgression.tradeInValue(4))
+        assertEquals(10, TradeInProgression.tradeInValue(5))
+        assertEquals(10, TradeInProgression.tradeInValue(6))
+    }
+}

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/map/config/MapConfigLoaderTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/map/config/MapConfigLoaderTest.kt
@@ -18,6 +18,12 @@ class MapConfigLoaderTest {
         assertEquals(MapConfig.CURRENT_SCHEMA_VERSION, definition.schemaVersion)
         assertEquals(24, definition.territories.size)
         assertEquals(6, definition.continents.size)
+        assertEquals(2, definition.continentsById.getValue(ContinentId("nordamerika")).bonusValue)
+        assertEquals(2, definition.continentsById.getValue(ContinentId("europa")).bonusValue)
+        assertEquals(3, definition.continentsById.getValue(ContinentId("asien")).bonusValue)
+        assertEquals(1, definition.continentsById.getValue(ContinentId("suedamerika")).bonusValue)
+        assertEquals(2, definition.continentsById.getValue(ContinentId("afrika")).bonusValue)
+        assertEquals(1, definition.continentsById.getValue(ContinentId("ozeanien")).bonusValue)
         assertNotNull(definition.territoriesById[TerritoryId("argentinien")])
         assertTrue(
             definition.territoriesById
@@ -66,7 +72,7 @@ class MapConfigLoaderTest {
                         { "territoryId": "beta", "edges": [{ "targetId": "alpha" }] }
                       ],
                       "continents": [
-                        { "continentId": "north", "territoryIds": ["alpha", "beta"], "bonusValue": 2 }
+                        { "continentId": "north", "territoryIds": ["alpha", "beta"], "bonus": 2 }
                       ]
                     }
                     """.trimIndent(),
@@ -89,7 +95,7 @@ class MapConfigLoaderTest {
                         { "territoryId": "beta", "adjacentTerritoryIds": ["alpha"] }
                       ],
                       "continents": [
-                        { "continentId": "north", "territoryIds": ["alpha", "beta"], "bonusValue": 2 }
+                        { "continentId": "north", "territoryIds": ["alpha", "beta"], "bonus": 2 }
                       ]
                     }
                     """.trimIndent(),
@@ -112,7 +118,7 @@ class MapConfigLoaderTest {
                         { "territoryId": "beta", "adjacentTerritoryIds": [] }
                       ],
                       "continents": [
-                        { "continentId": "north", "territoryIds": ["alpha", "beta"], "bonusValue": 2 }
+                        { "continentId": "north", "territoryIds": ["alpha", "beta"], "bonus": 2 }
                       ]
                     }
                     """.trimIndent(),
@@ -135,7 +141,7 @@ class MapConfigLoaderTest {
                         { "territoryId": "beta", "edges": [{ "targetId": "alpha" }] }
                       ],
                       "continents": [
-                        { "continentId": "north", "territoryIds": ["alpha", "missing"], "bonusValue": 2 }
+                        { "continentId": "north", "territoryIds": ["alpha", "missing"], "bonus": 2 }
                       ]
                     }
                     """.trimIndent(),
@@ -161,7 +167,7 @@ class MapConfigLoaderTest {
                         { "territoryId": "gamma", "edges": [{ "targetId": "beta" }] }
                       ],
                       "continents": [
-                        { "continentId": "north", "territoryIds": ["alpha", "beta", "gamma"], "bonusValue": 3 }
+                        { "continentId": "north", "territoryIds": ["alpha", "beta", "gamma"], "bonus": 3 }
                       ]
                     }
                     """.trimIndent(),
@@ -195,7 +201,7 @@ class MapConfigLoaderTest {
                         }
                       ],
                       "continents": [
-                        { "continentId": "north", "territoryIds": ["alpha", "beta"], "bonusValue": 2 }
+                        { "continentId": "north", "territoryIds": ["alpha", "beta"], "bonus": 2 }
                       ]
                     }
                     """.trimIndent(),
@@ -218,8 +224,8 @@ class MapConfigLoaderTest {
                         { "territoryId": "beta", "edges": [{ "targetId": "alpha" }] }
                       ],
                       "continents": [
-                        { "continentId": "north", "territoryIds": ["alpha"], "bonusValue": 1 },
-                        { "continentId": "south", "territoryIds": ["alpha", "beta"], "bonusValue": 1 }
+                        { "continentId": "north", "territoryIds": ["alpha"], "bonus": 1 },
+                        { "continentId": "south", "territoryIds": ["alpha", "beta"], "bonus": 1 }
                       ]
                     }
                     """.trimIndent(),
@@ -282,23 +288,46 @@ class MapConfigLoaderTest {
     }
 
     @Test
-    fun `config model defaults and invariants are explicit`() {
+    fun `negative continent bonus führt zu validation fail`() {
+        val exception =
+            assertThrows<MapConfigValidationException> {
+                MapConfigLoader.loadFromJson(
+                    """
+                    {
+                      "schemaVersion": 1,
+                      "territories": [
+                        { "territoryId": "alpha", "edges": [{ "targetId": "beta" }] },
+                        { "territoryId": "beta", "edges": [{ "targetId": "alpha" }] }
+                      ],
+                      "continents": [
+                        { "continentId": "north", "territoryIds": ["alpha", "beta"], "bonus": -1 }
+                      ]
+                    }
+                    """.trimIndent(),
+                )
+            }
+
+        assertTrue(exception.message.orEmpty().contains("negativen Bonus"))
+    }
+
+    @Test
+    fun `config model defaults are explicit`() {
         val territory = TerritoryConfig(territoryId = TerritoryId("alpha"))
         val edge = TerritoryEdgeConfig(TerritoryId("beta"))
         val cause = IllegalStateException("source")
         val exception = MapConfigLoadException("load failed", cause)
+        val continent =
+            ContinentConfig(
+                continentId = ContinentId("north"),
+                territoryIds = listOf(TerritoryId("alpha")),
+                bonus = 2,
+            )
 
         assertTrue(territory.edges.isEmpty())
         assertTrue(territory.adjacentTerritoryIds.isEmpty())
         assertEquals(TerritoryId("beta"), edge.targetId)
+        assertEquals(2, continent.bonus)
         assertSame(cause, exception.cause)
-        assertThrows<IllegalArgumentException> {
-            ContinentConfig(
-                continentId = ContinentId("north"),
-                territoryIds = listOf(TerritoryId("alpha")),
-                bonusValue = -1,
-            )
-        }
     }
 
     private fun validEdgesJson(): String =
@@ -327,8 +356,8 @@ class MapConfigLoaderTest {
             }
           ],
           "continents": [
-            { "continentId": "north", "territoryIds": ["alpha", "beta"], "bonusValue": 2 },
-            { "continentId": "south", "territoryIds": ["gamma"], "bonusValue": 1 }
+            { "continentId": "north", "territoryIds": ["alpha", "beta"], "bonus": 2 },
+            { "continentId": "south", "territoryIds": ["gamma"], "bonus": 1 }
           ]
         }
         """.trimIndent()
@@ -352,8 +381,8 @@ class MapConfigLoaderTest {
             }
           ],
           "continents": [
-            { "continentId": "north", "territoryIds": ["alpha", "beta"], "bonusValue": 2 },
-            { "continentId": "south", "territoryIds": ["gamma"], "bonusValue": 1 }
+            { "continentId": "north", "territoryIds": ["alpha", "beta"], "bonus": 2 },
+            { "continentId": "south", "territoryIds": ["gamma"], "bonus": 1 }
           ]
         }
         """.trimIndent()

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/map/config/MapConfigLoaderTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/map/config/MapConfigLoaderTest.kt
@@ -18,10 +18,10 @@ class MapConfigLoaderTest {
         assertEquals(MapConfig.CURRENT_SCHEMA_VERSION, definition.schemaVersion)
         assertEquals(24, definition.territories.size)
         assertEquals(6, definition.continents.size)
-        assertEquals(2, definition.continentsById.getValue(ContinentId("nordamerika")).bonusValue)
+        assertEquals(3, definition.continentsById.getValue(ContinentId("nordamerika")).bonusValue)
         assertEquals(2, definition.continentsById.getValue(ContinentId("europa")).bonusValue)
-        assertEquals(3, definition.continentsById.getValue(ContinentId("asien")).bonusValue)
-        assertEquals(1, definition.continentsById.getValue(ContinentId("suedamerika")).bonusValue)
+        assertEquals(4, definition.continentsById.getValue(ContinentId("asien")).bonusValue)
+        assertEquals(2, definition.continentsById.getValue(ContinentId("suedamerika")).bonusValue)
         assertEquals(2, definition.continentsById.getValue(ContinentId("afrika")).bonusValue)
         assertEquals(1, definition.continentsById.getValue(ContinentId("ozeanien")).bonusValue)
         assertNotNull(definition.territoriesById[TerritoryId("argentinien")])
@@ -65,7 +65,7 @@ class MapConfigLoaderTest {
                 MapConfigLoader.loadFromJson(
                     """
                     {
-                      "schemaVersion": 1,
+                      "schemaVersion": 2,
                       "territories": [
                         { "territoryId": "alpha", "edges": [{ "targetId": "beta" }] },
                         { "territoryId": "alpha", "edges": [{ "targetId": "beta" }] },
@@ -89,7 +89,7 @@ class MapConfigLoaderTest {
                 MapConfigLoader.loadFromJson(
                     """
                     {
-                      "schemaVersion": 1,
+                      "schemaVersion": 2,
                       "territories": [
                         { "territoryId": "alpha", "adjacentTerritoryIds": ["beta", "missing"] },
                         { "territoryId": "beta", "adjacentTerritoryIds": ["alpha"] }
@@ -112,7 +112,7 @@ class MapConfigLoaderTest {
                 MapConfigLoader.loadFromJson(
                     """
                     {
-                      "schemaVersion": 1,
+                      "schemaVersion": 2,
                       "territories": [
                         { "territoryId": "alpha", "adjacentTerritoryIds": ["beta"] },
                         { "territoryId": "beta", "adjacentTerritoryIds": [] }
@@ -135,7 +135,7 @@ class MapConfigLoaderTest {
                 MapConfigLoader.loadFromJson(
                     """
                     {
-                      "schemaVersion": 1,
+                      "schemaVersion": 2,
                       "territories": [
                         { "territoryId": "alpha", "edges": [{ "targetId": "beta" }] },
                         { "territoryId": "beta", "edges": [{ "targetId": "alpha" }] }
@@ -160,7 +160,7 @@ class MapConfigLoaderTest {
                 MapConfigLoader.loadFromJson(
                     """
                     {
-                      "schemaVersion": 1,
+                      "schemaVersion": 2,
                       "territories": [
                         { "territoryId": "alpha", "edges": [{ "targetId": "beta" }] },
                         { "territoryId": "beta", "edges": [{ "targetId": "gamma" }] },
@@ -186,7 +186,7 @@ class MapConfigLoaderTest {
                 MapConfigLoader.loadFromJson(
                     """
                     {
-                      "schemaVersion": 1,
+                      "schemaVersion": 2,
                       "territories": [
                         {
                           "territoryId": "alpha",
@@ -218,7 +218,7 @@ class MapConfigLoaderTest {
                 MapConfigLoader.loadFromJson(
                     """
                     {
-                      "schemaVersion": 1,
+                      "schemaVersion": 2,
                       "territories": [
                         { "territoryId": "alpha", "edges": [{ "targetId": "beta" }] },
                         { "territoryId": "beta", "edges": [{ "targetId": "alpha" }] }
@@ -294,7 +294,7 @@ class MapConfigLoaderTest {
                 MapConfigLoader.loadFromJson(
                     """
                     {
-                      "schemaVersion": 1,
+                      "schemaVersion": 2,
                       "territories": [
                         { "territoryId": "alpha", "edges": [{ "targetId": "beta" }] },
                         { "territoryId": "beta", "edges": [{ "targetId": "alpha" }] }
@@ -333,7 +333,7 @@ class MapConfigLoaderTest {
     private fun validEdgesJson(): String =
         """
         {
-          "schemaVersion": 1,
+          "schemaVersion": 2,
           "territories": [
             {
               "territoryId": "alpha",
@@ -365,7 +365,7 @@ class MapConfigLoaderTest {
     private fun validLegacyJson(): String =
         """
         {
-          "schemaVersion": 1,
+          "schemaVersion": 2,
           "territories": [
             {
               "territoryId": "alpha",

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/map/config/MapDefinitionHashingTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/map/config/MapDefinitionHashingTest.kt
@@ -29,7 +29,7 @@ class MapDefinitionHashingTest {
                     { "territoryId": "beta", "edges": [{ "targetId": "alpha" }] }
                   ],
                   "continents": [
-                    { "continentId": "north", "territoryIds": ["alpha", "beta"], "bonusValue": 2 }
+                    { "continentId": "north", "territoryIds": ["alpha", "beta"], "bonus": 2 }
                   ]
                 }
                 """.trimIndent(),
@@ -40,7 +40,7 @@ class MapDefinitionHashingTest {
                 {
                   "continents": [
                     {
-                      "bonusValue": 2,
+                      "bonus": 2,
                       "territoryIds": ["alpha", "beta"],
                       "continentId": "north"
                     }
@@ -98,8 +98,8 @@ class MapDefinitionHashingTest {
                     }
                   ],
                   "continents": [
-                    { "continentId": "north", "territoryIds": ["alpha", "beta"], "bonusValue": 2 },
-                    { "continentId": "south", "territoryIds": ["gamma"], "bonusValue": 1 }
+                    { "continentId": "north", "territoryIds": ["alpha", "beta"], "bonus": 2 },
+                    { "continentId": "south", "territoryIds": ["gamma"], "bonus": 1 }
                   ]
                 }
                 """.trimIndent(),
@@ -199,7 +199,7 @@ class MapDefinitionHashingTest {
         val definition = MapConfigLoader.loadDefault()
 
         assertEquals(
-            "73224ce6c8944f5413b4afff99f77ad3964f90b91b5de6807bf8891b33e6ec56",
+            "c36f7b9b02a068333f24e52af875ed50836a3f9d1c328186a9a804b1bf7f2a43",
             definition.mapHash,
         )
     }
@@ -230,8 +230,8 @@ class MapDefinitionHashingTest {
             }
           ],
           "continents": [
-            { "continentId": "north", "territoryIds": ["alpha", "beta"], "bonusValue": 2 },
-            { "continentId": "south", "territoryIds": ["gamma"], "bonusValue": 1 }
+            { "continentId": "north", "territoryIds": ["alpha", "beta"], "bonus": 2 },
+            { "continentId": "south", "territoryIds": ["gamma"], "bonus": 1 }
           ]
         }
         """.trimIndent()

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/map/config/MapDefinitionHashingTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/map/config/MapDefinitionHashingTest.kt
@@ -23,7 +23,7 @@ class MapDefinitionHashingTest {
             MapConfigLoader.loadFromJson(
                 """
                 {
-                  "schemaVersion": 1,
+                  "schemaVersion": 2,
                   "territories": [
                     { "territoryId": "alpha", "edges": [{ "targetId": "beta" }] },
                     { "territoryId": "beta", "edges": [{ "targetId": "alpha" }] }
@@ -57,7 +57,7 @@ class MapDefinitionHashingTest {
                       "edges": [{ "targetId": "alpha" }]
                     }
                   ],
-                  "schemaVersion": 1
+                  "schemaVersion": 2
                 }
                 """.trimIndent(),
             )
@@ -73,7 +73,7 @@ class MapDefinitionHashingTest {
             MapConfigLoader.loadFromJson(
                 """
                 {
-                  "schemaVersion": 1,
+                  "schemaVersion": 2,
                   "territories": [
                     {
                       "territoryId": "alpha",
@@ -199,7 +199,7 @@ class MapDefinitionHashingTest {
         val definition = MapConfigLoader.loadDefault()
 
         assertEquals(
-            "c36f7b9b02a068333f24e52af875ed50836a3f9d1c328186a9a804b1bf7f2a43",
+            "fbb6d67f4b4f0994ab6bcfe7a875b5411b1eeac9b3b5493fdbdc27c1e48128e4",
             definition.mapHash,
         )
     }
@@ -207,7 +207,7 @@ class MapDefinitionHashingTest {
     private fun validEdgesJson(): String =
         """
         {
-          "schemaVersion": 1,
+          "schemaVersion": 2,
           "territories": [
             {
               "territoryId": "alpha",

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/ConfirmReinforcementsDoneMessageTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/ConfirmReinforcementsDoneMessageTest.kt
@@ -1,0 +1,64 @@
+package at.aau.pulverfass.shared.network.message
+
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.message.lobby.request.ConfirmReinforcementsDoneRequest
+import at.aau.pulverfass.shared.message.lobby.response.ConfirmReinforcementsDoneResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.ConfirmReinforcementsDoneErrorCode
+import at.aau.pulverfass.shared.message.lobby.response.error.ConfirmReinforcementsDoneErrorResponse
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ConfirmReinforcementsDoneMessageTest {
+    private val json = Json
+
+    @Test
+    fun `serializer roundtrip request`() {
+        val request =
+            ConfirmReinforcementsDoneRequest(
+                lobbyCode = LobbyCode("AB12"),
+                playerId = PlayerId(7),
+            )
+
+        val serialized =
+            json.encodeToString(ConfirmReinforcementsDoneRequest.serializer(), request)
+        val deserialized =
+            json.decodeFromString(ConfirmReinforcementsDoneRequest.serializer(), serialized)
+
+        assertEquals(request, deserialized)
+    }
+
+    @Test
+    fun `serializer roundtrip response`() {
+        val response = ConfirmReinforcementsDoneResponse(lobbyCode = LobbyCode("CD34"))
+
+        val serialized =
+            json.encodeToString(ConfirmReinforcementsDoneResponse.serializer(), response)
+        val deserialized =
+            json.decodeFromString(ConfirmReinforcementsDoneResponse.serializer(), serialized)
+
+        assertEquals(response, deserialized)
+    }
+
+    @Test
+    fun `serializer roundtrip error response`() {
+        val response =
+            ConfirmReinforcementsDoneErrorResponse(
+                code = ConfirmReinforcementsDoneErrorCode.PENDING_REINFORCEMENTS_REMAINING,
+                reason = "Noch offene Verstärkungen vorhanden.",
+            )
+
+        val serialized =
+            json.encodeToString(ConfirmReinforcementsDoneErrorResponse.serializer(), response)
+        val deserialized =
+            json.decodeFromString(
+                ConfirmReinforcementsDoneErrorResponse.serializer(),
+                serialized,
+            )
+
+        assertTrue(serialized.contains("PENDING_REINFORCEMENTS_REMAINING"))
+        assertEquals(response, deserialized)
+    }
+}

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/GameStateCatchUpMessageTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/GameStateCatchUpMessageTest.kt
@@ -58,6 +58,7 @@ class GameStateCatchUpMessageTest {
                         turnPhase = TurnPhase.REINFORCEMENTS,
                         turnCount = 2,
                         startPlayerId = PlayerId(1),
+                        pendingReinforcements = 3,
                     ),
                 definition =
                     MapDefinitionSnapshot(
@@ -85,6 +86,7 @@ class GameStateCatchUpMessageTest {
 
         assertTrue(serialized.contains("determinism"))
         assertTrue(serialized.contains("turnState"))
+        assertTrue(serialized.contains("pendingReinforcements"))
         assertFalse(serialized.contains("recipientPlayerId"))
         assertEquals(response, deserialized)
     }

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/MessageTypeTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/MessageTypeTest.kt
@@ -89,6 +89,10 @@ class MessageTypeTest {
                 MessageType.LOBBY_CONFIRM_REINFORCEMENTS_DONE_ERROR_RESPONSE,
             ),
         )
+        assertTrue(MessageType.entries.contains(MessageType.LOBBY_TRADE_IN_CARDS_REQUEST))
+        assertTrue(MessageType.entries.contains(MessageType.LOBBY_TRADE_IN_CARDS_RESPONSE))
+        assertTrue(MessageType.entries.contains(MessageType.LOBBY_TRADE_IN_CARDS_ERROR_RESPONSE))
+        assertTrue(MessageType.entries.contains(MessageType.LOBBY_PLAYER_HAND_UPDATED_EVENT))
         assertTrue(MessageType.entries.contains(MessageType.LOBBY_PLAYER_LEFT_BROADCAST))
         assertTrue(MessageType.entries.contains(MessageType.LOBBY_MAP_GET_REQUEST))
         assertTrue(MessageType.entries.contains(MessageType.LOBBY_MAP_GET_RESPONSE))

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/MessageTypeTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/MessageTypeTest.kt
@@ -65,6 +65,30 @@ class MessageTypeTest {
         assertTrue(MessageType.entries.contains(MessageType.LOBBY_PLAYER_COUNT_REQUEST))
         assertTrue(MessageType.entries.contains(MessageType.LOBBY_PLAYER_COUNT_RESPONSE))
         assertTrue(MessageType.entries.contains(MessageType.LOBBY_PLAYER_COUNT_ERROR_RESPONSE))
+        assertTrue(
+            MessageType.entries.contains(MessageType.LOBBY_REINFORCEMENTS_GRANTED_BROADCAST),
+        )
+        assertTrue(
+            MessageType.entries.contains(
+                MessageType.LOBBY_PENDING_REINFORCEMENTS_CHANGED_BROADCAST,
+            ),
+        )
+        assertTrue(MessageType.entries.contains(MessageType.LOBBY_PLACE_REINFORCEMENTS_REQUEST))
+        assertTrue(MessageType.entries.contains(MessageType.LOBBY_PLACE_REINFORCEMENTS_RESPONSE))
+        assertTrue(
+            MessageType.entries.contains(MessageType.LOBBY_PLACE_REINFORCEMENTS_ERROR_RESPONSE),
+        )
+        assertTrue(
+            MessageType.entries.contains(MessageType.LOBBY_CONFIRM_REINFORCEMENTS_DONE_REQUEST),
+        )
+        assertTrue(
+            MessageType.entries.contains(MessageType.LOBBY_CONFIRM_REINFORCEMENTS_DONE_RESPONSE),
+        )
+        assertTrue(
+            MessageType.entries.contains(
+                MessageType.LOBBY_CONFIRM_REINFORCEMENTS_DONE_ERROR_RESPONSE,
+            ),
+        )
         assertTrue(MessageType.entries.contains(MessageType.LOBBY_PLAYER_LEFT_BROADCAST))
         assertTrue(MessageType.entries.contains(MessageType.LOBBY_MAP_GET_REQUEST))
         assertTrue(MessageType.entries.contains(MessageType.LOBBY_MAP_GET_RESPONSE))

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/NetworkPayloadRegistryTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/NetworkPayloadRegistryTest.kt
@@ -4,6 +4,7 @@ import at.aau.pulverfass.shared.ids.LobbyCode
 import at.aau.pulverfass.shared.ids.PlayerId
 import at.aau.pulverfass.shared.ids.SessionToken
 import at.aau.pulverfass.shared.ids.TerritoryId
+import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsChangedEvent
 import at.aau.pulverfass.shared.lobby.event.TerritoryOwnerChangedEvent
 import at.aau.pulverfass.shared.lobby.event.TerritoryTroopsChangedEvent
 import at.aau.pulverfass.shared.lobby.event.TurnStateUpdatedEvent
@@ -20,20 +21,26 @@ import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostReason
 import at.aau.pulverfass.shared.message.lobby.event.PlayerJoinedLobbyEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerLeftLobbyEvent
+import at.aau.pulverfass.shared.message.lobby.event.ReinforcementsGrantedEvent
+import at.aau.pulverfass.shared.message.lobby.request.ConfirmReinforcementsDoneRequest
 import at.aau.pulverfass.shared.message.lobby.request.CreateLobbyRequest
 import at.aau.pulverfass.shared.message.lobby.request.JoinLobbyRequest
 import at.aau.pulverfass.shared.message.lobby.request.LeaveLobbyRequest
 import at.aau.pulverfass.shared.message.lobby.request.LobbyPlayerCountRequest
 import at.aau.pulverfass.shared.message.lobby.request.MapGetRequest
+import at.aau.pulverfass.shared.message.lobby.request.PlaceReinforcementsRequest
 import at.aau.pulverfass.shared.message.lobby.request.StartPlayerSetRequest
+import at.aau.pulverfass.shared.message.lobby.request.TerritoryPlacement
 import at.aau.pulverfass.shared.message.lobby.request.TurnAdvanceRequest
 import at.aau.pulverfass.shared.message.lobby.request.TurnStateGetRequest
 import at.aau.pulverfass.shared.message.lobby.response.CreateLobbyResponse
+import at.aau.pulverfass.shared.message.lobby.response.ConfirmReinforcementsDoneResponse
 import at.aau.pulverfass.shared.message.lobby.response.JoinLobbyResponse
 import at.aau.pulverfass.shared.message.lobby.response.LeaveLobbyResponse
 import at.aau.pulverfass.shared.message.lobby.response.LobbyPlayerCountResponse
 import at.aau.pulverfass.shared.message.lobby.response.MapDefinitionSnapshot
 import at.aau.pulverfass.shared.message.lobby.response.MapGetResponse
+import at.aau.pulverfass.shared.message.lobby.response.PlaceReinforcementsResponse
 import at.aau.pulverfass.shared.message.lobby.response.MapTerritoryDefinitionSnapshot
 import at.aau.pulverfass.shared.message.lobby.response.MapTerritoryEdgeSnapshot
 import at.aau.pulverfass.shared.message.lobby.response.MapTerritoryStateSnapshot
@@ -43,11 +50,15 @@ import at.aau.pulverfass.shared.message.lobby.response.StartPlayerSetResponse
 import at.aau.pulverfass.shared.message.lobby.response.TurnAdvanceResponse
 import at.aau.pulverfass.shared.message.lobby.response.TurnStateGetResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.CreateLobbyErrorResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.ConfirmReinforcementsDoneErrorCode
+import at.aau.pulverfass.shared.message.lobby.response.error.ConfirmReinforcementsDoneErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.JoinLobbyErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.LobbyPlayerCountErrorCode
 import at.aau.pulverfass.shared.message.lobby.response.error.LobbyPlayerCountErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.MapGetErrorCode
 import at.aau.pulverfass.shared.message.lobby.response.error.MapGetErrorResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.PlaceReinforcementsErrorCode
+import at.aau.pulverfass.shared.message.lobby.response.error.PlaceReinforcementsErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.StartPlayerSetErrorCode
 import at.aau.pulverfass.shared.message.lobby.response.error.StartPlayerSetErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.TurnAdvanceErrorCode
@@ -230,6 +241,132 @@ class NetworkPayloadRegistryTest {
             """{"lobbyCode":"EF57","playerId":18,"reason":"HEARTBEAT_TIMEOUT"}""",
             serialized,
         )
+        assertEquals(payload, deserialized)
+    }
+
+    @Test
+    fun `should resolve message type and serialization for reinforcements granted event`() {
+        val payload =
+            ReinforcementsGrantedEvent(
+                lobbyCode = LobbyCode("RG12"),
+                playerId = PlayerId(8),
+                amount = 6,
+                territoryBonus = 4,
+                continentBonus = 2,
+                cardBonus = 0,
+            )
+
+        val messageType = NetworkPayloadRegistry.messageTypeFor(payload)
+        val serialized = NetworkPayloadRegistry.serializePayload(payload)
+        val deserialized = NetworkPayloadRegistry.deserializePayload(messageType, serialized)
+
+        assertEquals(MessageType.LOBBY_REINFORCEMENTS_GRANTED_BROADCAST, messageType)
+        assertEquals(payload, deserialized)
+    }
+
+    @Test
+    fun `should resolve message type and serialization for pending reinforcements changed event`() {
+        val payload =
+            PendingReinforcementsChangedEvent(
+                lobbyCode = LobbyCode("PR12"),
+                playerId = PlayerId(9),
+                delta = -4,
+            )
+
+        val messageType = NetworkPayloadRegistry.messageTypeFor(payload)
+        val serialized = NetworkPayloadRegistry.serializePayload(payload)
+        val deserialized = NetworkPayloadRegistry.deserializePayload(messageType, serialized)
+
+        assertEquals(MessageType.LOBBY_PENDING_REINFORCEMENTS_CHANGED_BROADCAST, messageType)
+        assertEquals(payload, deserialized)
+    }
+
+    @Test
+    fun `should resolve message type and serialization for confirm reinforcements done request`() {
+        val payload =
+            ConfirmReinforcementsDoneRequest(
+                lobbyCode = LobbyCode("CR12"),
+                playerId = PlayerId(5),
+            )
+
+        val messageType = NetworkPayloadRegistry.messageTypeFor(payload)
+        val serialized = NetworkPayloadRegistry.serializePayload(payload)
+        val deserialized = NetworkPayloadRegistry.deserializePayload(messageType, serialized)
+
+        assertEquals(MessageType.LOBBY_CONFIRM_REINFORCEMENTS_DONE_REQUEST, messageType)
+        assertEquals(payload, deserialized)
+    }
+
+    @Test
+    fun `should resolve message type and serialization for confirm reinforcements done response`() {
+        val payload = ConfirmReinforcementsDoneResponse(lobbyCode = LobbyCode("CR13"))
+
+        val messageType = NetworkPayloadRegistry.messageTypeFor(payload)
+        val serialized = NetworkPayloadRegistry.serializePayload(payload)
+        val deserialized = NetworkPayloadRegistry.deserializePayload(messageType, serialized)
+
+        assertEquals(MessageType.LOBBY_CONFIRM_REINFORCEMENTS_DONE_RESPONSE, messageType)
+        assertEquals(payload, deserialized)
+    }
+
+    @Test
+    fun `should resolve message type and serialization for confirm reinforcements done error response`() {
+        val payload =
+            ConfirmReinforcementsDoneErrorResponse(
+                code = ConfirmReinforcementsDoneErrorCode.FORCED_TRADE_REQUIRED,
+                reason = "Pflichtabgabe ausstehend.",
+            )
+
+        val messageType = NetworkPayloadRegistry.messageTypeFor(payload)
+        val serialized = NetworkPayloadRegistry.serializePayload(payload)
+        val deserialized = NetworkPayloadRegistry.deserializePayload(messageType, serialized)
+
+        assertEquals(MessageType.LOBBY_CONFIRM_REINFORCEMENTS_DONE_ERROR_RESPONSE, messageType)
+        assertEquals(payload, deserialized)
+    }
+
+    @Test
+    fun `should resolve message type and serialization for place reinforcements request`() {
+        val payload =
+            PlaceReinforcementsRequest(
+                lobbyCode = LobbyCode("PR13"),
+                playerId = PlayerId(3),
+                placements = listOf(TerritoryPlacement(TerritoryId("alpha"), 2)),
+            )
+
+        val messageType = NetworkPayloadRegistry.messageTypeFor(payload)
+        val serialized = NetworkPayloadRegistry.serializePayload(payload)
+        val deserialized = NetworkPayloadRegistry.deserializePayload(messageType, serialized)
+
+        assertEquals(MessageType.LOBBY_PLACE_REINFORCEMENTS_REQUEST, messageType)
+        assertEquals(payload, deserialized)
+    }
+
+    @Test
+    fun `should resolve message type and serialization for place reinforcements response`() {
+        val payload = PlaceReinforcementsResponse(lobbyCode = LobbyCode("PR14"))
+
+        val messageType = NetworkPayloadRegistry.messageTypeFor(payload)
+        val serialized = NetworkPayloadRegistry.serializePayload(payload)
+        val deserialized = NetworkPayloadRegistry.deserializePayload(messageType, serialized)
+
+        assertEquals(MessageType.LOBBY_PLACE_REINFORCEMENTS_RESPONSE, messageType)
+        assertEquals(payload, deserialized)
+    }
+
+    @Test
+    fun `should resolve message type and serialization for place reinforcements error response`() {
+        val payload =
+            PlaceReinforcementsErrorResponse(
+                code = PlaceReinforcementsErrorCode.INVALID_PLACEMENT,
+                reason = "Mindestens eine Platzierung ist ungültig.",
+            )
+
+        val messageType = NetworkPayloadRegistry.messageTypeFor(payload)
+        val serialized = NetworkPayloadRegistry.serializePayload(payload)
+        val deserialized = NetworkPayloadRegistry.deserializePayload(messageType, serialized)
+
+        assertEquals(MessageType.LOBBY_PLACE_REINFORCEMENTS_ERROR_RESPONSE, messageType)
         assertEquals(payload, deserialized)
     }
 

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/NetworkPayloadRegistryTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/NetworkPayloadRegistryTest.kt
@@ -33,25 +33,25 @@ import at.aau.pulverfass.shared.message.lobby.request.StartPlayerSetRequest
 import at.aau.pulverfass.shared.message.lobby.request.TerritoryPlacement
 import at.aau.pulverfass.shared.message.lobby.request.TurnAdvanceRequest
 import at.aau.pulverfass.shared.message.lobby.request.TurnStateGetRequest
-import at.aau.pulverfass.shared.message.lobby.response.CreateLobbyResponse
 import at.aau.pulverfass.shared.message.lobby.response.ConfirmReinforcementsDoneResponse
+import at.aau.pulverfass.shared.message.lobby.response.CreateLobbyResponse
 import at.aau.pulverfass.shared.message.lobby.response.JoinLobbyResponse
 import at.aau.pulverfass.shared.message.lobby.response.LeaveLobbyResponse
 import at.aau.pulverfass.shared.message.lobby.response.LobbyPlayerCountResponse
 import at.aau.pulverfass.shared.message.lobby.response.MapDefinitionSnapshot
 import at.aau.pulverfass.shared.message.lobby.response.MapGetResponse
-import at.aau.pulverfass.shared.message.lobby.response.PlaceReinforcementsResponse
 import at.aau.pulverfass.shared.message.lobby.response.MapTerritoryDefinitionSnapshot
 import at.aau.pulverfass.shared.message.lobby.response.MapTerritoryEdgeSnapshot
 import at.aau.pulverfass.shared.message.lobby.response.MapTerritoryStateSnapshot
+import at.aau.pulverfass.shared.message.lobby.response.PlaceReinforcementsResponse
 import at.aau.pulverfass.shared.message.lobby.response.PublicDeterminismMetadataSnapshot
 import at.aau.pulverfass.shared.message.lobby.response.PublicTurnStateSnapshot
 import at.aau.pulverfass.shared.message.lobby.response.StartPlayerSetResponse
 import at.aau.pulverfass.shared.message.lobby.response.TurnAdvanceResponse
 import at.aau.pulverfass.shared.message.lobby.response.TurnStateGetResponse
-import at.aau.pulverfass.shared.message.lobby.response.error.CreateLobbyErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.ConfirmReinforcementsDoneErrorCode
 import at.aau.pulverfass.shared.message.lobby.response.error.ConfirmReinforcementsDoneErrorResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.CreateLobbyErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.JoinLobbyErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.LobbyPlayerCountErrorCode
 import at.aau.pulverfass.shared.message.lobby.response.error.LobbyPlayerCountErrorResponse
@@ -310,7 +310,7 @@ class NetworkPayloadRegistryTest {
     }
 
     @Test
-    fun `should resolve message type and serialization for confirm reinforcements done error response`() {
+    fun `should resolve message type for confirm reinforcements done error response`() {
         val payload =
             ConfirmReinforcementsDoneErrorResponse(
                 code = ConfirmReinforcementsDoneErrorCode.FORCED_TRADE_REQUIRED,

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/PlaceReinforcementsMessageTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/PlaceReinforcementsMessageTest.kt
@@ -1,0 +1,86 @@
+package at.aau.pulverfass.shared.network.message
+
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.ids.TerritoryId
+import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsChangedEvent
+import at.aau.pulverfass.shared.message.lobby.request.PlaceReinforcementsRequest
+import at.aau.pulverfass.shared.message.lobby.request.TerritoryPlacement
+import at.aau.pulverfass.shared.message.lobby.response.PlaceReinforcementsResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.PlaceReinforcementsErrorCode
+import at.aau.pulverfass.shared.message.lobby.response.error.PlaceReinforcementsErrorResponse
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class PlaceReinforcementsMessageTest {
+    private val json = Json
+
+    @Test
+    fun `serializer roundtrip request`() {
+        val request =
+            PlaceReinforcementsRequest(
+                lobbyCode = LobbyCode("AB12"),
+                playerId = PlayerId(7),
+                placements =
+                    listOf(
+                        TerritoryPlacement(TerritoryId("alpha"), 2),
+                        TerritoryPlacement(TerritoryId("beta"), 3),
+                    ),
+            )
+
+        val serialized = json.encodeToString(PlaceReinforcementsRequest.serializer(), request)
+        val deserialized =
+            json.decodeFromString(PlaceReinforcementsRequest.serializer(), serialized)
+
+        assertTrue(serialized.contains("placements"))
+        assertEquals(request, deserialized)
+    }
+
+    @Test
+    fun `serializer roundtrip response`() {
+        val response = PlaceReinforcementsResponse(lobbyCode = LobbyCode("CD34"))
+
+        val serialized = json.encodeToString(PlaceReinforcementsResponse.serializer(), response)
+        val deserialized =
+            json.decodeFromString(PlaceReinforcementsResponse.serializer(), serialized)
+
+        assertEquals(response, deserialized)
+    }
+
+    @Test
+    fun `serializer roundtrip error response`() {
+        val response =
+            PlaceReinforcementsErrorResponse(
+                code = PlaceReinforcementsErrorCode.OVERSPEND,
+                reason = "Zu viele Truppen angefordert.",
+            )
+
+        val serialized =
+            json.encodeToString(PlaceReinforcementsErrorResponse.serializer(), response)
+        val deserialized =
+            json.decodeFromString(PlaceReinforcementsErrorResponse.serializer(), serialized)
+
+        assertTrue(serialized.contains("OVERSPEND"))
+        assertEquals(response, deserialized)
+    }
+
+    @Test
+    fun `serializer roundtrip pending reinforcements changed event`() {
+        val event =
+            PendingReinforcementsChangedEvent(
+                lobbyCode = LobbyCode("EF56"),
+                playerId = PlayerId(4),
+                delta = -3,
+            )
+
+        val serialized =
+            json.encodeToString(PendingReinforcementsChangedEvent.serializer(), event)
+        val deserialized =
+            json.decodeFromString(PendingReinforcementsChangedEvent.serializer(), serialized)
+
+        assertTrue(serialized.contains("delta"))
+        assertEquals(event, deserialized)
+    }
+}

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/ReinforcementsGrantedEventMessageTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/ReinforcementsGrantedEventMessageTest.kt
@@ -1,0 +1,31 @@
+package at.aau.pulverfass.shared.network.message
+
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.message.lobby.event.ReinforcementsGrantedEvent
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ReinforcementsGrantedEventMessageTest {
+    private val json = Json
+
+    @Test
+    fun `serializer roundtrip reinforcements granted event`() {
+        val event =
+            ReinforcementsGrantedEvent(
+                lobbyCode = LobbyCode("RG12"),
+                playerId = PlayerId(7),
+                amount = 5,
+                territoryBonus = 3,
+                continentBonus = 2,
+                cardBonus = 0,
+            )
+
+        val serialized = json.encodeToString(ReinforcementsGrantedEvent.serializer(), event)
+        val deserialized =
+            json.decodeFromString(ReinforcementsGrantedEvent.serializer(), serialized)
+
+        assertEquals(event, deserialized)
+    }
+}

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/TradeInCardsMessageTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/TradeInCardsMessageTest.kt
@@ -1,0 +1,85 @@
+package at.aau.pulverfass.shared.network.message
+
+import at.aau.pulverfass.shared.ids.CardId
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.lobby.state.CardType
+import at.aau.pulverfass.shared.message.lobby.event.PlayerHandUpdatedEvent
+import at.aau.pulverfass.shared.message.lobby.event.PrivateHandCardSnapshot
+import at.aau.pulverfass.shared.message.lobby.request.TradeInCardsRequest
+import at.aau.pulverfass.shared.message.lobby.response.TradeInCardsResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.TradeInCardsErrorCode
+import at.aau.pulverfass.shared.message.lobby.response.error.TradeInCardsErrorResponse
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class TradeInCardsMessageTest {
+    private val json = Json
+
+    @Test
+    fun `serializer roundtrip request`() {
+        val request =
+            TradeInCardsRequest(
+                lobbyCode = LobbyCode("AB12"),
+                playerId = PlayerId(7),
+                cardIds = listOf(CardId("card-a"), CardId("card-b"), CardId("card-c")),
+            )
+
+        val serialized = json.encodeToString(TradeInCardsRequest.serializer(), request)
+        val deserialized = json.decodeFromString(TradeInCardsRequest.serializer(), serialized)
+
+        assertTrue(serialized.contains("cardIds"))
+        assertEquals(request, deserialized)
+    }
+
+    @Test
+    fun `serializer roundtrip response`() {
+        val response = TradeInCardsResponse(lobbyCode = LobbyCode("CD34"))
+
+        val serialized = json.encodeToString(TradeInCardsResponse.serializer(), response)
+        val deserialized = json.decodeFromString(TradeInCardsResponse.serializer(), serialized)
+
+        assertEquals(response, deserialized)
+    }
+
+    @Test
+    fun `serializer roundtrip error response`() {
+        val response =
+            TradeInCardsErrorResponse(
+                code = TradeInCardsErrorCode.INVALID_SET,
+                reason = "Die ausgewaehlten Karten bilden kein gueltiges Trade-In-Set.",
+            )
+
+        val serialized = json.encodeToString(TradeInCardsErrorResponse.serializer(), response)
+        val deserialized =
+            json.decodeFromString(TradeInCardsErrorResponse.serializer(), serialized)
+
+        assertTrue(serialized.contains("INVALID_SET"))
+        assertEquals(response, deserialized)
+    }
+
+    @Test
+    fun `serializer roundtrip private hand updated event`() {
+        val event =
+            PlayerHandUpdatedEvent(
+                lobbyCode = LobbyCode("EF56"),
+                recipientPlayerId = PlayerId(4),
+                stateVersion = 9,
+                handCards =
+                    listOf(
+                        PrivateHandCardSnapshot(CardId("card-a"), CardType.A),
+                        PrivateHandCardSnapshot(CardId("card-joker"), CardType.JOKER),
+                    ),
+            )
+
+        val serialized = json.encodeToString(PlayerHandUpdatedEvent.serializer(), event)
+        val deserialized =
+            json.decodeFromString(PlayerHandUpdatedEvent.serializer(), serialized)
+
+        assertTrue(serialized.contains("recipientPlayerId"))
+        assertTrue(serialized.contains("handCards"))
+        assertEquals(event, deserialized)
+    }
+}

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/TradeInCardsRegistryTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/TradeInCardsRegistryTest.kt
@@ -1,0 +1,81 @@
+package at.aau.pulverfass.shared.network.message
+
+import at.aau.pulverfass.shared.ids.CardId
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.lobby.state.CardType
+import at.aau.pulverfass.shared.message.codec.NetworkPayloadRegistry
+import at.aau.pulverfass.shared.message.lobby.event.PlayerHandUpdatedEvent
+import at.aau.pulverfass.shared.message.lobby.event.PrivateHandCardSnapshot
+import at.aau.pulverfass.shared.message.lobby.request.TradeInCardsRequest
+import at.aau.pulverfass.shared.message.lobby.response.TradeInCardsResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.TradeInCardsErrorCode
+import at.aau.pulverfass.shared.message.lobby.response.error.TradeInCardsErrorResponse
+import at.aau.pulverfass.shared.message.protocol.MessageType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class TradeInCardsRegistryTest {
+    @Test
+    fun `should resolve message type and serialization for trade in request`() {
+        val payload =
+            TradeInCardsRequest(
+                lobbyCode = LobbyCode("TI12"),
+                playerId = PlayerId(4),
+                cardIds = listOf(CardId("card-a"), CardId("card-b"), CardId("card-c")),
+            )
+
+        val messageType = NetworkPayloadRegistry.messageTypeFor(payload)
+        val serialized = NetworkPayloadRegistry.serializePayload(payload)
+        val deserialized = NetworkPayloadRegistry.deserializePayload(messageType, serialized)
+
+        assertEquals(MessageType.LOBBY_TRADE_IN_CARDS_REQUEST, messageType)
+        assertEquals(payload, deserialized)
+    }
+
+    @Test
+    fun `should resolve message type and serialization for trade in response`() {
+        val payload = TradeInCardsResponse(LobbyCode("TI34"))
+
+        val messageType = NetworkPayloadRegistry.messageTypeFor(payload)
+        val serialized = NetworkPayloadRegistry.serializePayload(payload)
+        val deserialized = NetworkPayloadRegistry.deserializePayload(messageType, serialized)
+
+        assertEquals(MessageType.LOBBY_TRADE_IN_CARDS_RESPONSE, messageType)
+        assertEquals(payload, deserialized)
+    }
+
+    @Test
+    fun `should resolve message type and serialization for trade in error response`() {
+        val payload =
+            TradeInCardsErrorResponse(
+                code = TradeInCardsErrorCode.CARDS_NOT_OWNED,
+                reason = "Alle eingetauschten Karten muessen Spieler '4' gehoeren.",
+            )
+
+        val messageType = NetworkPayloadRegistry.messageTypeFor(payload)
+        val serialized = NetworkPayloadRegistry.serializePayload(payload)
+        val deserialized = NetworkPayloadRegistry.deserializePayload(messageType, serialized)
+
+        assertEquals(MessageType.LOBBY_TRADE_IN_CARDS_ERROR_RESPONSE, messageType)
+        assertEquals(payload, deserialized)
+    }
+
+    @Test
+    fun `should resolve message type and serialization for player hand updated event`() {
+        val payload =
+            PlayerHandUpdatedEvent(
+                lobbyCode = LobbyCode("TI56"),
+                recipientPlayerId = PlayerId(4),
+                stateVersion = 7,
+                handCards = listOf(PrivateHandCardSnapshot(CardId("card-j"), CardType.JOKER)),
+            )
+
+        val messageType = NetworkPayloadRegistry.messageTypeFor(payload)
+        val serialized = NetworkPayloadRegistry.serializePayload(payload)
+        val deserialized = NetworkPayloadRegistry.deserializePayload(messageType, serialized)
+
+        assertEquals(MessageType.LOBBY_PLAYER_HAND_UPDATED_EVENT, messageType)
+        assertEquals(payload, deserialized)
+    }
+}


### PR DESCRIPTION
This pull request introduces several improvements and new features to the server's lobby and persistence subsystems, as well as enhancements to the CI workflow. The main highlights are the introduction of atomic batch event processing for lobby events, improved event persistence and recovery for new event types, and the addition of a deterministic card set validator. There are also workflow improvements in the CI pipeline to support parallel and isolated test database containers.

**Lobby Event Processing Enhancements**
- Added support for atomic batch processing of lobby events by introducing the `QueuedItem` sealed class and corresponding logic in `LobbyEventLoop`, along with new `submitBatch` and `submitAll` methods in `LobbyEventLoop`, `LobbyRuntime`, and `LobbyManager`. This ensures that batches of events are processed without interleaving, improving consistency and correctness of state transitions. [[1]](diffhunk://#diff-0b854c8b911e2a071c37a77f7b1f67d972e5476d0736b858da76bf8afe8bb8e1L42-R42) [[2]](diffhunk://#diff-0b854c8b911e2a071c37a77f7b1f67d972e5476d0736b858da76bf8afe8bb8e1L59-R62) [[3]](diffhunk://#diff-0b854c8b911e2a071c37a77f7b1f67d972e5476d0736b858da76bf8afe8bb8e1L99-R152) [[4]](diffhunk://#diff-0b854c8b911e2a071c37a77f7b1f67d972e5476d0736b858da76bf8afe8bb8e1L122-R184) [[5]](diffhunk://#diff-554125502ece0a9ffecc1d5a5835716fb5a95d3af44124c0a7501f75a5eee30bR103-R140) [[6]](diffhunk://#diff-284f71b14cae2e3b8a89e472314ce111256b7a7ab0b7c69d3810098a1dbf75c1R86-R93)

**Persistence and Recovery Improvements**
- Extended event persistence and recovery to handle new event types (`CardSetTradedInEvent`, `PendingReinforcementsSetEvent`, `PendingReinforcementsChangedEvent`, `PlayerCardsRemovedEvent`), and updated snapshot logic to persist and restore additional game state fields (`pendingReinforcements`, `handState`, `deckState`, `discardPileState`, `tradedInSetCount`). [[1]](diffhunk://#diff-f7fa3c81328af81097dbbc7214f258b0eb42db36b0d9947e2ed079e28f9dc6d8R6-R17) [[2]](diffhunk://#diff-f7fa3c81328af81097dbbc7214f258b0eb42db36b0d9947e2ed079e28f9dc6d8R32-R33) [[3]](diffhunk://#diff-f7fa3c81328af81097dbbc7214f258b0eb42db36b0d9947e2ed079e28f9dc6d8R177-R233) [[4]](diffhunk://#diff-a9e9fcdb5f81ee282229735c460fa653ee411936da3451e33933618a6dc4f94aR5-R17) [[5]](diffhunk://#diff-a9e9fcdb5f81ee282229735c460fa653ee411936da3451e33933618a6dc4f94aR30-R35) [[6]](diffhunk://#diff-a9e9fcdb5f81ee282229735c460fa653ee411936da3451e33933618a6dc4f94aR56) [[7]](diffhunk://#diff-a9e9fcdb5f81ee282229735c460fa653ee411936da3451e33933618a6dc4f94aR159-R163) [[8]](diffhunk://#diff-a9e9fcdb5f81ee282229735c460fa653ee411936da3451e33933618a6dc4f94aR208-R212) [[9]](diffhunk://#diff-a9e9fcdb5f81ee282229735c460fa653ee411936da3451e33933618a6dc4f94aR256-R260)

**Game Logic**
- Introduced a new deterministic `CardSetValidator` utility to validate card trade-in sets, including joker handling and set composition rules.

**CI Workflow Improvements**
- Updated the CI pipeline to use isolated, per-run PostgreSQL containers with dynamic port assignment, preventing conflicts during parallel builds and improving reliability. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL65-R65) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL87-R96) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL767-R768) [[4]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL806-R816)

Closes #239 
Closes #238 
Closes #237 
Closes #236 
Closes #235 
Closes #234 
Closes #233 
Closes #232 
Closes #231 
Closes #225
Closes #226 
Closes #227 
Closes #228 
Closes #229 
Closes #230 
Closes #24