### PR TITLE
Fix/resume turn after reconnect

### DIFF
--- a/app/src/main/kotlin/at/aau/pulverfass/app/lobby/LobbyController.kt
+++ b/app/src/main/kotlin/at/aau/pulverfass/app/lobby/LobbyController.kt
@@ -216,6 +216,10 @@ class LobbyController(
         if (snapshot.isConnected || snapshot.isConnecting || snapshot.isReconnecting) {
             return
         }
+        if (canReconnect(snapshot)) {
+            beginReconnect(snapshot)
+            return
+        }
 
         scope.launch {
             _state.update {

--- a/app/src/test/kotlin/at/aau/pulverfass/app/lobby/LobbyControllerTest.kt
+++ b/app/src/test/kotlin/at/aau/pulverfass/app/lobby/LobbyControllerTest.kt
@@ -560,6 +560,106 @@ class LobbyControllerTest {
     }
 
     @Test
+    fun `manual connect with active lobby session should reconnect`() {
+        runBlocking {
+            val lobbyCode = LobbyCode("MR01")
+            val originalToken = SessionToken("123e4567-e89b-12d3-a456-426614174212")
+            val payloads = Collections.synchronizedList(mutableListOf<Any>())
+            val server =
+                startProtocolServer(
+                    onOpenPayload = ConnectionResponse(originalToken),
+                ) { payload, outgoing ->
+                    payloads += payload
+                    when (payload) {
+                        CreateLobbyRequest ->
+                            outgoing.send(
+                                Frame.Binary(
+                                    true,
+                                    MessageCodec.encode(CreateLobbyResponse(lobbyCode)),
+                                ),
+                            )
+                        is JoinLobbyRequest -> {
+                            outgoing.send(
+                                Frame.Binary(
+                                    true,
+                                    MessageCodec.encode(JoinLobbyResponse(payload.lobbyCode)),
+                                ),
+                            )
+                            outgoing.send(
+                                Frame.Binary(
+                                    true,
+                                    MessageCodec.encode(
+                                        PlayerJoinedLobbyEvent(
+                                            lobbyCode = payload.lobbyCode,
+                                            playerId = PlayerId(1),
+                                            playerDisplayName = payload.playerDisplayName,
+                                            isHost = true,
+                                        ),
+                                    ),
+                                ),
+                            )
+                        }
+                        is ReconnectRequest ->
+                            outgoing.send(
+                                Frame.Binary(
+                                    true,
+                                    MessageCodec.encode(
+                                        ReconnectResponse(
+                                            success = true,
+                                            playerId = PlayerId(1),
+                                            lobbyCode = lobbyCode,
+                                            playerDisplayName = "Alice",
+                                        ),
+                                    ),
+                                ),
+                            )
+                    }
+                }
+            val controller =
+                createController(
+                    config =
+                        LobbyControllerConfig(
+                            reconnectMaxAttempts = 10,
+                            reconnectRetryDelayMillis = 100L,
+                        ),
+                )
+            try {
+                controller.updateServerUrl(server.url)
+                controller.updatePlayerName("Alice")
+                controller.createLobby { }
+                waitUntil { controller.state.value.activeLobbyCode == lobbyCode.value }
+
+                controller.disconnect()
+                waitUntil { !controller.state.value.isConnected }
+                payloads.clear()
+
+                controller.connect()
+
+                waitUntil {
+                    payloads.any {
+                        it is ReconnectRequest && it.sessionToken == originalToken
+                    }
+                }
+                waitUntil {
+                    controller.state.value.isConnected &&
+                        !controller.state.value.isReconnecting
+                }
+
+                val reconnectRequests = payloads.filterIsInstance<ReconnectRequest>()
+                assertEquals(listOf(originalToken), reconnectRequests.map { it.sessionToken })
+                assertFalse(payloads.any { it is CreateLobbyRequest })
+                assertFalse(payloads.any { it is JoinLobbyRequest })
+                assertEquals(originalToken.value, controller.state.value.sessionToken)
+                assertEquals(lobbyCode.value, controller.state.value.activeLobbyCode)
+                assertEquals(PlayerId(1), controller.state.value.ownPlayerId)
+            } finally {
+                controller.close()
+                server.close()
+            }
+        }
+    }
+
+    @Test
     fun `startup reconnect should reuse persisted token`() {
         runBlocking {
             val lobbyCode = LobbyCode("PR35")

--- a/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
@@ -290,6 +290,10 @@ class MainServerLobbyRoutingService(
      * @param playerId fachlich identifizierter Spieler nach Connect/Reconnect
      */
     suspend fun onPlayerConnected(playerId: PlayerId) {
+        resumeWaitingTurnForPlayer(playerId)
+    }
+
+    private suspend fun resumeWaitingTurnForPlayer(playerId: PlayerId) {
         val lobbyCode = lobbyManager.findLobbyCodeByPlayer(playerId) ?: return
         val previousTurnState = currentTurnState(lobbyCode)
         val currentState = lobbyManager.getLobby(lobbyCode)?.currentState() ?: return
@@ -577,6 +581,10 @@ class MainServerLobbyRoutingService(
         connectionId: ConnectionId,
         payload: ReconnectRequest,
     ) {
+        if (resolveSessionToken(connectionId) != payload.sessionToken) {
+            return
+        }
+
         val reconnectContext =
             sessionContextRegistry?.contextFor(payload.sessionToken)
                 ?: return
@@ -607,6 +615,8 @@ class MainServerLobbyRoutingService(
                 ),
             )
         }
+
+        resumeWaitingTurnForPlayer(reconnectingPlayerId)
     }
 
     private suspend fun dispatchCreateErrorResponse(

--- a/server/src/test/kotlin/at/aau/pulverfass/server/MainServerLobbyRoutingIntegrationTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/MainServerLobbyRoutingIntegrationTest.kt
@@ -2146,7 +2146,10 @@ class MainServerLobbyRoutingIntegrationTest {
                     ),
                     receivePayloadOfType<PlayerConnectionLostEvent>(bobSession),
                 )
-                assertEquals(expectedPause, receivePayloadOfType<TurnStateUpdatedEvent>(bobSession))
+                assertEquals(
+                    expectedPause,
+                    receivePayloadOfType<TurnStateUpdatedEvent>(bobSession),
+                )
                 assertEquals(
                     PlayerConnectionLostEvent(
                         lobbyCode = lobbyCode,
@@ -2155,7 +2158,10 @@ class MainServerLobbyRoutingIntegrationTest {
                     ),
                     receivePayloadOfType<PlayerConnectionLostEvent>(carolSession),
                 )
-                assertEquals(expectedPause, receivePayloadOfType<TurnStateUpdatedEvent>(carolSession))
+                assertEquals(
+                    expectedPause,
+                    receivePayloadOfType<TurnStateUpdatedEvent>(carolSession),
+                )
 
                 val reconnectingSession = client.webSocketSession("/ws")
                 discardConnectionHandshake(reconnectingSession)
@@ -2190,8 +2196,14 @@ class MainServerLobbyRoutingIntegrationTest {
                         maxMessages = 10,
                     ),
                 )
-                assertEquals(expectedResume, receivePayloadOfType<TurnStateUpdatedEvent>(bobSession))
-                assertEquals(expectedResume, receivePayloadOfType<TurnStateUpdatedEvent>(carolSession))
+                assertEquals(
+                    expectedResume,
+                    receivePayloadOfType<TurnStateUpdatedEvent>(bobSession),
+                )
+                assertEquals(
+                    expectedResume,
+                    receivePayloadOfType<TurnStateUpdatedEvent>(carolSession),
+                )
 
                 reconnectingSession.send(
                     Frame.Binary(

--- a/server/src/test/kotlin/at/aau/pulverfass/server/MainServerLobbyRoutingIntegrationTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/MainServerLobbyRoutingIntegrationTest.kt
@@ -18,6 +18,7 @@ import at.aau.pulverfass.shared.lobby.event.TurnStateUpdatedEvent
 import at.aau.pulverfass.shared.lobby.reducer.DefaultLobbyEventReducer
 import at.aau.pulverfass.shared.lobby.state.GameState
 import at.aau.pulverfass.shared.lobby.state.GameStatus
+import at.aau.pulverfass.shared.lobby.state.TurnPauseReasons
 import at.aau.pulverfass.shared.lobby.state.TurnPhase
 import at.aau.pulverfass.shared.lobby.state.TurnState
 import at.aau.pulverfass.shared.map.config.MapConfigLoader
@@ -1993,6 +1994,204 @@ class MainServerLobbyRoutingIntegrationTest {
 
                 assertNull(receivePayloadOrNull(bobSession))
                 assertNull(receivePayloadOrNull(carolSession))
+
+                reconnectingSession.send(
+                    Frame.Binary(
+                        fin = true,
+                        data = MessageCodec.encode(TurnStateGetRequest(lobbyCode)),
+                    ),
+                )
+                assertEquals(
+                    TurnStateGetResponse(
+                        lobbyCode = lobbyCode,
+                        activePlayerId = PlayerId(1),
+                        turnPhase = TurnPhase.REINFORCEMENTS,
+                        turnCount = 1,
+                        startPlayerId = PlayerId(1),
+                    ),
+                    receivePayloadOfType<TurnStateGetResponse>(reconnectingSession),
+                )
+
+                reconnectingSession.close()
+                bobSession.close()
+                carolSession.close()
+            }
+        }
+
+    @Test
+    fun `active player reconnect resumes paused turn`() =
+        testApplication {
+            val network = ServerNetwork()
+
+            application {
+                moduleWithLobbyRuntime(network)
+            }
+
+            val client =
+                createClient {
+                    install(WebSockets)
+                }
+
+            coroutineScope {
+                val aliceSession = client.webSocketSession("/ws")
+                val aliceToken = discardConnectionHandshake(aliceSession)
+                aliceSession.send(
+                    Frame.Binary(
+                        fin = true,
+                        data = MessageCodec.encode(CreateLobbyRequest),
+                    ),
+                )
+                val lobbyCode =
+                    assertIs<CreateLobbyResponse>(
+                        receivePayload(aliceSession),
+                    ).lobbyCode
+                aliceSession.send(
+                    Frame.Binary(
+                        fin = true,
+                        data = MessageCodec.encode(JoinLobbyRequest(lobbyCode, "Alice")),
+                    ),
+                )
+                assertEquals(JoinLobbyResponse(lobbyCode), receivePayload(aliceSession))
+                assertEquals(
+                    PlayerJoinedLobbyEvent(lobbyCode, PlayerId(1), "Alice", isHost = true),
+                    receivePayloadOfType<PlayerJoinedLobbyEvent>(aliceSession),
+                )
+                receivePayloadOfType<TurnStateUpdatedEvent>(aliceSession)
+
+                val bobSession = client.webSocketSession("/ws")
+                discardConnectionHandshake(bobSession)
+                bobSession.send(
+                    Frame.Binary(
+                        fin = true,
+                        data = MessageCodec.encode(JoinLobbyRequest(lobbyCode, "Bob")),
+                    ),
+                )
+                assertEquals(JoinLobbyResponse(lobbyCode), receivePayload(bobSession))
+                assertEquals(
+                    PlayerJoinedLobbyEvent(lobbyCode, PlayerId(1), "Alice", isHost = true),
+                    receivePayload(bobSession),
+                )
+                assertEquals(
+                    PlayerJoinedLobbyEvent(lobbyCode, PlayerId(2), "Bob"),
+                    receivePayloadOfType<PlayerJoinedLobbyEvent>(bobSession),
+                )
+                assertEquals(
+                    PlayerJoinedLobbyEvent(lobbyCode, PlayerId(2), "Bob"),
+                    receivePayloadOfType<PlayerJoinedLobbyEvent>(aliceSession),
+                )
+
+                val carolSession = client.webSocketSession("/ws")
+                discardConnectionHandshake(carolSession)
+                carolSession.send(
+                    Frame.Binary(
+                        fin = true,
+                        data = MessageCodec.encode(JoinLobbyRequest(lobbyCode, "Carol")),
+                    ),
+                )
+                assertEquals(JoinLobbyResponse(lobbyCode), receivePayload(carolSession))
+                assertEquals(
+                    PlayerJoinedLobbyEvent(lobbyCode, PlayerId(1), "Alice", isHost = true),
+                    receivePayload(carolSession),
+                )
+                assertEquals(
+                    PlayerJoinedLobbyEvent(lobbyCode, PlayerId(2), "Bob"),
+                    receivePayload(carolSession),
+                )
+                assertEquals(
+                    PlayerJoinedLobbyEvent(lobbyCode, PlayerId(3), "Carol"),
+                    receivePayloadOfType<PlayerJoinedLobbyEvent>(carolSession),
+                )
+                assertEquals(
+                    PlayerJoinedLobbyEvent(lobbyCode, PlayerId(3), "Carol"),
+                    receivePayloadOfType<PlayerJoinedLobbyEvent>(aliceSession),
+                )
+                assertEquals(
+                    PlayerJoinedLobbyEvent(lobbyCode, PlayerId(3), "Carol"),
+                    receivePayloadOfType<PlayerJoinedLobbyEvent>(bobSession),
+                )
+
+                aliceSession.send(
+                    Frame.Binary(
+                        fin = true,
+                        data = MessageCodec.encode(StartGameRequest(lobbyCode)),
+                    ),
+                )
+                assertEquals(StartGameResponse(), receivePayload(aliceSession))
+                assertEquals(GameStartedEvent(lobbyCode), receivePayload(aliceSession))
+                receivePayloadOfType<TurnStateUpdatedEvent>(aliceSession)
+                assertEquals(GameStartedEvent(lobbyCode), receivePayload(bobSession))
+                receivePayloadOfType<TurnStateUpdatedEvent>(bobSession)
+                assertEquals(GameStartedEvent(lobbyCode), receivePayload(carolSession))
+                receivePayloadOfType<TurnStateUpdatedEvent>(carolSession)
+
+                aliceSession.close()
+                awaitDetachedSession(network, aliceToken)
+
+                val expectedPause =
+                    TurnStateUpdatedEvent(
+                        lobbyCode = lobbyCode,
+                        activePlayerId = PlayerId(1),
+                        turnPhase = TurnPhase.REINFORCEMENTS,
+                        turnCount = 1,
+                        startPlayerId = PlayerId(1),
+                        isPaused = true,
+                        pauseReason = TurnPauseReasons.WAITING_FOR_PLAYER,
+                        pausedPlayerId = PlayerId(1),
+                    )
+                assertEquals(
+                    PlayerConnectionLostEvent(
+                        lobbyCode = lobbyCode,
+                        playerId = PlayerId(1),
+                        reason = PlayerConnectionLostReason.SOCKET_CLOSED,
+                    ),
+                    receivePayloadOfType<PlayerConnectionLostEvent>(bobSession),
+                )
+                assertEquals(expectedPause, receivePayloadOfType<TurnStateUpdatedEvent>(bobSession))
+                assertEquals(
+                    PlayerConnectionLostEvent(
+                        lobbyCode = lobbyCode,
+                        playerId = PlayerId(1),
+                        reason = PlayerConnectionLostReason.SOCKET_CLOSED,
+                    ),
+                    receivePayloadOfType<PlayerConnectionLostEvent>(carolSession),
+                )
+                assertEquals(expectedPause, receivePayloadOfType<TurnStateUpdatedEvent>(carolSession))
+
+                val reconnectingSession = client.webSocketSession("/ws")
+                discardConnectionHandshake(reconnectingSession)
+                reconnectingSession.send(
+                    Frame.Binary(
+                        fin = true,
+                        data = MessageCodec.encode(ReconnectRequest(aliceToken)),
+                    ),
+                )
+                assertEquals(
+                    ReconnectResponse(
+                        success = true,
+                        playerId = PlayerId(1),
+                        lobbyCode = lobbyCode,
+                        playerDisplayName = "Alice",
+                    ),
+                    receivePayload(reconnectingSession),
+                )
+
+                val expectedResume =
+                    TurnStateUpdatedEvent(
+                        lobbyCode = lobbyCode,
+                        activePlayerId = PlayerId(1),
+                        turnPhase = TurnPhase.REINFORCEMENTS,
+                        turnCount = 1,
+                        startPlayerId = PlayerId(1),
+                    )
+                assertEquals(
+                    expectedResume,
+                    receivePayloadOfType<TurnStateUpdatedEvent>(
+                        session = reconnectingSession,
+                        maxMessages = 10,
+                    ),
+                )
+                assertEquals(expectedResume, receivePayloadOfType<TurnStateUpdatedEvent>(bobSession))
+                assertEquals(expectedResume, receivePayloadOfType<TurnStateUpdatedEvent>(carolSession))
 
                 reconnectingSession.send(
                     Frame.Binary(

--- a/server/src/test/kotlin/at/aau/pulverfass/server/MainServerLobbyRoutingIntegrationTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/MainServerLobbyRoutingIntegrationTest.kt
@@ -24,6 +24,7 @@ import at.aau.pulverfass.shared.lobby.state.TurnState
 import at.aau.pulverfass.shared.map.config.MapConfigLoader
 import at.aau.pulverfass.shared.message.connection.request.ReconnectRequest
 import at.aau.pulverfass.shared.message.connection.response.ConnectionResponse
+import at.aau.pulverfass.shared.message.connection.response.ReconnectErrorCode
 import at.aau.pulverfass.shared.message.connection.response.ReconnectResponse
 import at.aau.pulverfass.shared.message.lobby.event.GameStartedEvent
 import at.aau.pulverfass.shared.message.lobby.event.GameStateDeltaEvent
@@ -2015,6 +2016,48 @@ class MainServerLobbyRoutingIntegrationTest {
                 reconnectingSession.close()
                 bobSession.close()
                 carolSession.close()
+            }
+        }
+
+    @Test
+    fun `failed reconnect does not dispatch lobby snapshot`() =
+        testApplication {
+            val network = ServerNetwork()
+
+            application {
+                moduleWithLobbyRuntime(network)
+            }
+
+            val client =
+                createClient {
+                    install(WebSockets)
+                }
+
+            coroutineScope {
+                val session = client.webSocketSession("/ws")
+                discardConnectionHandshake(session)
+                session.send(
+                    Frame.Binary(
+                        fin = true,
+                        data =
+                            MessageCodec.encode(
+                                ReconnectRequest(
+                                    SessionToken("123e4567-e89b-12d3-a456-426614174999"),
+                                ),
+                            ),
+                    ),
+                )
+
+                assertEquals(
+                    ReconnectResponse(
+                        success = false,
+                        errorCode = ReconnectErrorCode.TOKEN_INVALID,
+                    ),
+                    receivePayload(session),
+                )
+                assertNull(receivePayloadOrNull(session))
+
+                session.close()
             }
         }
 


### PR DESCRIPTION
Diese PR behebt einen Deadlock im Reconnect-System. Wenn der aktive Spieler während seines Zuges die Verbindung verloren hat, wurde der Turn serverseitig korrekt mit WAITING_FOR_PLAYER pausiert. Nach dem Reconnect wurde diese Pause aber nicht zuverlässig aufgehoben. Dadurch war der Spieler zwar wieder verbunden und weiterhin am Zug, bekam aber keine Aktionsbuttons. Gleichzeitig konnte kein anderer Spieler handeln.

Was geändert wurde:
Im Server wurde die Resume-Logik für pausierte Turns zentralisiert.
Nach einem erfolgreichen ReconnectRequest prüft der Server jetzt, ob der pausierte Spieler zurückgekehrt ist.
Wenn der Turn wegen genau dieses Spielers pausiert war, wird isPaused=false gesetzt und ein aktueller TurnStateUpdatedEvent an die Lobby gesendet.
Der Reconnect-Snapshot/Resume läuft nur, wenn die neue Verbindung wirklich auf den alten Session-Token umgebunden wurde.
In der App wird bei vorhandenem Session-/Lobby-Kontext kein frischer Connect mehr gestartet, sondern der Reconnect-Flow verwendet.
Ein Integrationstest deckt den Deadlock-Fall ab: aktiver Spieler disconnectet, Turn pausiert, Spieler reconnectet, Turn wird wieder entsperrt.
Ein aktiver Spieler kann während seines Zuges disconnecten und wieder reconnecten.
Der Server hebt danach die WAITING_FOR_PLAYER-Pause auf.
Die App bekommt wieder einen nicht-pausierten TurnState.
Der aktive Spieler sieht seine Aktionsbuttons wieder.

Die Lobby bleibt nicht mehr in einem Zustand hängen, in dem niemand handeln kann.
Ich habe den Server lokal laufen lassen und den Reconnect-Fall getestet. Der Deadlock tritt dabei nicht mehr auf: Nach dem Reconnect wird der Turn korrekt fortgesetzt und der aktive Spieler kann wieder Aktionen ausführen.