### PR TITLE
Implement phase 1 reinforcement UI

### DIFF
--- a/app/src/main/kotlin/at/aau/pulverfass/app/MainActivity.kt
+++ b/app/src/main/kotlin/at/aau/pulverfass/app/MainActivity.kt
@@ -19,7 +19,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
@@ -66,11 +65,15 @@ class MainActivity : AppCompatActivity() {
         // Background-Music-Manager als Field, damit onPause/onResume drauf zugreifen können
         musicManager = BackgroundMusicManager(applicationContext)
 
-        // Fullscreen Immersive: System-Bars verstecken
+        /*
+         * Vollbild ist eine Eigenschaft der gesamten Activity und nicht eines
+         * einzelnen Screens. So bleibt der Modus auch bei Navigation zwischen
+         * Studio-Intro, Loading-Screen und Spiel erhalten.
+         */
+        enableEdgeToEdge()
         WindowCompat.setDecorFitsSystemWindows(window, false)
         hideSystemBars()
 
-        enableEdgeToEdge()
         setContent {
             AndroidAppTheme {
                 val navController = rememberNavController()
@@ -85,16 +88,14 @@ class MainActivity : AppCompatActivity() {
                 val lobbyState by lobbyController.state.collectAsState()
                 val serverHealthStatus by rememberServerHealthStatus()
 
-                // Immersive Enforcement bei jeder Navigation
-                val view = LocalView.current
+                /*
+                 * Jede Navigation kann neue Window-Inset-Berechnungen auslösen.
+                 * Systembars werden daher nach Routenwechsel erneut verborgen;
+                 * einzelne Screens dürfen den globalen Modus nicht zurücksetzen.
+                 */
                 val currentBackStackEntry by navController.currentBackStackEntryAsState()
                 LaunchedEffect(currentBackStackEntry) {
-                    val window = (view.context as Activity).window
-                    WindowCompat.setDecorFitsSystemWindows(window, false)
-                    val controller = WindowInsetsControllerCompat(window, window.decorView)
-                    controller.hide(WindowInsetsCompat.Type.systemBars())
-                    controller.systemBarsBehavior =
-                        WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+                    hideSystemBars()
                 }
 
                 // Audio: SFX bei Studio-Intro, Music erst wenn MainMenu erreicht
@@ -220,6 +221,7 @@ class MainActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
+        hideSystemBars()
         musicManager.resume()
     }
 
@@ -233,7 +235,16 @@ class MainActivity : AppCompatActivity() {
         if (hasFocus) hideSystemBars()
     }
 
+    /**
+     * Stellt den immersiven App-Modus für den Activity-Window wieder her.
+     *
+     * Android darf Bars temporär per Wischgeste oder bei Lifecycle-/Fokuswechsel
+     * anzeigen. Der Helper wird beim Start, nach Navigation, bei Resume und nach
+     * erneutem Window-Fokus aufgerufen, damit kein einzelner Screen die
+     * Vollbildgarantie besitzen oder zurücksetzen muss.
+     */
     private fun hideSystemBars() {
+        WindowCompat.setDecorFitsSystemWindows(window, false)
         val controller = WindowInsetsControllerCompat(window, window.decorView)
         controller.hide(WindowInsetsCompat.Type.systemBars())
         controller.systemBarsBehavior =

--- a/app/src/main/kotlin/at/aau/pulverfass/app/game/ClientGameStateReducer.kt
+++ b/app/src/main/kotlin/at/aau/pulverfass/app/game/ClientGameStateReducer.kt
@@ -1,7 +1,9 @@
 package at.aau.pulverfass.app.game
 
 import at.aau.pulverfass.app.lobby.LobbyPlayerUi
+import at.aau.pulverfass.shared.ids.CardId
 import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsChangedEvent
 import at.aau.pulverfass.shared.lobby.event.TerritoryOwnerChangedEvent
 import at.aau.pulverfass.shared.lobby.event.TerritoryTroopsChangedEvent
 import at.aau.pulverfass.shared.lobby.event.TurnStateUpdatedEvent
@@ -10,7 +12,9 @@ import at.aau.pulverfass.shared.message.lobby.event.GameStartedEvent
 import at.aau.pulverfass.shared.message.lobby.event.GameStateDeltaEvent
 import at.aau.pulverfass.shared.message.lobby.event.GameStateSnapshotBroadcast
 import at.aau.pulverfass.shared.message.lobby.event.PhaseBoundaryEvent
+import at.aau.pulverfass.shared.message.lobby.event.PlayerHandUpdatedEvent
 import at.aau.pulverfass.shared.message.lobby.event.PublicGameEvent
+import at.aau.pulverfass.shared.message.lobby.event.ReinforcementsGrantedEvent
 import at.aau.pulverfass.shared.message.lobby.response.GameStateCatchUpResponse
 import at.aau.pulverfass.shared.message.lobby.response.GameStatePrivateGetResponse
 import at.aau.pulverfass.shared.message.lobby.response.MapDefinitionSnapshot
@@ -169,6 +173,19 @@ object ClientGameStateReducer {
             selectionMessage = null,
             isCatchingUp = false,
             isDesynced = false,
+            reinforcementState =
+                if (event.nextPhase == TurnPhase.REINFORCEMENTS) {
+                    current.reinforcementState
+                } else {
+                    ReinforcementUiState()
+                },
+            reinforcementPlacementAmount = 1,
+            selectedTradeInCardIds =
+                if (event.nextPhase == TurnPhase.REINFORCEMENTS) {
+                    current.selectedTradeInCardIds
+                } else {
+                    emptySet()
+                },
             lastSyncError = null,
         )
     }
@@ -185,19 +202,73 @@ object ClientGameStateReducer {
             isPaused = response.isPaused,
             pauseReason = response.pauseReason,
             pausedPlayerId = response.pausedPlayerId,
+            reinforcementState =
+                if (response.turnPhase == TurnPhase.REINFORCEMENTS) {
+                    current.reinforcementState
+                } else {
+                    ReinforcementUiState()
+                },
+            selectedTradeInCardIds =
+                if (response.turnPhase == TurnPhase.REINFORCEMENTS) {
+                    current.selectedTradeInCardIds
+                } else {
+                    emptySet()
+                },
             isCatchingUp = false,
             lastSyncError = null,
         )
 
+    /**
+     * Übernimmt den privaten Snapshot des lokalen Spielers.
+     *
+     * `handCards` bleibt für ältere Serverantworten als reine Anzeige
+     * erhalten. `privateHandCards` enthält bei aktuellen Antworten zusätzlich
+     * IDs und Typen; nur damit kann die UI einen Trade-in eindeutig senden.
+     * Eine Auswahl wird mit dem neuen Snapshot geschnitten, damit keine
+     * bereits eingetauschte oder anderweitig entfernte Karte auswählbar bleibt.
+     */
     fun applyPrivateGetResponse(
         current: GameUiState,
         response: GameStatePrivateGetResponse,
     ): GameUiState =
         current.copy(
             handCards = response.handCards,
+            privateHandCards =
+                response.privateHandCards.map { card ->
+                    PrivateHandCardUi(cardId = card.cardId, type = card.type)
+                },
+            selectedTradeInCardIds =
+                current.selectedTradeInCardIds.intersect(
+                    response.privateHandCards.map { it.cardId }.toSet(),
+                ),
             secretObjectives = response.secretObjectives,
             lastSyncError = null,
         )
+
+    /**
+     * Übernimmt eine private Handaktualisierung nach einem erfolgreichen Trade-in.
+     *
+     * @param current bisheriger lokaler GameState
+     * @param event nur für den betroffenen Spieler ausgelieferte neue Hand
+     * @return State mit typisierten Karten und bereinigter lokaler Auswahl
+     */
+    fun applyPlayerHandUpdatedEvent(
+        current: GameUiState,
+        event: PlayerHandUpdatedEvent,
+    ): GameUiState {
+        val privateHandCards =
+            event.handCards.map { card ->
+                PrivateHandCardUi(cardId = card.cardId, type = card.type)
+            }
+        return current.copy(
+            privateHandCards = privateHandCards,
+            selectedTradeInCardIds =
+                current.selectedTradeInCardIds.intersect(
+                    privateHandCards.map(PrivateHandCardUi::cardId).toSet(),
+                ),
+            lastSyncError = null,
+        )
+    }
 
     /**
      * Baut die sichtbare Kartenprojektion mit einer aktualisierten Spielerliste
@@ -252,14 +323,40 @@ object ClientGameStateReducer {
         val territoryId = GameMapTerritoryMapper.toTerritoryId(regionId)
         val territory = current.territoryStates[territoryId]
 
+        /*
+         * Die Platzierungs-UI öffnet nur für eigene Gebiete. Ein Tap auf ein
+         * fremdes Gebiet wird bewusst ignoriert, statt einen Fehlerbanner zu
+         * erzeugen oder ein bereits sinnvoll gewähltes Ziel zu verlieren.
+         */
         if (
             current.turnPhase == TurnPhase.REINFORCEMENTS &&
             (localPlayerId == null || territory?.ownerId != localPlayerId)
         ) {
-            return current.copy(
-                selectionMessage =
-                    "In der Verstärkungsphase kannst du nur eigene Gebiete auswählen.",
-            )
+            return current.copy(selectionMessage = null)
+        }
+
+        if (current.turnPhase == TurnPhase.REINFORCEMENTS) {
+            /*
+             * Verstärkungen benötigen nur ein Zielgebiet. `selectionFrom` und
+             * `selectionTo` gehören zu mehrstufigen Kartenaktionen und bleiben
+             * hier leer, damit kein Zustand für eine nicht existierende
+             * Start-/Zielbewegung vorgetäuscht wird.
+             */
+            return if (current.selectedRegionId == regionId) {
+                current.copy(
+                    selectedRegionId = null,
+                    selectionFromRegionId = null,
+                    selectionToRegionId = null,
+                    selectionMessage = null,
+                )
+            } else {
+                current.copy(
+                    selectedRegionId = regionId,
+                    selectionFromRegionId = null,
+                    selectionToRegionId = null,
+                    selectionMessage = null,
+                )
+            }
         }
 
         return when {
@@ -288,6 +385,35 @@ object ClientGameStateReducer {
 
     fun toggleCards(current: GameUiState): GameUiState =
         current.copy(cardsVisible = !current.cardsVisible)
+
+    /** Ändert die zu platzierende Anzahl innerhalb des bekannten Restpools. */
+    fun adjustReinforcementPlacementAmount(
+        current: GameUiState,
+        delta: Int,
+    ): GameUiState {
+        val maxAmount = (current.reinforcementState.pendingAmount ?: 1).coerceAtLeast(1)
+        return current.copy(
+            reinforcementPlacementAmount =
+                (current.reinforcementPlacementAmount + delta).coerceIn(1, maxAmount),
+        )
+    }
+
+    /** Markiert maximal drei vorhandene private Karten für einen Trade-in. */
+    fun toggleTradeInCard(
+        current: GameUiState,
+        cardId: CardId,
+    ): GameUiState {
+        if (current.privateHandCards.none { it.cardId == cardId }) {
+            return current
+        }
+        if (cardId in current.selectedTradeInCardIds) {
+            return current.copy(selectedTradeInCardIds = current.selectedTradeInCardIds - cardId)
+        }
+        if (current.selectedTradeInCardIds.size >= 3) {
+            return current
+        }
+        return current.copy(selectedTradeInCardIds = current.selectedTradeInCardIds + cardId)
+    }
 
     /**
      * Ersetzt öffentliche Map-, Turn- und Determinismusdaten vollständig.
@@ -320,6 +446,22 @@ object ClientGameStateReducer {
                     isPaused = turnState.isPaused,
                     pauseReason = turnState.pauseReason,
                     pausedPlayerId = turnState.pausedPlayerId,
+                    reinforcementState =
+                        if (turnState.turnPhase == TurnPhase.REINFORCEMENTS) {
+                            ReinforcementUiState(
+                                playerId = turnState.activePlayerId,
+                                pendingAmount = turnState.pendingReinforcements,
+                            )
+                        } else {
+                            ReinforcementUiState()
+                        },
+                    reinforcementPlacementAmount = 1,
+                    selectedTradeInCardIds =
+                        if (turnState.turnPhase == TurnPhase.REINFORCEMENTS) {
+                            current.selectedTradeInCardIds
+                        } else {
+                            emptySet()
+                        },
                     selectedRegionId = null,
                     selectionFromRegionId = null,
                     selectionToRegionId = null,
@@ -372,6 +514,19 @@ object ClientGameStateReducer {
                     isPaused = event.isPaused,
                     pauseReason = event.pauseReason,
                     pausedPlayerId = event.pausedPlayerId,
+                    reinforcementState =
+                        if (event.turnPhase == TurnPhase.REINFORCEMENTS) {
+                            current.reinforcementState
+                        } else {
+                            ReinforcementUiState()
+                        },
+                    reinforcementPlacementAmount = 1,
+                    selectedTradeInCardIds =
+                        if (event.turnPhase == TurnPhase.REINFORCEMENTS) {
+                            current.selectedTradeInCardIds
+                        } else {
+                            emptySet()
+                        },
                     selectedRegionId = null,
                     selectionFromRegionId = null,
                     selectionToRegionId = null,
@@ -382,8 +537,75 @@ object ClientGameStateReducer {
                 current.updateTerritory(players = players, event = event)
             is TerritoryTroopsChangedEvent ->
                 current.updateTerritory(players = players, event = event)
+            is ReinforcementsGrantedEvent -> current.applyReinforcementsGranted(event)
+            is PendingReinforcementsChangedEvent -> current.applyPendingReinforcementsChanged(event)
             else -> current
         }
+
+    private fun GameUiState.applyReinforcementsGranted(
+        event: ReinforcementsGrantedEvent,
+    ): GameUiState {
+        /*
+         * Zu Beginn einer Verstärkungsphase liefert der Server einen Basisgrant
+         * mit Gebiets-/Kontinentbonus. Ein späterer Kartentausch liefert einen
+         * zusätzlichen Grant mit ausschließlich Kartenbonus; dessen Betrag
+         * wird durch das folgende PendingReinforcementsChangedEvent zum
+         * bestehenden Restpool addiert. Ein Basisgrant darf deshalb einen
+         * vorherigen Snapshot mit Restpool 0 ersetzen, ein Kartengrant nicht.
+         */
+        val isAdditionalCardGrant =
+            event.cardBonus > 0 &&
+                event.territoryBonus == 0 &&
+                event.continentBonus == 0
+        val continuesCurrentPool =
+            reinforcementState.playerId == event.playerId &&
+                reinforcementState.pendingAmount != null &&
+                isAdditionalCardGrant
+        val updatedReinforcements =
+            if (continuesCurrentPool) {
+                reinforcementState.copy(
+                    territoryBonus = reinforcementState.territoryBonus + event.territoryBonus,
+                    continentBonus = reinforcementState.continentBonus + event.continentBonus,
+                    cardBonus = reinforcementState.cardBonus + event.cardBonus,
+                )
+            } else {
+                ReinforcementUiState(
+                    playerId = event.playerId,
+                    pendingAmount = event.amount,
+                    territoryBonus = event.territoryBonus,
+                    continentBonus = event.continentBonus,
+                    cardBonus = event.cardBonus,
+                    isBonusBreakdownKnown = true,
+                )
+            }
+        val maxPlacement = (updatedReinforcements.pendingAmount ?: 1).coerceAtLeast(1)
+
+        return copy(
+            reinforcementState = updatedReinforcements,
+            reinforcementPlacementAmount = reinforcementPlacementAmount.coerceIn(1, maxPlacement),
+        )
+    }
+
+    private fun GameUiState.applyPendingReinforcementsChanged(
+        event: PendingReinforcementsChangedEvent,
+    ): GameUiState {
+        /*
+         * Der Server bleibt für den Restpool autoritativ: Platzierungen senden
+         * negative Deltas, Kartentausch positive. Events anderer Spieler oder
+         * Deltas vor der initialen Grant-/Snapshot-Basis dürfen den lokalen
+         * Bedienzustand nicht verändern.
+         */
+        if (reinforcementState.playerId != event.playerId) {
+            return this
+        }
+        val currentAmount = reinforcementState.pendingAmount ?: return this
+        val updatedAmount = (currentAmount + event.delta).coerceAtLeast(0)
+        return copy(
+            reinforcementState = reinforcementState.copy(pendingAmount = updatedAmount),
+            reinforcementPlacementAmount =
+                reinforcementPlacementAmount.coerceIn(1, updatedAmount.coerceAtLeast(1)),
+        )
+    }
 
     private fun GameUiState.updateTerritory(
         players: List<LobbyPlayerUi>,

--- a/app/src/main/kotlin/at/aau/pulverfass/app/game/GameUiState.kt
+++ b/app/src/main/kotlin/at/aau/pulverfass/app/game/GameUiState.kt
@@ -1,8 +1,10 @@
 package at.aau.pulverfass.app.game
 
 import at.aau.pulverfass.app.ui.map.GameMapRegionState
+import at.aau.pulverfass.shared.ids.CardId
 import at.aau.pulverfass.shared.ids.PlayerId
 import at.aau.pulverfass.shared.ids.TerritoryId
+import at.aau.pulverfass.shared.lobby.state.CardType
 import at.aau.pulverfass.shared.lobby.state.TurnPhase
 
 /**
@@ -34,7 +36,11 @@ data class GameUiState(
     val territoryStates: Map<TerritoryId, GameTerritoryUiState> = emptyMap(),
     val regionStates: Map<String, GameMapRegionState> = emptyMap(),
     val handCards: List<String> = emptyList(),
+    val privateHandCards: List<PrivateHandCardUi> = emptyList(),
+    val selectedTradeInCardIds: Set<CardId> = emptySet(),
     val secretObjectives: List<String> = emptyList(),
+    val reinforcementState: ReinforcementUiState = ReinforcementUiState(),
+    val reinforcementPlacementAmount: Int = 1,
     val lastSyncError: String? = null,
 ) {
     /**
@@ -67,7 +73,72 @@ data class GameUiState(
         isConnected: Boolean = true,
     ): Boolean =
         canUseGameActions(localPlayerId = localPlayerId, isConnected = isConnected) &&
-            turnPhase != null
+            turnPhase != null &&
+            turnPhase != TurnPhase.REINFORCEMENTS
+
+    /**
+     * Prüft, ob die aktuelle Verstärkungsphase lokal bedient werden kann.
+     *
+     * Die aktive Spieler-ID allein reicht nicht aus: Der Restpool muss bereits
+     * aus einem Snapshot oder Grant bekannt sein, damit keine Platzierung auf
+     * Basis eines noch nicht synchronisierten Clientzustands angeboten wird.
+     */
+    fun canManageReinforcements(
+        localPlayerId: PlayerId?,
+        isConnected: Boolean = true,
+    ): Boolean =
+        canUseGameActions(localPlayerId = localPlayerId, isConnected = isConnected) &&
+            turnPhase == TurnPhase.REINFORCEMENTS &&
+            reinforcementState.playerId == localPlayerId &&
+            reinforcementState.pendingAmount != null
+
+    /**
+     * Prüft, ob die ausgewählte Anzahl auf das Zielgebiet platziert werden kann.
+     *
+     * Das Zielgebiet ist zuvor im Reducer auf Eigentum geprüft worden. Der
+     * Controller validiert vor dem Senden nochmals dieselbe lokale
+     * Handlungsberechtigung; endgültig autoritativ bleibt die Serverprüfung.
+     */
+    fun canPlaceReinforcements(
+        localPlayerId: PlayerId?,
+        isConnected: Boolean = true,
+    ): Boolean {
+        val pendingAmount = reinforcementState.pendingAmount ?: return false
+        return canManageReinforcements(localPlayerId, isConnected) &&
+            selectedRegionId != null &&
+            pendingAmount > 0 &&
+            reinforcementPlacementAmount in 1..pendingAmount
+    }
+
+    /**
+     * Prüft, ob alle Verstärkungen verbraucht sind und die Phase enden darf.
+     *
+     * Diese Aktion ist fachlich kein normaler `TurnAdvanceRequest`: Der
+     * Server erwartet hierfür `ConfirmReinforcementsDoneRequest`. Im Screen
+     * wird sie dennoch über den bereits vorhandenen Button "Phase beenden"
+     * angeboten, sobald der Restpool exakt null ist.
+     */
+    fun canConfirmReinforcementsDone(
+        localPlayerId: PlayerId?,
+        isConnected: Boolean = true,
+    ): Boolean =
+        canManageReinforcements(localPlayerId, isConnected) &&
+            reinforcementState.pendingAmount == 0
+
+    /**
+     * Prüft, ob drei private Karten zum Eintausch ausgewählt wurden.
+     *
+     * Ob die konkrete Kombination gültig oder ein erzwungener Trade nötig ist,
+     * entscheidet weiterhin der Server. Die UI beschränkt lediglich die
+     * Auswahlmenge, damit kein offensichtlich ungültiger Request entsteht.
+     */
+    fun canTradeInCards(
+        localPlayerId: PlayerId?,
+        isConnected: Boolean = true,
+    ): Boolean =
+        canUseGameActions(localPlayerId = localPlayerId, isConnected = isConnected) &&
+            turnPhase == TurnPhase.REINFORCEMENTS &&
+            selectedTradeInCardIds.size == 3
 }
 
 /**
@@ -78,4 +149,29 @@ data class GameTerritoryUiState(
     val territoryId: TerritoryId,
     val ownerId: PlayerId?,
     val troopCount: Int,
+)
+
+/**
+ * Restpool und Bonusaufschlüsselung einer serverseitig gewährten Verstärkungsphase.
+ *
+ * `pendingAmount == null` bedeutet, dass der Client für die laufende Phase noch
+ * keinen autoritativen Restpool empfangen hat. `isBonusBreakdownKnown == false`
+ * bedeutet, dass der Restpool aus einem Snapshot stammt, der die Bonusquellen
+ * nicht separat enthält.
+ */
+data class ReinforcementUiState(
+    val playerId: PlayerId? = null,
+    val pendingAmount: Int? = null,
+    val territoryBonus: Int = 0,
+    val continentBonus: Int = 0,
+    val cardBonus: Int = 0,
+    val isBonusBreakdownKnown: Boolean = false,
+)
+
+/**
+ * Private Handkarte mit stabiler Server-ID für einen möglichen Trade-in.
+ */
+data class PrivateHandCardUi(
+    val cardId: CardId,
+    val type: CardType,
 )

--- a/app/src/main/kotlin/at/aau/pulverfass/app/lobby/GameErrorTextMapper.kt
+++ b/app/src/main/kotlin/at/aau/pulverfass/app/lobby/GameErrorTextMapper.kt
@@ -23,6 +23,9 @@ import at.aau.pulverfass.shared.message.lobby.response.error.TurnStateGetErrorRe
 object GameErrorTextMapper {
     internal const val GAME_NOT_FOUND_TEXT = "Das Spiel wurde nicht gefunden."
     internal const val NOT_IN_GAME_TEXT = "Du bist diesem Spiel noch nicht zugeordnet."
+    internal const val GAME_PAUSED_TEXT = "Das Spiel ist aktuell pausiert."
+    internal const val REQUESTER_MISMATCH_TEXT =
+        "Die Spielerzuordnung stimmt nicht mehr. Lade den Spielstand neu."
 
     fun map(error: MapGetErrorResponse): String =
         when (error.code) {
@@ -57,7 +60,7 @@ object GameErrorTextMapper {
     fun map(error: TurnAdvanceErrorResponse): String =
         when (error.code) {
             TurnAdvanceErrorCode.NOT_ACTIVE_PLAYER -> "Du bist gerade nicht am Zug."
-            TurnAdvanceErrorCode.GAME_PAUSED -> "Das Spiel ist aktuell pausiert."
+            TurnAdvanceErrorCode.GAME_PAUSED -> GAME_PAUSED_TEXT
             TurnAdvanceErrorCode.PHASE_MISMATCH ->
                 "Die Phase hat sich geändert. Lade den Spielstand neu."
             TurnAdvanceErrorCode.GAME_NOT_FOUND -> GAME_NOT_FOUND_TEXT
@@ -65,11 +68,10 @@ object GameErrorTextMapper {
 
     fun map(error: PlaceReinforcementsErrorResponse): String =
         when (error.code) {
-            PlaceReinforcementsErrorCode.REQUESTER_MISMATCH ->
-                "Die Spielerzuordnung stimmt nicht mehr. Lade den Spielstand neu."
+            PlaceReinforcementsErrorCode.REQUESTER_MISMATCH -> REQUESTER_MISMATCH_TEXT
             PlaceReinforcementsErrorCode.NOT_ACTIVE_PLAYER ->
                 "Verstärkungen können nur im eigenen Zug platziert werden."
-            PlaceReinforcementsErrorCode.GAME_PAUSED -> "Das Spiel ist aktuell pausiert."
+            PlaceReinforcementsErrorCode.GAME_PAUSED -> GAME_PAUSED_TEXT
             PlaceReinforcementsErrorCode.PHASE_MISMATCH ->
                 "Die Verstärkungsphase ist bereits beendet."
             PlaceReinforcementsErrorCode.GAME_NOT_FOUND -> GAME_NOT_FOUND_TEXT
@@ -85,11 +87,10 @@ object GameErrorTextMapper {
 
     fun map(error: ConfirmReinforcementsDoneErrorResponse): String =
         when (error.code) {
-            ConfirmReinforcementsDoneErrorCode.REQUESTER_MISMATCH ->
-                "Die Spielerzuordnung stimmt nicht mehr. Lade den Spielstand neu."
+            ConfirmReinforcementsDoneErrorCode.REQUESTER_MISMATCH -> REQUESTER_MISMATCH_TEXT
             ConfirmReinforcementsDoneErrorCode.NOT_ACTIVE_PLAYER ->
                 "Die Verstärkungsphase kann nur im eigenen Zug beendet werden."
-            ConfirmReinforcementsDoneErrorCode.GAME_PAUSED -> "Das Spiel ist aktuell pausiert."
+            ConfirmReinforcementsDoneErrorCode.GAME_PAUSED -> GAME_PAUSED_TEXT
             ConfirmReinforcementsDoneErrorCode.PHASE_MISMATCH ->
                 "Die Verstärkungsphase ist bereits beendet."
             ConfirmReinforcementsDoneErrorCode.GAME_NOT_FOUND -> GAME_NOT_FOUND_TEXT
@@ -101,11 +102,10 @@ object GameErrorTextMapper {
 
     fun map(error: TradeInCardsErrorResponse): String =
         when (error.code) {
-            TradeInCardsErrorCode.REQUESTER_MISMATCH ->
-                "Die Spielerzuordnung stimmt nicht mehr. Lade den Spielstand neu."
+            TradeInCardsErrorCode.REQUESTER_MISMATCH -> REQUESTER_MISMATCH_TEXT
             TradeInCardsErrorCode.NOT_ACTIVE_PLAYER ->
                 "Karten können nur im eigenen Zug eingetauscht werden."
-            TradeInCardsErrorCode.GAME_PAUSED -> "Das Spiel ist aktuell pausiert."
+            TradeInCardsErrorCode.GAME_PAUSED -> GAME_PAUSED_TEXT
             TradeInCardsErrorCode.PHASE_MISMATCH ->
                 "Karten können nur während der Verstärkungsphase eingetauscht werden."
             TradeInCardsErrorCode.GAME_NOT_FOUND -> GAME_NOT_FOUND_TEXT

--- a/app/src/main/kotlin/at/aau/pulverfass/app/lobby/GameErrorTextMapper.kt
+++ b/app/src/main/kotlin/at/aau/pulverfass/app/lobby/GameErrorTextMapper.kt
@@ -1,11 +1,17 @@
 package at.aau.pulverfass.app.lobby
 
+import at.aau.pulverfass.shared.message.lobby.response.error.ConfirmReinforcementsDoneErrorCode
+import at.aau.pulverfass.shared.message.lobby.response.error.ConfirmReinforcementsDoneErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.GameStateCatchUpErrorCode
 import at.aau.pulverfass.shared.message.lobby.response.error.GameStateCatchUpErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.GameStatePrivateGetErrorCode
 import at.aau.pulverfass.shared.message.lobby.response.error.GameStatePrivateGetErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.MapGetErrorCode
 import at.aau.pulverfass.shared.message.lobby.response.error.MapGetErrorResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.PlaceReinforcementsErrorCode
+import at.aau.pulverfass.shared.message.lobby.response.error.PlaceReinforcementsErrorResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.TradeInCardsErrorCode
+import at.aau.pulverfass.shared.message.lobby.response.error.TradeInCardsErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.TurnAdvanceErrorCode
 import at.aau.pulverfass.shared.message.lobby.response.error.TurnAdvanceErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.TurnStateGetErrorCode
@@ -55,5 +61,59 @@ object GameErrorTextMapper {
             TurnAdvanceErrorCode.PHASE_MISMATCH ->
                 "Die Phase hat sich geändert. Lade den Spielstand neu."
             TurnAdvanceErrorCode.GAME_NOT_FOUND -> GAME_NOT_FOUND_TEXT
+        }
+
+    fun map(error: PlaceReinforcementsErrorResponse): String =
+        when (error.code) {
+            PlaceReinforcementsErrorCode.REQUESTER_MISMATCH ->
+                "Die Spielerzuordnung stimmt nicht mehr. Lade den Spielstand neu."
+            PlaceReinforcementsErrorCode.NOT_ACTIVE_PLAYER ->
+                "Verstärkungen können nur im eigenen Zug platziert werden."
+            PlaceReinforcementsErrorCode.GAME_PAUSED -> "Das Spiel ist aktuell pausiert."
+            PlaceReinforcementsErrorCode.PHASE_MISMATCH ->
+                "Die Verstärkungsphase ist bereits beendet."
+            PlaceReinforcementsErrorCode.GAME_NOT_FOUND -> GAME_NOT_FOUND_TEXT
+            PlaceReinforcementsErrorCode.TERRITORY_NOT_OWNED ->
+                "Verstärkungen können nur auf eigene Gebiete gesetzt werden."
+            PlaceReinforcementsErrorCode.OVERSPEND ->
+                "Es sind nicht genügend Verstärkungen verfügbar."
+            PlaceReinforcementsErrorCode.INVALID_PLACEMENT ->
+                "Die gewählte Platzierung ist ungültig."
+            PlaceReinforcementsErrorCode.FORCED_TRADE_REQUIRED ->
+                "Vor dem Platzieren muss ein Kartenset eingetauscht werden."
+        }
+
+    fun map(error: ConfirmReinforcementsDoneErrorResponse): String =
+        when (error.code) {
+            ConfirmReinforcementsDoneErrorCode.REQUESTER_MISMATCH ->
+                "Die Spielerzuordnung stimmt nicht mehr. Lade den Spielstand neu."
+            ConfirmReinforcementsDoneErrorCode.NOT_ACTIVE_PLAYER ->
+                "Die Verstärkungsphase kann nur im eigenen Zug beendet werden."
+            ConfirmReinforcementsDoneErrorCode.GAME_PAUSED -> "Das Spiel ist aktuell pausiert."
+            ConfirmReinforcementsDoneErrorCode.PHASE_MISMATCH ->
+                "Die Verstärkungsphase ist bereits beendet."
+            ConfirmReinforcementsDoneErrorCode.GAME_NOT_FOUND -> GAME_NOT_FOUND_TEXT
+            ConfirmReinforcementsDoneErrorCode.PENDING_REINFORCEMENTS_REMAINING ->
+                "Verbleibende Verstärkungen müssen zuerst platziert werden."
+            ConfirmReinforcementsDoneErrorCode.FORCED_TRADE_REQUIRED ->
+                "Vor dem Beenden muss ein Kartenset eingetauscht werden."
+        }
+
+    fun map(error: TradeInCardsErrorResponse): String =
+        when (error.code) {
+            TradeInCardsErrorCode.REQUESTER_MISMATCH ->
+                "Die Spielerzuordnung stimmt nicht mehr. Lade den Spielstand neu."
+            TradeInCardsErrorCode.NOT_ACTIVE_PLAYER ->
+                "Karten können nur im eigenen Zug eingetauscht werden."
+            TradeInCardsErrorCode.GAME_PAUSED -> "Das Spiel ist aktuell pausiert."
+            TradeInCardsErrorCode.PHASE_MISMATCH ->
+                "Karten können nur während der Verstärkungsphase eingetauscht werden."
+            TradeInCardsErrorCode.GAME_NOT_FOUND -> GAME_NOT_FOUND_TEXT
+            TradeInCardsErrorCode.CARDS_NOT_OWNED ->
+                "Mindestens eine gewählte Karte ist nicht mehr auf der Hand."
+            TradeInCardsErrorCode.INVALID_SET ->
+                "Die gewählten Karten bilden kein gültiges Set."
+            TradeInCardsErrorCode.INVALID_REQUEST ->
+                "Für einen Tausch müssen genau drei Karten ausgewählt werden."
         }
 }

--- a/app/src/main/kotlin/at/aau/pulverfass/app/lobby/LobbyCommandDispatcher.kt
+++ b/app/src/main/kotlin/at/aau/pulverfass/app/lobby/LobbyCommandDispatcher.kt
@@ -19,6 +19,9 @@ enum class LobbyCommandKey {
     CATCH_UP,
     PRIVATE_STATE,
     TURN_ADVANCE,
+    PLACE_REINFORCEMENTS,
+    CONFIRM_REINFORCEMENTS_DONE,
+    TRADE_IN_CARDS,
 }
 
 /**

--- a/app/src/main/kotlin/at/aau/pulverfass/app/lobby/LobbyController.kt
+++ b/app/src/main/kotlin/at/aau/pulverfass/app/lobby/LobbyController.kt
@@ -1,10 +1,12 @@
 package at.aau.pulverfass.app.lobby
 
 import at.aau.pulverfass.app.game.ClientGameStateReducer
+import at.aau.pulverfass.app.game.GameMapTerritoryMapper
 import at.aau.pulverfass.app.game.GameUiState
 import at.aau.pulverfass.app.network.ClientNetwork
 import at.aau.pulverfass.app.storage.NoOpReconnectSessionStore
 import at.aau.pulverfass.app.storage.ReconnectSessionStore
+import at.aau.pulverfass.shared.ids.CardId
 import at.aau.pulverfass.shared.ids.LobbyCode
 import at.aau.pulverfass.shared.ids.PlayerId
 import at.aau.pulverfass.shared.ids.SessionToken
@@ -16,9 +18,11 @@ import at.aau.pulverfass.shared.message.lobby.event.GameStateDeltaEvent
 import at.aau.pulverfass.shared.message.lobby.event.GameStateSnapshotBroadcast
 import at.aau.pulverfass.shared.message.lobby.event.PhaseBoundaryEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostEvent
+import at.aau.pulverfass.shared.message.lobby.event.PlayerHandUpdatedEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerJoinedLobbyEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerKickedLobbyEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerLeftLobbyEvent
+import at.aau.pulverfass.shared.message.lobby.request.ConfirmReinforcementsDoneRequest
 import at.aau.pulverfass.shared.message.lobby.request.CreateLobbyRequest
 import at.aau.pulverfass.shared.message.lobby.request.GameStateCatchUpReason
 import at.aau.pulverfass.shared.message.lobby.request.GameStateCatchUpRequest
@@ -26,23 +30,32 @@ import at.aau.pulverfass.shared.message.lobby.request.GameStatePrivateGetRequest
 import at.aau.pulverfass.shared.message.lobby.request.JoinLobbyRequest
 import at.aau.pulverfass.shared.message.lobby.request.LeaveLobbyRequest
 import at.aau.pulverfass.shared.message.lobby.request.MapGetRequest
+import at.aau.pulverfass.shared.message.lobby.request.PlaceReinforcementsRequest
 import at.aau.pulverfass.shared.message.lobby.request.StartGameRequest
+import at.aau.pulverfass.shared.message.lobby.request.TerritoryPlacement
+import at.aau.pulverfass.shared.message.lobby.request.TradeInCardsRequest
 import at.aau.pulverfass.shared.message.lobby.request.TurnAdvanceRequest
 import at.aau.pulverfass.shared.message.lobby.request.TurnStateGetRequest
+import at.aau.pulverfass.shared.message.lobby.response.ConfirmReinforcementsDoneResponse
 import at.aau.pulverfass.shared.message.lobby.response.CreateLobbyResponse
 import at.aau.pulverfass.shared.message.lobby.response.GameStateCatchUpResponse
 import at.aau.pulverfass.shared.message.lobby.response.GameStatePrivateGetResponse
 import at.aau.pulverfass.shared.message.lobby.response.JoinLobbyResponse
 import at.aau.pulverfass.shared.message.lobby.response.MapGetResponse
+import at.aau.pulverfass.shared.message.lobby.response.PlaceReinforcementsResponse
 import at.aau.pulverfass.shared.message.lobby.response.StartGameResponse
+import at.aau.pulverfass.shared.message.lobby.response.TradeInCardsResponse
 import at.aau.pulverfass.shared.message.lobby.response.TurnAdvanceResponse
 import at.aau.pulverfass.shared.message.lobby.response.TurnStateGetResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.ConfirmReinforcementsDoneErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.CreateLobbyErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.GameStateCatchUpErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.GameStatePrivateGetErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.JoinLobbyErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.MapGetErrorResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.PlaceReinforcementsErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.StartGameErrorResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.TradeInCardsErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.TurnAdvanceErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.TurnStateGetErrorResponse
 import at.aau.pulverfass.shared.message.protocol.NetworkMessagePayload
@@ -525,6 +538,178 @@ class LobbyController(
             ).onFailure { error ->
                 _state.update {
                     it.copy(errorText = error.message ?: config.errorTurnAdvanceFailed)
+                }
+            }
+        }
+    }
+
+    /**
+     * Ändert die lokal vorbereitete Anzahl der nächsten Verstärkungsplatzierung.
+     *
+     * Dabei wird noch kein Request gesendet. Erst der Klick auf "Platzieren"
+     * übernimmt die aktuell ausgewählte Anzahl in einen autoritativen
+     * Serverrequest.
+     */
+    fun adjustReinforcementPlacementAmount(delta: Int) {
+        _state.update {
+            it.copy(
+                gameState =
+                    ClientGameStateReducer.adjustReinforcementPlacementAmount(
+                        current = it.gameState,
+                        delta = delta,
+                    ),
+            )
+        }
+    }
+
+    /**
+     * Sendet eine Verstärkungsplatzierung für das ausgewählte eigene Gebiet.
+     *
+     * Die Kartenoberfläche arbeitet mit den Android-Region-IDs der Hitmap,
+     * während das Protokoll die stabilen Territory-IDs aus `shared` benötigt.
+     * Die Übersetzung wird deshalb erst an dieser Request-Grenze durchgeführt.
+     * Der lokale Restpool wird nicht optimistisch reduziert; er folgt dem
+     * serverseitigen `PendingReinforcementsChangedEvent`.
+     */
+    fun placeReinforcements() {
+        val snapshot = state.value
+        val lobbyCode = snapshot.activeLobbyCode
+        val playerId = snapshot.ownPlayerId
+        if (lobbyCode == null || playerId == null) {
+            _state.update { it.copy(errorText = config.errorPlayerIdMissing) }
+            return
+        }
+        val regionId = snapshot.gameState.selectedRegionId
+        if (regionId == null) {
+            _state.update { it.copy(errorText = config.errorReinforcementTargetMissing) }
+            return
+        }
+        if (!snapshot.gameState.canPlaceReinforcements(playerId, snapshot.isConnected)) {
+            _state.update { it.copy(errorText = config.errorReinforcementsNotAllowed) }
+            return
+        }
+
+        scope.launch {
+            sendCommand(
+                command =
+                    LobbyCommand(
+                        key = LobbyCommandKey.PLACE_REINFORCEMENTS,
+                        payload =
+                            PlaceReinforcementsRequest(
+                                lobbyCode = parseLobbyCode(lobbyCode),
+                                playerId = playerId,
+                                placements =
+                                    listOf(
+                                        TerritoryPlacement(
+                                            territoryId =
+                                                GameMapTerritoryMapper.toTerritoryId(
+                                                    regionId,
+                                                ),
+                                            amount =
+                                                snapshot.gameState.reinforcementPlacementAmount,
+                                        ),
+                                    ),
+                            ),
+                    ),
+                keepPendingUntilResponse = true,
+            ).onFailure { error ->
+                _state.update {
+                    it.copy(errorText = error.message ?: config.errorPlaceReinforcementsFailed)
+                }
+            }
+        }
+    }
+
+    /**
+     * Bestätigt die Verstärkungsphase, sobald der Restpool vollständig verbraucht ist.
+     *
+     * Die UI ruft diese Methode über den gewöhnlichen Button "Phase beenden"
+     * auf. Der separate Request verhindert, dass der Client eine
+     * Verstärkungsphase durch einen generischen Phasenwechsel überspringen
+     * könnte, solange der Server noch Truppen oder einen Pflicht-Trade erwartet.
+     */
+    fun confirmReinforcementsDone() {
+        val snapshot = state.value
+        val lobbyCode = snapshot.activeLobbyCode
+        val playerId = snapshot.ownPlayerId
+        if (lobbyCode == null || playerId == null) {
+            _state.update { it.copy(errorText = config.errorPlayerIdMissing) }
+            return
+        }
+        if (!snapshot.gameState.canConfirmReinforcementsDone(playerId, snapshot.isConnected)) {
+            _state.update { it.copy(errorText = config.errorReinforcementsNotAllowed) }
+            return
+        }
+
+        scope.launch {
+            sendCommand(
+                command =
+                    LobbyCommand(
+                        key = LobbyCommandKey.CONFIRM_REINFORCEMENTS_DONE,
+                        payload =
+                            ConfirmReinforcementsDoneRequest(
+                                lobbyCode = parseLobbyCode(lobbyCode),
+                                playerId = playerId,
+                            ),
+                    ),
+                keepPendingUntilResponse = true,
+            ).onFailure { error ->
+                _state.update {
+                    it.copy(errorText = error.message ?: config.errorConfirmReinforcementsFailed)
+                }
+            }
+        }
+    }
+
+    /**
+     * Wählt eine private Karte für den möglichen Eintausch aus oder ab.
+     *
+     * Die Auswahl bleibt rein lokal und enthält ausschließlich IDs aus dem
+     * privaten Snapshot. Nach einem Trade-in bereinigt das private Hand-Event
+     * nicht mehr vorhandene ausgewählte Karten automatisch.
+     */
+    fun toggleTradeInCard(cardId: CardId) {
+        _state.update {
+            it.copy(gameState = ClientGameStateReducer.toggleTradeInCard(it.gameState, cardId))
+        }
+    }
+
+    /**
+     * Sendet das lokal ausgewählte Kartenset für die Verstärkungsphase.
+     *
+     * Der Request trägt nur die ausgewählten Karten-IDs. Bonushöhe, Gültigkeit
+     * des Sets und ein möglicher Pflicht-Trade werden vollständig serverseitig
+     * berechnet und danach über Grant-/Hand-Events zurückgespiegelt.
+     */
+    fun tradeInCards() {
+        val snapshot = state.value
+        val lobbyCode = snapshot.activeLobbyCode
+        val playerId = snapshot.ownPlayerId
+        if (lobbyCode == null || playerId == null) {
+            _state.update { it.copy(errorText = config.errorPlayerIdMissing) }
+            return
+        }
+        if (!snapshot.gameState.canTradeInCards(playerId, snapshot.isConnected)) {
+            _state.update { it.copy(errorText = config.errorTradeInNotAllowed) }
+            return
+        }
+
+        scope.launch {
+            sendCommand(
+                command =
+                    LobbyCommand(
+                        key = LobbyCommandKey.TRADE_IN_CARDS,
+                        payload =
+                            TradeInCardsRequest(
+                                lobbyCode = parseLobbyCode(lobbyCode),
+                                playerId = playerId,
+                                cardIds = snapshot.gameState.selectedTradeInCardIds.toList(),
+                            ),
+                    ),
+                keepPendingUntilResponse = true,
+            ).onFailure { error ->
+                _state.update {
+                    it.copy(errorText = error.message ?: config.errorTradeInFailed)
                 }
             }
         }
@@ -1020,6 +1205,30 @@ class LobbyController(
                 clearPendingCommand(LobbyCommandKey.TURN_ADVANCE)
                 updateGameError(GameErrorTextMapper.map(payload))
             }
+            is PlaceReinforcementsResponse -> {
+                clearPendingCommand(LobbyCommandKey.PLACE_REINFORCEMENTS)
+                _state.update { it.copy(errorText = null) }
+            }
+            is PlaceReinforcementsErrorResponse -> {
+                clearPendingCommand(LobbyCommandKey.PLACE_REINFORCEMENTS)
+                updateGameError(GameErrorTextMapper.map(payload))
+            }
+            is ConfirmReinforcementsDoneResponse -> {
+                clearPendingCommand(LobbyCommandKey.CONFIRM_REINFORCEMENTS_DONE)
+                _state.update { it.copy(errorText = null) }
+            }
+            is ConfirmReinforcementsDoneErrorResponse -> {
+                clearPendingCommand(LobbyCommandKey.CONFIRM_REINFORCEMENTS_DONE)
+                updateGameError(GameErrorTextMapper.map(payload))
+            }
+            is TradeInCardsResponse -> {
+                clearPendingCommand(LobbyCommandKey.TRADE_IN_CARDS)
+                _state.update { it.copy(errorText = null) }
+            }
+            is TradeInCardsErrorResponse -> {
+                clearPendingCommand(LobbyCommandKey.TRADE_IN_CARDS)
+                updateGameError(GameErrorTextMapper.map(payload))
+            }
             is TurnStateGetErrorResponse -> {
                 clearPendingCommand(LobbyCommandKey.TURN_STATE_GET)
                 updateGameError(GameErrorTextMapper.map(payload))
@@ -1034,6 +1243,10 @@ class LobbyController(
                 clearPendingCommand(LobbyCommandKey.PRIVATE_STATE)
                 updateGameError(GameErrorTextMapper.map(payload))
             }
+            is PlayerHandUpdatedEvent ->
+                applyGameState { current, _ ->
+                    ClientGameStateReducer.applyPlayerHandUpdatedEvent(current, payload)
+                }
         }
     }
 

--- a/app/src/main/kotlin/at/aau/pulverfass/app/lobby/LobbyController.kt
+++ b/app/src/main/kotlin/at/aau/pulverfass/app/lobby/LobbyController.kt
@@ -1121,6 +1121,9 @@ class LobbyController(
          * technische Connection-Payloads bleiben hier, Lobby-Events pflegen die
          * Playerliste und Game-Payloads werden an den GameStateReducer delegiert.
          */
+        if (handleReinforcementPayload(payload)) {
+            return
+        }
         when (payload) {
             is ConnectionResponse -> handleConnectionResponse(payload)
             is ReconnectResponse -> handleReconnectResponse(payload)
@@ -1205,30 +1208,6 @@ class LobbyController(
                 clearPendingCommand(LobbyCommandKey.TURN_ADVANCE)
                 updateGameError(GameErrorTextMapper.map(payload))
             }
-            is PlaceReinforcementsResponse -> {
-                clearPendingCommand(LobbyCommandKey.PLACE_REINFORCEMENTS)
-                _state.update { it.copy(errorText = null) }
-            }
-            is PlaceReinforcementsErrorResponse -> {
-                clearPendingCommand(LobbyCommandKey.PLACE_REINFORCEMENTS)
-                updateGameError(GameErrorTextMapper.map(payload))
-            }
-            is ConfirmReinforcementsDoneResponse -> {
-                clearPendingCommand(LobbyCommandKey.CONFIRM_REINFORCEMENTS_DONE)
-                _state.update { it.copy(errorText = null) }
-            }
-            is ConfirmReinforcementsDoneErrorResponse -> {
-                clearPendingCommand(LobbyCommandKey.CONFIRM_REINFORCEMENTS_DONE)
-                updateGameError(GameErrorTextMapper.map(payload))
-            }
-            is TradeInCardsResponse -> {
-                clearPendingCommand(LobbyCommandKey.TRADE_IN_CARDS)
-                _state.update { it.copy(errorText = null) }
-            }
-            is TradeInCardsErrorResponse -> {
-                clearPendingCommand(LobbyCommandKey.TRADE_IN_CARDS)
-                updateGameError(GameErrorTextMapper.map(payload))
-            }
             is TurnStateGetErrorResponse -> {
                 clearPendingCommand(LobbyCommandKey.TURN_STATE_GET)
                 updateGameError(GameErrorTextMapper.map(payload))
@@ -1249,6 +1228,48 @@ class LobbyController(
                 }
         }
     }
+
+    /**
+     * Verarbeitet die drei Requests der Verstärkungsphase außerhalb des allgemeinen
+     * Payload-Routers. Dadurch bleibt der zentrale Router auf fachliche Gruppen
+     * begrenzt, während Success- und Error-Antworten weiterhin identisch wirken.
+     *
+     * @return `true`, wenn [payload] vollständig verarbeitet wurde
+     */
+    private fun handleReinforcementPayload(payload: NetworkMessagePayload): Boolean =
+        when (payload) {
+            is PlaceReinforcementsResponse -> {
+                clearPendingCommand(LobbyCommandKey.PLACE_REINFORCEMENTS)
+                _state.update { it.copy(errorText = null) }
+                true
+            }
+            is PlaceReinforcementsErrorResponse -> {
+                clearPendingCommand(LobbyCommandKey.PLACE_REINFORCEMENTS)
+                updateGameError(GameErrorTextMapper.map(payload))
+                true
+            }
+            is ConfirmReinforcementsDoneResponse -> {
+                clearPendingCommand(LobbyCommandKey.CONFIRM_REINFORCEMENTS_DONE)
+                _state.update { it.copy(errorText = null) }
+                true
+            }
+            is ConfirmReinforcementsDoneErrorResponse -> {
+                clearPendingCommand(LobbyCommandKey.CONFIRM_REINFORCEMENTS_DONE)
+                updateGameError(GameErrorTextMapper.map(payload))
+                true
+            }
+            is TradeInCardsResponse -> {
+                clearPendingCommand(LobbyCommandKey.TRADE_IN_CARDS)
+                _state.update { it.copy(errorText = null) }
+                true
+            }
+            is TradeInCardsErrorResponse -> {
+                clearPendingCommand(LobbyCommandKey.TRADE_IN_CARDS)
+                updateGameError(GameErrorTextMapper.map(payload))
+                true
+            }
+            else -> false
+        }
 
     private fun handlePlayerJoined(payload: PlayerJoinedLobbyEvent) {
         val existingPlayer = playersById[payload.playerId.value]

--- a/app/src/main/kotlin/at/aau/pulverfass/app/lobby/LobbyControllerConfig.kt
+++ b/app/src/main/kotlin/at/aau/pulverfass/app/lobby/LobbyControllerConfig.kt
@@ -37,6 +37,13 @@ data class LobbyControllerConfig(
     val errorPlayerIdMissing: String = "Eigene Spieler-ID fehlt noch",
     val errorTurnAdvanceNotAllowed: String = "Du kannst die aktuelle Phase nicht beenden",
     val errorTurnAdvanceFailed: String = "Phasenwechsel fehlgeschlagen",
+    val errorReinforcementsNotAllowed: String =
+        "Verstärkungen können gerade nicht platziert werden",
+    val errorReinforcementTargetMissing: String = "Wähle zuerst ein eigenes Gebiet aus",
+    val errorPlaceReinforcementsFailed: String = "Verstärkungen konnten nicht platziert werden",
+    val errorConfirmReinforcementsFailed: String = "Verstärkungsphase konnte nicht beendet werden",
+    val errorTradeInNotAllowed: String = "Wähle genau drei Karten zum Eintauschen aus",
+    val errorTradeInFailed: String = "Kartentausch fehlgeschlagen",
     val errorDisconnectedDuringGame: String =
         "Verbindung getrennt. Reconnect wird vorbereitet.",
     val errorReconnectFailed: String = "Session konnte nicht wiederhergestellt werden",

--- a/app/src/main/kotlin/at/aau/pulverfass/app/ui/components/ServerStatusIndicator.kt
+++ b/app/src/main/kotlin/at/aau/pulverfass/app/ui/components/ServerStatusIndicator.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
@@ -77,7 +78,9 @@ fun rememberServerHealthStatus(
  * Zeigt den aktuellen Serverstatus als einfachen farbigen Kreis.
  *
  * Grün steht für einen gesunden Server, Orange für eine erreichbare
- * Fehlerantwort und Rot für einen nicht erreichbaren Server.
+ * Fehlerantwort und Rot für einen nicht erreichbaren Server. Die Anzeige
+ * bleibt halbtransparent, weil sie global über dem aktuellen Screen liegt
+ * und im Spiel keine Karteninformationen verdecken soll.
  */
 @Composable
 fun ServerStatusIndicator(
@@ -102,6 +105,7 @@ fun ServerStatusIndicator(
         modifier =
             modifier
                 .size(16.dp)
+                .alpha(0.5f)
                 .background(statusColor, CircleShape)
                 .semantics {
                     contentDescription = statusText

--- a/app/src/main/kotlin/at/aau/pulverfass/app/ui/screens/GameScreen.kt
+++ b/app/src/main/kotlin/at/aau/pulverfass/app/ui/screens/GameScreen.kt
@@ -83,7 +83,7 @@ private val TopBarHeight = 52.dp
 private val BottomBarHeight = 54.dp
 private val SidebarWidth = 156.dp
 private val CardsSidebarWidth = SidebarWidth
-private const val SyncFeedbackDelayMillis = 500L
+private const val SYNC_FEEDBACK_DELAY_MILLIS = 500L
 
 /**
  * Einstiegspunkt des Spielbildschirms.
@@ -240,7 +240,7 @@ internal fun GameScreenContent(
     LaunchedEffect(uiState.isCatchingUp) {
         showCatchUpFeedback = false
         if (uiState.isCatchingUp) {
-            delay(SyncFeedbackDelayMillis)
+            delay(SYNC_FEEDBACK_DELAY_MILLIS)
             showCatchUpFeedback = true
         }
     }

--- a/app/src/main/kotlin/at/aau/pulverfass/app/ui/screens/GameScreen.kt
+++ b/app/src/main/kotlin/at/aau/pulverfass/app/ui/screens/GameScreen.kt
@@ -281,19 +281,17 @@ internal fun GameScreenContent(
                     .fillMaxWidth(),
         )
 
-        if (statusMessage != null) {
-            GameStatusBanner(
-                message = statusMessage,
-                canRefresh = isConnected && !isRefreshPending,
-                isRefreshPending = isRefreshPending,
-                onRefreshGameState = onRefreshGameState,
-                modifier =
-                    Modifier
-                        .align(Alignment.TopCenter)
-                        .padding(top = TopBarHeight)
-                        .fillMaxWidth(),
-            )
-        }
+        OptionalGameStatusBanner(
+            message = statusMessage,
+            canRefresh = isConnected && !isRefreshPending,
+            isRefreshPending = isRefreshPending,
+            onRefreshGameState = onRefreshGameState,
+            modifier =
+                Modifier
+                    .align(Alignment.TopCenter)
+                    .padding(top = TopBarHeight)
+                    .fillMaxWidth(),
+        )
 
         if (uiState.isCatchingUp && showCatchUpFeedback) {
             SyncProgressOverlay(
@@ -380,6 +378,28 @@ internal fun GameScreenContent(
                     .align(Alignment.BottomCenter)
                     .fillMaxWidth()
                     .navigationBarsPadding(),
+        )
+    }
+}
+
+/**
+ * Rendert den Statusbereich nur dann, wenn eine synchronisationsrelevante Meldung vorliegt.
+ */
+@Composable
+private fun OptionalGameStatusBanner(
+    message: String?,
+    canRefresh: Boolean,
+    isRefreshPending: Boolean,
+    onRefreshGameState: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (message != null) {
+        GameStatusBanner(
+            message = message,
+            canRefresh = canRefresh,
+            isRefreshPending = isRefreshPending,
+            onRefreshGameState = onRefreshGameState,
+            modifier = modifier,
         )
     }
 }

--- a/app/src/main/kotlin/at/aau/pulverfass/app/ui/screens/GameScreen.kt
+++ b/app/src/main/kotlin/at/aau/pulverfass/app/ui/screens/GameScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -20,6 +21,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -39,7 +41,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -48,20 +52,27 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import at.aau.pulverfass.app.R
 import at.aau.pulverfass.app.game.GamePlayerUi
 import at.aau.pulverfass.app.game.GameUiState
+import at.aau.pulverfass.app.game.PrivateHandCardUi
+import at.aau.pulverfass.app.game.ReinforcementUiState
 import at.aau.pulverfass.app.game.lobbyPlayersToGamePlayers
 import at.aau.pulverfass.app.lobby.LobbyCommandKey
 import at.aau.pulverfass.app.lobby.LobbyController
 import at.aau.pulverfass.app.ui.map.InteractiveGameMap
 import at.aau.pulverfass.app.ui.map.InteractiveGameMapOptions
 import at.aau.pulverfass.app.ui.map.PulverfassMapDefaults
+import at.aau.pulverfass.shared.ids.CardId
 import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.lobby.state.CardType
 import at.aau.pulverfass.shared.lobby.state.TurnPhase
+import kotlinx.coroutines.delay
 
 private val HudSurfaceColor = Color.White
 private val HudSurfaceMutedColor = Color(0xFFF1F1F1)
@@ -72,6 +83,7 @@ private val TopBarHeight = 52.dp
 private val BottomBarHeight = 54.dp
 private val SidebarWidth = 156.dp
 private val CardsSidebarWidth = SidebarWidth
+private const val SyncFeedbackDelayMillis = 500L
 
 /**
  * Einstiegspunkt des Spielbildschirms.
@@ -100,6 +112,12 @@ fun GameScreen(controller: LobbyController) {
                 onRegionSelected = controller::selectGameRegion,
                 onToggleCards = controller::toggleCards,
                 onAdvanceTurn = controller::advanceTurn,
+                onAdjustReinforcementPlacementAmount =
+                    controller::adjustReinforcementPlacementAmount,
+                onPlaceReinforcements = controller::placeReinforcements,
+                onConfirmReinforcementsDone = controller::confirmReinforcementsDone,
+                onToggleTradeInCard = controller::toggleTradeInCard,
+                onTradeInCards = controller::tradeInCards,
                 onRefreshGameState = controller::refreshGameState,
             ),
     )
@@ -118,22 +136,26 @@ internal data class GameScreenActions(
     val onRegionSelected: (String) -> Unit,
     val onToggleCards: () -> Unit,
     val onAdvanceTurn: () -> Unit,
+    val onAdjustReinforcementPlacementAmount: (Int) -> Unit = {},
+    val onPlaceReinforcements: () -> Unit = {},
+    val onConfirmReinforcementsDone: () -> Unit = {},
+    val onToggleTradeInCard: (CardId) -> Unit = {},
+    val onTradeInCards: () -> Unit = {},
     val onRefreshGameState: () -> Unit,
 )
 
 /**
- * Baut das eigentliche Game-Layout aus Karte, HUD, Seitenteilen und Aktionen.
+ * Baut das aktive Spielfeld aus Karte, HUD, Seitenteilen und servergebundenen Aktionen.
  *
- * @param players sichtbare Spieler im Spiel
- * @param localPlayerId eigener Spieler für Gating und Highlighting
- * @param uiState serverbasierter GameState für Karte und HUD
- * @param isConnected aktueller Verbindungszustand
- * @param pendingCommandKeys ausstehende Requests für Button-Sperren
- * @param onRegionSelected Callback für erfolgreiche Kartenauswahl
- * @param onToggleCards Callback zum Ein-/Ausblenden der privaten Hand
- * @param onAdvanceTurn Callback für den aktuell vorhandenen TurnAdvance-Request
- * @param onRefreshGameState Callback für manuelles Snapshot-Refresh
- * @param mapPainter sichtbares Kartenbild
+ * Der Screen sendet selbst keine Protokollnachrichten. Er entscheidet anhand
+ * des serverautoritativen Zustands und der ausstehenden Commands, welche
+ * Bedienhandlungen angeboten werden, und reicht diese an den Controller
+ * weiter. Normale Phasenwechsel und das Abschließen der Verstärkungsphase
+ * teilen sich beispielsweise denselben sichtbaren Button, benötigen aber
+ * unterschiedliche Backend-Requests.
+ *
+ * @param contentState darstellbarer Zustand inklusive Karte, Spieler und Pending-Requests
+ * @param actions Controller-Callbacks für die ausgelösten Bedienhandlungen
  */
 @Composable
 internal fun GameScreenContent(
@@ -149,6 +171,11 @@ internal fun GameScreenContent(
     val onRegionSelected = actions.onRegionSelected
     val onToggleCards = actions.onToggleCards
     val onAdvanceTurn = actions.onAdvanceTurn
+    val onAdjustReinforcementPlacementAmount = actions.onAdjustReinforcementPlacementAmount
+    val onPlaceReinforcements = actions.onPlaceReinforcements
+    val onConfirmReinforcementsDone = actions.onConfirmReinforcementsDone
+    val onToggleTradeInCard = actions.onToggleTradeInCard
+    val onTradeInCards = actions.onTradeInCards
     val onRefreshGameState = actions.onRefreshGameState
     val personalPlayer = players.firstOrNull { it.playerId == localPlayerId } ?: fallbackPlayer()
     val canUseGameActions = uiState.canUseGameActions(localPlayerId, isConnected)
@@ -164,16 +191,72 @@ internal fun GameScreenContent(
                 it == LobbyCommandKey.TURN_STATE_GET ||
                 it == LobbyCommandKey.CATCH_UP
         }
+    val isReinforcementCommandPending =
+        pendingCommandKeys.any {
+            it == LobbyCommandKey.PLACE_REINFORCEMENTS ||
+                it == LobbyCommandKey.CONFIRM_REINFORCEMENTS_DONE ||
+                it == LobbyCommandKey.TRADE_IN_CARDS
+        }
+    val canManageReinforcements = uiState.canManageReinforcements(localPlayerId, isConnected)
+    val remainingReinforcementAmount = uiState.reinforcementState.pendingAmount ?: 0
+
+    /*
+     * Das Platzierungs-Panel ist keine dauerhafte Phasenanzeige: Es wird nur
+     * mit einem ausgewählten Ziel und einem positiven Restpool eingeblendet.
+     * Ohne diese Voraussetzung würde es nur den zoombaren Kartenausschnitt
+     * verdecken; bei einem leeren Pool übernimmt "Phase beenden".
+     */
+    val reinforcementPanelRegionId =
+        if (
+            uiState.turnPhase == TurnPhase.REINFORCEMENTS &&
+            canManageReinforcements &&
+            remainingReinforcementAmount > 0
+        ) {
+            uiState.selectedRegionId
+        } else {
+            null
+        }
+
+    /*
+     * Der bestehende Button "Phase beenden" hat je nach Phase eine andere
+     * Protokollbedeutung: TurnAdvance in regulären Phasen, aber
+     * ConfirmReinforcementsDone nach vollständiger Verstärkungsplatzierung.
+     */
+    val canEndCurrentPhase =
+        if (uiState.turnPhase == TurnPhase.REINFORCEMENTS) {
+            uiState.canConfirmReinforcementsDone(localPlayerId, isConnected) &&
+                !isReinforcementCommandPending
+        } else {
+            uiState.canRequestTurnAdvance(localPlayerId, isConnected) &&
+                !pendingCommandKeys.contains(LobbyCommandKey.TURN_ADVANCE)
+        }
+    val onEndCurrentPhase =
+        if (uiState.turnPhase == TurnPhase.REINFORCEMENTS) {
+            onConfirmReinforcementsDone
+        } else {
+            onAdvanceTurn
+        }
+    var showCatchUpFeedback by remember { mutableStateOf(false) }
+    LaunchedEffect(uiState.isCatchingUp) {
+        showCatchUpFeedback = false
+        if (uiState.isCatchingUp) {
+            delay(SyncFeedbackDelayMillis)
+            showCatchUpFeedback = true
+        }
+    }
 
     /*
      * Priorität der Statusanzeige: Verbindungsausfall schlägt Catch-up,
      * Catch-up schlägt Desync, danach kommen konkrete Fehler und zuletzt reine
-     * Auswahlhinweise. So sieht der Nutzer immer den dringendsten Zustand.
+     * Auswahlhinweise. Sehr kurze Catch-ups bleiben unsichtbar, damit normale
+     * Serverantworten keinen flackernden Synchronisationshinweis auslösen.
      */
     val statusMessage =
         when {
             !isConnected -> stringResource(id = R.string.game_sync_reconnecting)
-            uiState.isCatchingUp -> stringResource(id = R.string.game_sync_catching_up)
+            uiState.isCatchingUp && showCatchUpFeedback ->
+                stringResource(id = R.string.game_sync_catching_up)
+            uiState.isCatchingUp -> null
             uiState.isDesynced ->
                 uiState.lastSyncError ?: stringResource(id = R.string.game_sync_desynced)
             uiState.lastSyncError != null -> uiState.lastSyncError
@@ -230,7 +313,7 @@ internal fun GameScreenContent(
             )
         }
 
-        if (uiState.isCatchingUp) {
+        if (uiState.isCatchingUp && showCatchUpFeedback) {
             SyncProgressOverlay(
                 modifier = Modifier.align(Alignment.Center),
             )
@@ -239,6 +322,18 @@ internal fun GameScreenContent(
         CardsSidebar(
             player = personalPlayer,
             handCards = uiState.handCards,
+            privateHandCards = uiState.privateHandCards,
+            selectedTradeInCardIds = uiState.selectedTradeInCardIds,
+            showTradeControls = uiState.turnPhase == TurnPhase.REINFORCEMENTS,
+            canSelectTradeCards =
+                uiState.canUseGameActions(localPlayerId, isConnected) &&
+                    !isReinforcementCommandPending,
+            canTradeInCards =
+                uiState.canTradeInCards(localPlayerId, isConnected) &&
+                    !isReinforcementCommandPending,
+            isTradePending = pendingCommandKeys.contains(LobbyCommandKey.TRADE_IN_CARDS),
+            onToggleTradeInCard = onToggleTradeInCard,
+            onTradeInCards = onTradeInCards,
             isVisible = uiState.cardsVisible,
             modifier =
                 Modifier
@@ -259,15 +354,35 @@ internal fun GameScreenContent(
                     .fillMaxHeight(),
         )
 
+        reinforcementPanelRegionId?.let { selectedRegionId ->
+            ReinforcementPanel(
+                reinforcementState = uiState.reinforcementState,
+                remainingAmount = remainingReinforcementAmount,
+                placementAmount = uiState.reinforcementPlacementAmount,
+                selectedRegionId = selectedRegionId,
+                canAdjust =
+                    canManageReinforcements &&
+                        !isReinforcementCommandPending,
+                canPlace =
+                    uiState.canPlaceReinforcements(localPlayerId, isConnected) &&
+                        !isReinforcementCommandPending,
+                onDismiss = { onRegionSelected(selectedRegionId) },
+                onAdjustPlacementAmount = onAdjustReinforcementPlacementAmount,
+                onPlace = onPlaceReinforcements,
+                modifier =
+                    Modifier
+                        .align(Alignment.BottomCenter)
+                        .padding(bottom = BottomBarHeight + 8.dp),
+            )
+        }
+
         BottomActionClusters(
             currentPhase = uiState.turnPhase,
             canUseLocalInput = isConnected && !uiState.isCatchingUp && !uiState.isDesynced,
-            canAdvanceTurn =
-                uiState.canRequestTurnAdvance(localPlayerId, isConnected) &&
-                    !pendingCommandKeys.contains(LobbyCommandKey.TURN_ADVANCE),
+            canEndPhase = canEndCurrentPhase,
             cardsVisible = uiState.cardsVisible,
             onToggleCards = onToggleCards,
-            onAdvanceTurn = onAdvanceTurn,
+            onEndPhase = onEndCurrentPhase,
             modifier =
                 Modifier
                     .align(Alignment.BottomCenter)
@@ -446,6 +561,14 @@ private fun GameTopBar(
 private fun CardsSidebar(
     player: GamePlayerUi,
     handCards: List<String>,
+    privateHandCards: List<PrivateHandCardUi>,
+    selectedTradeInCardIds: Set<CardId>,
+    showTradeControls: Boolean,
+    canSelectTradeCards: Boolean,
+    canTradeInCards: Boolean,
+    isTradePending: Boolean,
+    onToggleTradeInCard: (CardId) -> Unit,
+    onTradeInCards: () -> Unit,
     isVisible: Boolean,
     modifier: Modifier = Modifier,
 ) {
@@ -461,6 +584,14 @@ private fun CardsSidebar(
             PrivateHandPanel(
                 playerName = player.name,
                 handCards = handCards,
+                privateHandCards = privateHandCards,
+                selectedTradeInCardIds = selectedTradeInCardIds,
+                showTradeControls = showTradeControls,
+                canSelectTradeCards = canSelectTradeCards,
+                canTradeInCards = canTradeInCards,
+                isTradePending = isTradePending,
+                onToggleTradeInCard = onToggleTradeInCard,
+                onTradeInCards = onTradeInCards,
                 modifier =
                     Modifier
                         .fillMaxWidth()
@@ -647,15 +778,47 @@ private fun PlayerAvatar(
 internal fun PrivateHandPanel(
     playerName: String,
     handCards: List<String>,
+    privateHandCards: List<PrivateHandCardUi> = emptyList(),
+    selectedTradeInCardIds: Set<CardId> = emptySet(),
+    showTradeControls: Boolean = false,
+    canSelectTradeCards: Boolean = false,
+    canTradeInCards: Boolean = false,
+    isTradePending: Boolean = false,
+    onToggleTradeInCard: (CardId) -> Unit = {},
+    onTradeInCards: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val unknownCardLabel = stringResource(id = R.string.game_cards_unknown)
+    val typeLabels =
+        mapOf(
+            CardType.A to stringResource(id = R.string.game_card_type_a),
+            CardType.B to stringResource(id = R.string.game_card_type_b),
+            CardType.C to stringResource(id = R.string.game_card_type_c),
+            CardType.JOKER to stringResource(id = R.string.game_card_type_joker),
+        )
     val handCardItems =
-        remember(handCards, unknownCardLabel) {
-            buildHandCardItems(
-                handCards = handCards,
-                unknownCardLabel = unknownCardLabel,
-            )
+        remember(
+            handCards,
+            privateHandCards,
+            selectedTradeInCardIds,
+            unknownCardLabel,
+            typeLabels,
+        ) {
+            if (privateHandCards.isNotEmpty()) {
+                privateHandCards.map { card ->
+                    HandCardItemUi(
+                        stableKey = card.cardId.value,
+                        label = typeLabels.getValue(card.type),
+                        cardId = card.cardId,
+                        isSelected = card.cardId in selectedTradeInCardIds,
+                    )
+                }
+            } else {
+                buildHandCardItems(
+                    handCards = handCards,
+                    unknownCardLabel = unknownCardLabel,
+                )
+            }
         }
 
     Column(
@@ -692,7 +855,31 @@ internal fun PrivateHandPanel(
                     items = handCardItems,
                     key = HandCardItemUi::stableKey,
                 ) { item ->
-                    HandCardRow(item = item)
+                    HandCardRow(
+                        item = item,
+                        selectable = showTradeControls && canSelectTradeCards,
+                        onSelected = { cardId -> onToggleTradeInCard(cardId) },
+                    )
+                }
+            }
+            if (showTradeControls && privateHandCards.isNotEmpty()) {
+                FilledTonalButton(
+                    onClick = onTradeInCards,
+                    enabled = canTradeInCards,
+                    modifier = Modifier.fillMaxWidth().testTag("trade_in_cards_button"),
+                    shape = RoundedCornerShape(6.dp),
+                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 6.dp),
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.game_cards_trade_in),
+                        style = MaterialTheme.typography.labelMedium,
+                    )
+                }
+                if (isTradePending) {
+                    Text(
+                        text = stringResource(id = R.string.loading),
+                        style = MaterialTheme.typography.bodySmall,
+                    )
                 }
             }
         }
@@ -700,11 +887,21 @@ internal fun PrivateHandPanel(
 }
 
 @Composable
-private fun HandCardRow(item: HandCardItemUi) {
+private fun HandCardRow(
+    item: HandCardItemUi,
+    selectable: Boolean,
+    onSelected: (CardId) -> Unit,
+) {
     Surface(
-        modifier = Modifier.fillMaxWidth(),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .testTag("game_hand_card_${item.stableKey}")
+                .clickable(enabled = selectable && item.cardId != null) {
+                    item.cardId?.let(onSelected)
+                },
         shape = RoundedCornerShape(6.dp),
-        color = HudSurfaceMutedColor,
+        color = if (item.isSelected) Color(0xFFD7EEE9) else HudSurfaceMutedColor,
         contentColor = HudContentColor,
         tonalElevation = 0.dp,
         shadowElevation = 0.dp,
@@ -722,14 +919,17 @@ private fun HandCardRow(item: HandCardItemUi) {
 internal data class HandCardItemUi(
     val stableKey: String,
     val label: String,
+    val cardId: CardId? = null,
+    val isSelected: Boolean = false,
 )
 
 /**
- * Erzeugt Listeneinträge mit stabilen Keys aus dem privaten Hand-Snapshot.
+ * Erzeugt Listeneinträge mit stabilen Keys aus einer älteren privaten Handdarstellung.
  *
- * Das Backend liefert aktuell nur Kartenlabels ohne Karten-ID. Der Key nutzt
- * deshalb Label plus laufende Duplikatnummer, damit gleiche Karten mehrfach
- * ohne LazyList-Key-Kollision angezeigt werden.
+ * Aktuelle Responses liefern [PrivateHandCardUi] mit stabilen IDs, damit
+ * Karten für einen Trade-in auswählbar sind. Die Stringliste bleibt als
+ * kompatibler Lesepfad für ältere Snapshots erhalten. Weil in diesem Pfad
+ * keine Karten-ID vorhanden ist, nutzt der Key Label plus Duplikatnummer.
  */
 internal fun buildHandCardItems(
     handCards: List<String>,
@@ -749,14 +949,141 @@ internal fun buildHandCardItems(
     }
 }
 
+/**
+ * Zeigt die Platzierungssteuerung für ein bereits ausgewähltes eigenes Gebiet.
+ *
+ * Diese Composable wird ausschließlich bei einem positiven [remainingAmount]
+ * und einem konkreten [selectedRegionId] erzeugt. Ein leerer Restpool erscheint
+ * daher nicht als Popup; das Abschließen erfolgt über die untere Aktionsleiste.
+ */
+@Composable
+private fun ReinforcementPanel(
+    reinforcementState: ReinforcementUiState,
+    remainingAmount: Int,
+    placementAmount: Int,
+    selectedRegionId: String,
+    canAdjust: Boolean,
+    canPlace: Boolean,
+    onDismiss: () -> Unit,
+    onAdjustPlacementAmount: (Int) -> Unit,
+    onPlace: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier =
+            modifier
+                .widthIn(max = 560.dp)
+                .testTag("reinforcement_panel"),
+        shape = RoundedCornerShape(6.dp),
+        color = HudSurfaceColor,
+        contentColor = HudContentColor,
+        border = BorderStroke(1.dp, HudBorderColor),
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text =
+                        stringResource(
+                            id = R.string.game_reinforcements_remaining,
+                            remainingAmount.toString(),
+                        ),
+                    modifier = Modifier.testTag("reinforcement_remaining"),
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.Bold,
+                )
+                if (reinforcementState.isBonusBreakdownKnown) {
+                    Text(
+                        text =
+                            stringResource(
+                                id = R.string.game_reinforcements_bonus,
+                                reinforcementState.territoryBonus,
+                                reinforcementState.continentBonus,
+                                reinforcementState.cardBonus,
+                            ),
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+                Spacer(modifier = Modifier.weight(1f))
+                val closePanelDescription =
+                    stringResource(id = R.string.game_reinforcements_close)
+                BlockActionButton(
+                    label = "X",
+                    onClick = onDismiss,
+                    selected = false,
+                    enabled = true,
+                    modifier =
+                        Modifier
+                            .size(34.dp)
+                            .semantics {
+                                contentDescription = closePanelDescription
+                            }
+                            .testTag("close_reinforcement_panel"),
+                )
+            }
+            Text(
+                text = stringResource(id = R.string.game_reinforcements_target, selectedRegionId),
+                style = MaterialTheme.typography.bodySmall,
+            )
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                BlockActionButton(
+                    label = "-",
+                    onClick = { onAdjustPlacementAmount(-1) },
+                    selected = false,
+                    enabled = canAdjust && placementAmount > 1,
+                    modifier = Modifier.size(42.dp).testTag("reinforcement_decrease"),
+                )
+                Text(
+                    text = placementAmount.toString(),
+                    modifier = Modifier.width(32.dp).testTag("reinforcement_amount"),
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
+                )
+                BlockActionButton(
+                    label = "+",
+                    onClick = { onAdjustPlacementAmount(1) },
+                    selected = false,
+                    enabled =
+                        canAdjust &&
+                            placementAmount < remainingAmount,
+                    modifier = Modifier.size(42.dp).testTag("reinforcement_increase"),
+                )
+                BlockActionButton(
+                    label = stringResource(id = R.string.game_reinforcements_place),
+                    onClick = onPlace,
+                    selected = true,
+                    enabled = canPlace,
+                    modifier = Modifier.testTag("place_reinforcements_button"),
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Rendert die ständig sichtbare Aktionsleiste am unteren Rand.
+ *
+ * [onEndPhase] ist bereits vom aufrufenden Screen auf den fachlich korrekten
+ * Request abgebildet: `TurnAdvance` außerhalb von Verstärkungen und
+ * `ConfirmReinforcementsDone` nach vollständigem Verbrauch des Restpools.
+ */
 @Composable
 private fun BottomActionClusters(
     currentPhase: TurnPhase?,
     canUseLocalInput: Boolean,
-    canAdvanceTurn: Boolean,
+    canEndPhase: Boolean,
     cardsVisible: Boolean,
     onToggleCards: () -> Unit,
-    onAdvanceTurn: () -> Unit,
+    onEndPhase: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Surface(
@@ -819,9 +1146,9 @@ private fun BottomActionClusters(
             ) {
                 BlockActionButton(
                     label = stringResource(id = R.string.game_end_round_button),
-                    onClick = onAdvanceTurn,
+                    onClick = onEndPhase,
                     selected = true,
-                    enabled = canAdvanceTurn,
+                    enabled = canEndPhase,
                     modifier = Modifier.fillMaxWidth().testTag("end_round_button"),
                 )
             }

--- a/app/src/main/kotlin/at/aau/pulverfass/app/ui/screens/GameScreen.kt
+++ b/app/src/main/kotlin/at/aau/pulverfass/app/ui/screens/GameScreen.kt
@@ -145,6 +145,43 @@ internal data class GameScreenActions(
 )
 
 /**
+ * Kompakter Anzeige- und Interaktionszustand der privaten Kartenhand.
+ *
+ * Die Gruppierung hält die Panel-Schnittstelle stabil, wenn weitere
+ * kartenspezifische Eigenschaften aus dem privaten Snapshot hinzukommen.
+ */
+internal data class PrivateHandPanelState(
+    val playerName: String,
+    val handCards: List<String>,
+    val privateHandCards: List<PrivateHandCardUi> = emptyList(),
+    val selectedTradeInCardIds: Set<CardId> = emptySet(),
+    val showTradeControls: Boolean = false,
+    val canSelectTradeCards: Boolean = false,
+    val canTradeInCards: Boolean = false,
+    val isTradePending: Boolean = false,
+)
+
+internal data class PrivateHandPanelActions(
+    val onToggleTradeInCard: (CardId) -> Unit = {},
+    val onTradeInCards: () -> Unit = {},
+)
+
+private data class ReinforcementPanelState(
+    val reinforcementState: ReinforcementUiState,
+    val remainingAmount: Int,
+    val placementAmount: Int,
+    val selectedRegionId: String,
+    val canAdjust: Boolean,
+    val canPlace: Boolean,
+)
+
+private data class ReinforcementPanelActions(
+    val onDismiss: () -> Unit,
+    val onAdjustPlacementAmount: (Int) -> Unit,
+    val onPlace: () -> Unit,
+)
+
+/**
  * Baut das aktive Spielfeld aus Karte, HUD, Seitenteilen und servergebundenen Aktionen.
  *
  * Der Screen sendet selbst keine Protokollnachrichten. Er entscheidet anhand
@@ -180,62 +217,23 @@ internal fun GameScreenContent(
     val personalPlayer = players.firstOrNull { it.playerId == localPlayerId } ?: fallbackPlayer()
     val canUseGameActions = uiState.canUseGameActions(localPlayerId, isConnected)
 
-    /*
-     * Refresh-Pending bündelt die drei Snapshot-Requests, aus denen der aktuelle
-     * öffentliche und private Spielstand besteht. Der Reload-Button bleibt
-     * gesperrt, bis diese Runde abgeschlossen ist.
-     */
-    val isRefreshPending =
-        pendingCommandKeys.any {
-            it == LobbyCommandKey.MAP_GET ||
-                it == LobbyCommandKey.TURN_STATE_GET ||
-                it == LobbyCommandKey.CATCH_UP
-        }
-    val isReinforcementCommandPending =
-        pendingCommandKeys.any {
-            it == LobbyCommandKey.PLACE_REINFORCEMENTS ||
-                it == LobbyCommandKey.CONFIRM_REINFORCEMENTS_DONE ||
-                it == LobbyCommandKey.TRADE_IN_CARDS
-        }
+    val isRefreshPending = pendingCommandKeys.hasRefreshRequest()
+    val isReinforcementCommandPending = pendingCommandKeys.hasReinforcementRequest()
     val canManageReinforcements = uiState.canManageReinforcements(localPlayerId, isConnected)
     val remainingReinforcementAmount = uiState.reinforcementState.pendingAmount ?: 0
 
-    /*
-     * Das Platzierungs-Panel ist keine dauerhafte Phasenanzeige: Es wird nur
-     * mit einem ausgewählten Ziel und einem positiven Restpool eingeblendet.
-     * Ohne diese Voraussetzung würde es nur den zoombaren Kartenausschnitt
-     * verdecken; bei einem leeren Pool übernimmt "Phase beenden".
-     */
     val reinforcementPanelRegionId =
-        if (
-            uiState.turnPhase == TurnPhase.REINFORCEMENTS &&
-            canManageReinforcements &&
-            remainingReinforcementAmount > 0
-        ) {
-            uiState.selectedRegionId
-        } else {
-            null
-        }
-
-    /*
-     * Der bestehende Button "Phase beenden" hat je nach Phase eine andere
-     * Protokollbedeutung: TurnAdvance in regulären Phasen, aber
-     * ConfirmReinforcementsDone nach vollständiger Verstärkungsplatzierung.
-     */
+        visibleReinforcementTarget(uiState, canManageReinforcements, remainingReinforcementAmount)
     val canEndCurrentPhase =
-        if (uiState.turnPhase == TurnPhase.REINFORCEMENTS) {
-            uiState.canConfirmReinforcementsDone(localPlayerId, isConnected) &&
-                !isReinforcementCommandPending
-        } else {
-            uiState.canRequestTurnAdvance(localPlayerId, isConnected) &&
-                !pendingCommandKeys.contains(LobbyCommandKey.TURN_ADVANCE)
-        }
+        canEndCurrentPhase(
+            uiState = uiState,
+            localPlayerId = localPlayerId,
+            isConnected = isConnected,
+            isReinforcementCommandPending = isReinforcementCommandPending,
+            pendingCommandKeys = pendingCommandKeys,
+        )
     val onEndCurrentPhase =
-        if (uiState.turnPhase == TurnPhase.REINFORCEMENTS) {
-            onConfirmReinforcementsDone
-        } else {
-            onAdvanceTurn
-        }
+        endCurrentPhaseAction(uiState, onConfirmReinforcementsDone, onAdvanceTurn)
     var showCatchUpFeedback by remember { mutableStateOf(false) }
     LaunchedEffect(uiState.isCatchingUp) {
         showCatchUpFeedback = false
@@ -245,24 +243,8 @@ internal fun GameScreenContent(
         }
     }
 
-    /*
-     * Priorität der Statusanzeige: Verbindungsausfall schlägt Catch-up,
-     * Catch-up schlägt Desync, danach kommen konkrete Fehler und zuletzt reine
-     * Auswahlhinweise. Sehr kurze Catch-ups bleiben unsichtbar, damit normale
-     * Serverantworten keinen flackernden Synchronisationshinweis auslösen.
-     */
     val statusMessage =
-        when {
-            !isConnected -> stringResource(id = R.string.game_sync_reconnecting)
-            uiState.isCatchingUp && showCatchUpFeedback ->
-                stringResource(id = R.string.game_sync_catching_up)
-            uiState.isCatchingUp -> null
-            uiState.isDesynced ->
-                uiState.lastSyncError ?: stringResource(id = R.string.game_sync_desynced)
-            uiState.lastSyncError != null -> uiState.lastSyncError
-            uiState.selectionMessage != null -> uiState.selectionMessage
-            else -> null
-        }
+        gameStatusMessage(uiState, isConnected, showCatchUpFeedback)
 
     Box(
         modifier =
@@ -320,20 +302,26 @@ internal fun GameScreenContent(
         }
 
         CardsSidebar(
-            player = personalPlayer,
-            handCards = uiState.handCards,
-            privateHandCards = uiState.privateHandCards,
-            selectedTradeInCardIds = uiState.selectedTradeInCardIds,
-            showTradeControls = uiState.turnPhase == TurnPhase.REINFORCEMENTS,
-            canSelectTradeCards =
-                uiState.canUseGameActions(localPlayerId, isConnected) &&
-                    !isReinforcementCommandPending,
-            canTradeInCards =
-                uiState.canTradeInCards(localPlayerId, isConnected) &&
-                    !isReinforcementCommandPending,
-            isTradePending = pendingCommandKeys.contains(LobbyCommandKey.TRADE_IN_CARDS),
-            onToggleTradeInCard = onToggleTradeInCard,
-            onTradeInCards = onTradeInCards,
+            state =
+                PrivateHandPanelState(
+                    playerName = personalPlayer.name,
+                    handCards = uiState.handCards,
+                    privateHandCards = uiState.privateHandCards,
+                    selectedTradeInCardIds = uiState.selectedTradeInCardIds,
+                    showTradeControls = uiState.turnPhase == TurnPhase.REINFORCEMENTS,
+                    canSelectTradeCards =
+                        uiState.canUseGameActions(localPlayerId, isConnected) &&
+                            !isReinforcementCommandPending,
+                    canTradeInCards =
+                        uiState.canTradeInCards(localPlayerId, isConnected) &&
+                            !isReinforcementCommandPending,
+                    isTradePending = pendingCommandKeys.contains(LobbyCommandKey.TRADE_IN_CARDS),
+                ),
+            actions =
+                PrivateHandPanelActions(
+                    onToggleTradeInCard = onToggleTradeInCard,
+                    onTradeInCards = onTradeInCards,
+                ),
             isVisible = uiState.cardsVisible,
             modifier =
                 Modifier
@@ -356,19 +344,23 @@ internal fun GameScreenContent(
 
         reinforcementPanelRegionId?.let { selectedRegionId ->
             ReinforcementPanel(
-                reinforcementState = uiState.reinforcementState,
-                remainingAmount = remainingReinforcementAmount,
-                placementAmount = uiState.reinforcementPlacementAmount,
-                selectedRegionId = selectedRegionId,
-                canAdjust =
-                    canManageReinforcements &&
-                        !isReinforcementCommandPending,
-                canPlace =
-                    uiState.canPlaceReinforcements(localPlayerId, isConnected) &&
-                        !isReinforcementCommandPending,
-                onDismiss = { onRegionSelected(selectedRegionId) },
-                onAdjustPlacementAmount = onAdjustReinforcementPlacementAmount,
-                onPlace = onPlaceReinforcements,
+                state =
+                    ReinforcementPanelState(
+                        reinforcementState = uiState.reinforcementState,
+                        remainingAmount = remainingReinforcementAmount,
+                        placementAmount = uiState.reinforcementPlacementAmount,
+                        selectedRegionId = selectedRegionId,
+                        canAdjust = canManageReinforcements && !isReinforcementCommandPending,
+                        canPlace =
+                            uiState.canPlaceReinforcements(localPlayerId, isConnected) &&
+                                !isReinforcementCommandPending,
+                    ),
+                actions =
+                    ReinforcementPanelActions(
+                        onDismiss = { onRegionSelected(selectedRegionId) },
+                        onAdjustPlacementAmount = onAdjustReinforcementPlacementAmount,
+                        onPlace = onPlaceReinforcements,
+                    ),
                 modifier =
                     Modifier
                         .align(Alignment.BottomCenter)
@@ -391,6 +383,90 @@ internal fun GameScreenContent(
         )
     }
 }
+
+/**
+ * Liefert `true`, solange ein Request eines vollständigen Refresh-Zyklus aussteht.
+ */
+private fun Set<LobbyCommandKey>.hasRefreshRequest(): Boolean =
+    any {
+        it == LobbyCommandKey.MAP_GET ||
+            it == LobbyCommandKey.TURN_STATE_GET ||
+            it == LobbyCommandKey.CATCH_UP
+    }
+
+private fun Set<LobbyCommandKey>.hasReinforcementRequest(): Boolean =
+    any {
+        it == LobbyCommandKey.PLACE_REINFORCEMENTS ||
+            it == LobbyCommandKey.CONFIRM_REINFORCEMENTS_DONE ||
+            it == LobbyCommandKey.TRADE_IN_CARDS
+    }
+
+/**
+ * Das Platzierungs-Panel erscheint nur mit einem ausgewählten Ziel und Restpool.
+ * Andernfalls bleibt die Karte frei; ein leerer Pool wird in der Aktionsleiste beendet.
+ */
+private fun visibleReinforcementTarget(
+    uiState: GameUiState,
+    canManageReinforcements: Boolean,
+    remainingAmount: Int,
+): String? =
+    if (
+        uiState.turnPhase == TurnPhase.REINFORCEMENTS &&
+        canManageReinforcements &&
+        remainingAmount > 0
+    ) {
+        uiState.selectedRegionId
+    } else {
+        null
+    }
+
+private fun canEndCurrentPhase(
+    uiState: GameUiState,
+    localPlayerId: PlayerId?,
+    isConnected: Boolean,
+    isReinforcementCommandPending: Boolean,
+    pendingCommandKeys: Set<LobbyCommandKey>,
+): Boolean =
+    if (uiState.turnPhase == TurnPhase.REINFORCEMENTS) {
+        uiState.canConfirmReinforcementsDone(localPlayerId, isConnected) &&
+            !isReinforcementCommandPending
+    } else {
+        uiState.canRequestTurnAdvance(localPlayerId, isConnected) &&
+            !pendingCommandKeys.contains(LobbyCommandKey.TURN_ADVANCE)
+    }
+
+private fun endCurrentPhaseAction(
+    uiState: GameUiState,
+    onConfirmReinforcementsDone: () -> Unit,
+    onAdvanceTurn: () -> Unit,
+): () -> Unit =
+    if (uiState.turnPhase == TurnPhase.REINFORCEMENTS) {
+        onConfirmReinforcementsDone
+    } else {
+        onAdvanceTurn
+    }
+
+/**
+ * Priorisiert Verbindungs- und Synchronisationszustände vor Bedienhinweisen.
+ * Sehr kurze Catch-ups bleiben unsichtbar, damit reguläre Antworten nicht flackern.
+ */
+@Composable
+private fun gameStatusMessage(
+    uiState: GameUiState,
+    isConnected: Boolean,
+    showCatchUpFeedback: Boolean,
+): String? =
+    when {
+        !isConnected -> stringResource(id = R.string.game_sync_reconnecting)
+        uiState.isCatchingUp && showCatchUpFeedback ->
+            stringResource(id = R.string.game_sync_catching_up)
+        uiState.isCatchingUp -> null
+        uiState.isDesynced ->
+            uiState.lastSyncError ?: stringResource(id = R.string.game_sync_desynced)
+        uiState.lastSyncError != null -> uiState.lastSyncError
+        uiState.selectionMessage != null -> uiState.selectionMessage
+        else -> null
+    }
 
 @Composable
 private fun GameStatusBanner(
@@ -559,16 +635,8 @@ private fun GameTopBar(
 
 @Composable
 private fun CardsSidebar(
-    player: GamePlayerUi,
-    handCards: List<String>,
-    privateHandCards: List<PrivateHandCardUi>,
-    selectedTradeInCardIds: Set<CardId>,
-    showTradeControls: Boolean,
-    canSelectTradeCards: Boolean,
-    canTradeInCards: Boolean,
-    isTradePending: Boolean,
-    onToggleTradeInCard: (CardId) -> Unit,
-    onTradeInCards: () -> Unit,
+    state: PrivateHandPanelState,
+    actions: PrivateHandPanelActions,
     isVisible: Boolean,
     modifier: Modifier = Modifier,
 ) {
@@ -582,16 +650,8 @@ private fun CardsSidebar(
             shadowElevation = 0.dp,
         ) {
             PrivateHandPanel(
-                playerName = player.name,
-                handCards = handCards,
-                privateHandCards = privateHandCards,
-                selectedTradeInCardIds = selectedTradeInCardIds,
-                showTradeControls = showTradeControls,
-                canSelectTradeCards = canSelectTradeCards,
-                canTradeInCards = canTradeInCards,
-                isTradePending = isTradePending,
-                onToggleTradeInCard = onToggleTradeInCard,
-                onTradeInCards = onTradeInCards,
+                state = state,
+                actions = actions,
                 modifier =
                     Modifier
                         .fillMaxWidth()
@@ -776,16 +836,8 @@ private fun PlayerAvatar(
 
 @Composable
 internal fun PrivateHandPanel(
-    playerName: String,
-    handCards: List<String>,
-    privateHandCards: List<PrivateHandCardUi> = emptyList(),
-    selectedTradeInCardIds: Set<CardId> = emptySet(),
-    showTradeControls: Boolean = false,
-    canSelectTradeCards: Boolean = false,
-    canTradeInCards: Boolean = false,
-    isTradePending: Boolean = false,
-    onToggleTradeInCard: (CardId) -> Unit = {},
-    onTradeInCards: () -> Unit = {},
+    state: PrivateHandPanelState,
+    actions: PrivateHandPanelActions = PrivateHandPanelActions(),
     modifier: Modifier = Modifier,
 ) {
     val unknownCardLabel = stringResource(id = R.string.game_cards_unknown)
@@ -798,24 +850,24 @@ internal fun PrivateHandPanel(
         )
     val handCardItems =
         remember(
-            handCards,
-            privateHandCards,
-            selectedTradeInCardIds,
+            state.handCards,
+            state.privateHandCards,
+            state.selectedTradeInCardIds,
             unknownCardLabel,
             typeLabels,
         ) {
-            if (privateHandCards.isNotEmpty()) {
-                privateHandCards.map { card ->
+            if (state.privateHandCards.isNotEmpty()) {
+                state.privateHandCards.map { card ->
                     HandCardItemUi(
                         stableKey = card.cardId.value,
                         label = typeLabels.getValue(card.type),
                         cardId = card.cardId,
-                        isSelected = card.cardId in selectedTradeInCardIds,
+                        isSelected = card.cardId in state.selectedTradeInCardIds,
                     )
                 }
             } else {
                 buildHandCardItems(
-                    handCards = handCards,
+                    handCards = state.handCards,
                     unknownCardLabel = unknownCardLabel,
                 )
             }
@@ -832,7 +884,7 @@ internal fun PrivateHandPanel(
             color = HudContentColor,
         )
         Text(
-            text = playerName,
+            text = state.playerName,
             style = MaterialTheme.typography.labelMedium,
             color = HudContentColor,
         )
@@ -857,15 +909,15 @@ internal fun PrivateHandPanel(
                 ) { item ->
                     HandCardRow(
                         item = item,
-                        selectable = showTradeControls && canSelectTradeCards,
-                        onSelected = { cardId -> onToggleTradeInCard(cardId) },
+                        selectable = state.showTradeControls && state.canSelectTradeCards,
+                        onSelected = { cardId -> actions.onToggleTradeInCard(cardId) },
                     )
                 }
             }
-            if (showTradeControls && privateHandCards.isNotEmpty()) {
+            if (state.showTradeControls && state.privateHandCards.isNotEmpty()) {
                 FilledTonalButton(
-                    onClick = onTradeInCards,
-                    enabled = canTradeInCards,
+                    onClick = actions.onTradeInCards,
+                    enabled = state.canTradeInCards,
                     modifier = Modifier.fillMaxWidth().testTag("trade_in_cards_button"),
                     shape = RoundedCornerShape(6.dp),
                     contentPadding = PaddingValues(horizontal = 8.dp, vertical = 6.dp),
@@ -875,7 +927,7 @@ internal fun PrivateHandPanel(
                         style = MaterialTheme.typography.labelMedium,
                     )
                 }
-                if (isTradePending) {
+                if (state.isTradePending) {
                     Text(
                         text = stringResource(id = R.string.loading),
                         style = MaterialTheme.typography.bodySmall,
@@ -952,21 +1004,14 @@ internal fun buildHandCardItems(
 /**
  * Zeigt die Platzierungssteuerung für ein bereits ausgewähltes eigenes Gebiet.
  *
- * Diese Composable wird ausschließlich bei einem positiven [remainingAmount]
- * und einem konkreten [selectedRegionId] erzeugt. Ein leerer Restpool erscheint
+ * Diese Composable wird ausschließlich bei einem positiven Restpool in [state]
+ * und einem konkreten ausgewählten Gebiet erzeugt. Ein leerer Restpool erscheint
  * daher nicht als Popup; das Abschließen erfolgt über die untere Aktionsleiste.
  */
 @Composable
 private fun ReinforcementPanel(
-    reinforcementState: ReinforcementUiState,
-    remainingAmount: Int,
-    placementAmount: Int,
-    selectedRegionId: String,
-    canAdjust: Boolean,
-    canPlace: Boolean,
-    onDismiss: () -> Unit,
-    onAdjustPlacementAmount: (Int) -> Unit,
-    onPlace: () -> Unit,
+    state: ReinforcementPanelState,
+    actions: ReinforcementPanelActions,
     modifier: Modifier = Modifier,
 ) {
     Surface(
@@ -992,20 +1037,20 @@ private fun ReinforcementPanel(
                     text =
                         stringResource(
                             id = R.string.game_reinforcements_remaining,
-                            remainingAmount.toString(),
+                            state.remainingAmount.toString(),
                         ),
                     modifier = Modifier.testTag("reinforcement_remaining"),
                     style = MaterialTheme.typography.labelLarge,
                     fontWeight = FontWeight.Bold,
                 )
-                if (reinforcementState.isBonusBreakdownKnown) {
+                if (state.reinforcementState.isBonusBreakdownKnown) {
                     Text(
                         text =
                             stringResource(
                                 id = R.string.game_reinforcements_bonus,
-                                reinforcementState.territoryBonus,
-                                reinforcementState.continentBonus,
-                                reinforcementState.cardBonus,
+                                state.reinforcementState.territoryBonus,
+                                state.reinforcementState.continentBonus,
+                                state.reinforcementState.cardBonus,
                             ),
                         style = MaterialTheme.typography.bodySmall,
                     )
@@ -1015,7 +1060,7 @@ private fun ReinforcementPanel(
                     stringResource(id = R.string.game_reinforcements_close)
                 BlockActionButton(
                     label = "X",
-                    onClick = onDismiss,
+                    onClick = actions.onDismiss,
                     selected = false,
                     enabled = true,
                     modifier =
@@ -1028,7 +1073,11 @@ private fun ReinforcementPanel(
                 )
             }
             Text(
-                text = stringResource(id = R.string.game_reinforcements_target, selectedRegionId),
+                text =
+                    stringResource(
+                        id = R.string.game_reinforcements_target,
+                        state.selectedRegionId,
+                    ),
                 style = MaterialTheme.typography.bodySmall,
             )
             Row(
@@ -1037,31 +1086,31 @@ private fun ReinforcementPanel(
             ) {
                 BlockActionButton(
                     label = "-",
-                    onClick = { onAdjustPlacementAmount(-1) },
+                    onClick = { actions.onAdjustPlacementAmount(-1) },
                     selected = false,
-                    enabled = canAdjust && placementAmount > 1,
+                    enabled = state.canAdjust && state.placementAmount > 1,
                     modifier = Modifier.size(42.dp).testTag("reinforcement_decrease"),
                 )
                 Text(
-                    text = placementAmount.toString(),
+                    text = state.placementAmount.toString(),
                     modifier = Modifier.width(32.dp).testTag("reinforcement_amount"),
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.Bold,
                 )
                 BlockActionButton(
                     label = "+",
-                    onClick = { onAdjustPlacementAmount(1) },
+                    onClick = { actions.onAdjustPlacementAmount(1) },
                     selected = false,
                     enabled =
-                        canAdjust &&
-                            placementAmount < remainingAmount,
+                        state.canAdjust &&
+                            state.placementAmount < state.remainingAmount,
                     modifier = Modifier.size(42.dp).testTag("reinforcement_increase"),
                 )
                 BlockActionButton(
                     label = stringResource(id = R.string.game_reinforcements_place),
-                    onClick = onPlace,
+                    onClick = actions.onPlace,
                     selected = true,
-                    enabled = canPlace,
+                    enabled = state.canPlace,
                     modifier = Modifier.testTag("place_reinforcements_button"),
                 )
             }

--- a/app/src/main/kotlin/at/aau/pulverfass/app/ui/screens/StudioIntroScreen.kt
+++ b/app/src/main/kotlin/at/aau/pulverfass/app/ui/screens/StudioIntroScreen.kt
@@ -1,23 +1,17 @@
 package at.aau.pulverfass.app.ui.screens
 
-import android.app.Activity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalView
-import androidx.core.view.WindowCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsControllerCompat
 import androidx.navigation.NavController
 import at.aau.pulverfass.app.R
 import at.aau.pulverfass.app.ui.components.VideoPlayer
@@ -30,8 +24,10 @@ private const val MAX_INTRO_DURATION_MS = 10_000L
 /**
  * Gabumon Studios Intro-Screen beim App-Start.
  *
- * Spielt das Studio-Intro-Video im IMMERSIVE MODE (kein Status-Bar, kein
- * Navigation-Bar) für maximale Brand-Wirkung. Navigiert danach zum LoadScreen.
+ * Spielt das Studio-Intro-Video und navigiert danach zum LoadScreen. Der
+ * immersive Vollbildmodus wird bewusst von `MainActivity` für die gesamte App
+ * gehalten: Würde dieser Screen beim Verlassen Systembars wieder einblenden,
+ * wären sie während des direkt folgenden LoadScreens sichtbar.
  *
  * - Click anywhere → sofort skip
  * - Video-Ende → auto-navigate zu Load
@@ -43,25 +39,6 @@ private const val MAX_INTRO_DURATION_MS = 10_000L
 @Composable
 fun StudioIntroScreen(navController: NavController) {
     var hasNavigated by remember { mutableStateOf(false) }
-    val view = LocalView.current
-
-    /*
-     * Immersive Mode: versteckt System-UI (Status-Bar oben, Navigation-Bar unten)
-     * solange der Studio-Intro-Screen angezeigt wird. Auf Dispose wird das
-     * automatisch zurückgesetzt damit andere Screens normal funktionieren.
-     */
-    if (!view.isInEditMode) {
-        DisposableEffect(view) {
-            val window = (view.context as Activity).window
-            val controller = WindowCompat.getInsetsController(window, view)
-            controller.hide(WindowInsetsCompat.Type.systemBars())
-            controller.systemBarsBehavior =
-                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-            onDispose {
-                controller.show(WindowInsetsCompat.Type.systemBars())
-            }
-        }
-    }
 
     /*
      * navigateNext ist idempotent — egal wie oft sie aufgerufen wird

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,16 @@
     <string name="game_cards_title">Kartenhand</string>
     <string name="game_cards_empty">Keine Karten</string>
     <string name="game_cards_unknown">Unbekannte Karte</string>
+    <string name="game_cards_trade_in">Set eintauschen</string>
+    <string name="game_card_type_a">Infanterie</string>
+    <string name="game_card_type_b">Kavallerie</string>
+    <string name="game_card_type_c">Artillerie</string>
+    <string name="game_card_type_joker">Joker</string>
+    <string name="game_reinforcements_remaining">Verfügbar: %1$s</string>
+    <string name="game_reinforcements_bonus">Gebiet %1$d · Kontinent %2$d · Karten %3$d</string>
+    <string name="game_reinforcements_target">Ziel: %1$s</string>
+    <string name="game_reinforcements_place">Platzieren</string>
+    <string name="game_reinforcements_close">Schließen</string>
     <string name="server_url">Server URL</string>
     <string name="connection_status">Status</string>
     <string name="last_message_type">Letzte Message</string>

--- a/app/src/test/kotlin/at/aau/pulverfass/app/game/ClientGameStateReducerTest.kt
+++ b/app/src/test/kotlin/at/aau/pulverfass/app/game/ClientGameStateReducerTest.kt
@@ -1,18 +1,24 @@
 package at.aau.pulverfass.app.game
 
 import at.aau.pulverfass.app.lobby.LobbyPlayerUi
+import at.aau.pulverfass.shared.ids.CardId
 import at.aau.pulverfass.shared.ids.LobbyCode
 import at.aau.pulverfass.shared.ids.PlayerId
 import at.aau.pulverfass.shared.ids.TerritoryId
+import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsChangedEvent
 import at.aau.pulverfass.shared.lobby.event.TerritoryOwnerChangedEvent
 import at.aau.pulverfass.shared.lobby.event.TerritoryTroopsChangedEvent
 import at.aau.pulverfass.shared.lobby.event.TurnStateUpdatedEvent
+import at.aau.pulverfass.shared.lobby.state.CardType
 import at.aau.pulverfass.shared.lobby.state.TurnPhase
 import at.aau.pulverfass.shared.message.lobby.event.GameStartedEvent
 import at.aau.pulverfass.shared.message.lobby.event.GameStateDeltaEvent
 import at.aau.pulverfass.shared.message.lobby.event.GameStateSnapshotBroadcast
 import at.aau.pulverfass.shared.message.lobby.event.PhaseBoundaryEvent
+import at.aau.pulverfass.shared.message.lobby.event.PlayerHandUpdatedEvent
+import at.aau.pulverfass.shared.message.lobby.event.PrivateHandCardSnapshot
 import at.aau.pulverfass.shared.message.lobby.event.PublicGameEvent
+import at.aau.pulverfass.shared.message.lobby.event.ReinforcementsGrantedEvent
 import at.aau.pulverfass.shared.message.lobby.response.GameStateCatchUpResponse
 import at.aau.pulverfass.shared.message.lobby.response.GameStatePrivateGetResponse
 import at.aau.pulverfass.shared.message.lobby.response.MapDefinitionSnapshot
@@ -41,6 +47,7 @@ class ClientGameStateReducerTest {
                         turnPhase = TurnPhase.REINFORCEMENTS,
                         turnCount = 1,
                         startPlayerId = aliceId,
+                        pendingReinforcements = 4,
                     ),
                 definition = mapDefinition("brasilien"),
                 territoryStates =
@@ -64,6 +71,10 @@ class ClientGameStateReducerTest {
         assertFalse(state.isCatchingUp)
         assertEquals(3, state.stateVersion)
         assertEquals(TurnPhase.REINFORCEMENTS, state.turnPhase)
+        assertEquals(aliceId, state.reinforcementState.playerId)
+        assertEquals(4, state.reinforcementState.pendingAmount)
+        assertFalse(state.reinforcementState.isBonusBreakdownKnown)
+        assertTrue(state.canManageReinforcements(aliceId))
         assertEquals(5, state.regionStates.getValue("brazil").troopCount)
         assertEquals("Alice", state.regionStates.getValue("brazil").ownerName)
     }
@@ -335,14 +346,255 @@ class ClientGameStateReducerTest {
                 regionId = ownRegion,
                 localPlayerId = aliceId,
             )
+        val retainedAfterEnemyTap =
+            ClientGameStateReducer.selectRegion(
+                current = accepted,
+                regionId = enemyRegion,
+                localPlayerId = aliceId,
+            )
+        val dismissed =
+            ClientGameStateReducer.selectRegion(
+                current = accepted,
+                regionId = ownRegion,
+                localPlayerId = aliceId,
+            )
 
         assertEquals(null, rejected.selectedRegionId)
-        assertEquals(
-            "In der Verstärkungsphase kannst du nur eigene Gebiete auswählen.",
-            rejected.selectionMessage,
-        )
+        assertEquals(null, rejected.selectionMessage)
         assertEquals(ownRegion, accepted.selectedRegionId)
-        assertEquals(ownRegion, accepted.selectionFromRegionId)
+        assertEquals(null, accepted.selectionFromRegionId)
+        assertEquals(null, accepted.selectionMessage)
+        assertEquals(ownRegion, retainedAfterEnemyTap.selectedRegionId)
+        assertEquals(null, retainedAfterEnemyTap.selectionMessage)
+        assertEquals(null, dismissed.selectedRegionId)
+    }
+
+    @Test
+    fun `reinforcement events expose pending pool bonuses and bound placement amount`() {
+        val initial =
+            GameUiState(
+                stateVersion = 1,
+                activePlayerId = aliceId,
+                turnPhase = TurnPhase.REINFORCEMENTS,
+                selectedRegionId = "brazil",
+            )
+        val granted =
+            ClientGameStateReducer.applyDelta(
+                current = initial,
+                delta =
+                    GameStateDeltaEvent(
+                        lobbyCode = lobbyCode,
+                        fromVersion = 1,
+                        toVersion = 2,
+                        events =
+                            listOf(
+                                ReinforcementsGrantedEvent(
+                                    lobbyCode = lobbyCode,
+                                    playerId = aliceId,
+                                    amount = 5,
+                                    territoryBonus = 3,
+                                    continentBonus = 2,
+                                    cardBonus = 0,
+                                ),
+                            ),
+                    ),
+                players = players,
+            ).state
+        val increased =
+            ClientGameStateReducer.adjustReinforcementPlacementAmount(
+                current = granted,
+                delta = 20,
+            )
+        val placed =
+            ClientGameStateReducer.applyDelta(
+                current = increased,
+                delta =
+                    GameStateDeltaEvent(
+                        lobbyCode = lobbyCode,
+                        fromVersion = 2,
+                        toVersion = 3,
+                        events =
+                            listOf(
+                                PendingReinforcementsChangedEvent(
+                                    lobbyCode = lobbyCode,
+                                    playerId = aliceId,
+                                    delta = -5,
+                                ),
+                            ),
+                    ),
+                players = players,
+            ).state
+
+        assertEquals(5, granted.reinforcementState.pendingAmount)
+        assertEquals(3, granted.reinforcementState.territoryBonus)
+        assertTrue(granted.reinforcementState.isBonusBreakdownKnown)
+        assertTrue(granted.canPlaceReinforcements(aliceId))
+        assertEquals(5, increased.reinforcementPlacementAmount)
+        assertEquals(0, placed.reinforcementState.pendingAmount)
+        assertEquals(1, placed.reinforcementPlacementAmount)
+        assertTrue(placed.canConfirmReinforcementsDone(aliceId))
+        assertFalse(placed.canRequestTurnAdvance(aliceId))
+    }
+
+    @Test
+    fun `trade grant adds card bonus without resetting existing pending pool`() {
+        val state =
+            GameUiState(
+                stateVersion = 1,
+                reinforcementState =
+                    ReinforcementUiState(
+                        playerId = aliceId,
+                        pendingAmount = 3,
+                        territoryBonus = 3,
+                        isBonusBreakdownKnown = true,
+                    ),
+                turnPhase = TurnPhase.REINFORCEMENTS,
+            )
+        val grant =
+            ClientGameStateReducer.applyDelta(
+                current = state,
+                delta =
+                    GameStateDeltaEvent(
+                        lobbyCode = lobbyCode,
+                        fromVersion = 1,
+                        toVersion = 2,
+                        events =
+                            listOf(
+                                ReinforcementsGrantedEvent(
+                                    lobbyCode = lobbyCode,
+                                    playerId = aliceId,
+                                    amount = 2,
+                                    territoryBonus = 0,
+                                    continentBonus = 0,
+                                    cardBonus = 2,
+                                ),
+                            ),
+                    ),
+                players = players,
+            ).state
+        val increased =
+            ClientGameStateReducer.applyDelta(
+                current = grant,
+                delta =
+                    GameStateDeltaEvent(
+                        lobbyCode = lobbyCode,
+                        fromVersion = 2,
+                        toVersion = 3,
+                        events =
+                            listOf(
+                                PendingReinforcementsChangedEvent(lobbyCode, aliceId, 2),
+                            ),
+                    ),
+                players = players,
+            ).state
+
+        assertEquals(3, grant.reinforcementState.pendingAmount)
+        assertEquals(2, grant.reinforcementState.cardBonus)
+        assertTrue(grant.reinforcementState.isBonusBreakdownKnown)
+        assertEquals(5, increased.reinforcementState.pendingAmount)
+    }
+
+    @Test
+    fun `base reinforcement grant after zero snapshot initializes a new visible pool`() {
+        val snapshotted =
+            ClientGameStateReducer.applyCatchUpResponse(
+                current = GameUiState(isCatchingUp = true),
+                response =
+                    GameStateCatchUpResponse(
+                        lobbyCode = lobbyCode,
+                        stateVersion = 1,
+                        determinism = determinism,
+                        turnState =
+                            PublicTurnStateSnapshot(
+                                activePlayerId = aliceId,
+                                turnPhase = TurnPhase.REINFORCEMENTS,
+                                turnCount = 1,
+                                startPlayerId = aliceId,
+                                pendingReinforcements = 0,
+                            ),
+                        definition = mapDefinition("brasilien"),
+                        territoryStates = emptyList(),
+                    ),
+                players = players,
+            )
+
+        val granted =
+            ClientGameStateReducer.applyDelta(
+                current = snapshotted,
+                delta =
+                    GameStateDeltaEvent(
+                        lobbyCode = lobbyCode,
+                        fromVersion = 1,
+                        toVersion = 2,
+                        events =
+                            listOf(
+                                ReinforcementsGrantedEvent(
+                                    lobbyCode = lobbyCode,
+                                    playerId = aliceId,
+                                    amount = 3,
+                                    territoryBonus = 3,
+                                    continentBonus = 0,
+                                    cardBonus = 0,
+                                ),
+                            ),
+                    ),
+                players = players,
+            ).state
+
+        assertEquals(3, granted.reinforcementState.pendingAmount)
+        assertEquals(3, granted.reinforcementState.territoryBonus)
+        assertTrue(granted.reinforcementState.isBonusBreakdownKnown)
+    }
+
+    @Test
+    fun `private typed hand supports selecting three cards and clears removed cards`() {
+        val cards =
+            listOf(
+                PrivateHandCardSnapshot(CardId("a"), CardType.A),
+                PrivateHandCardSnapshot(CardId("b"), CardType.B),
+                PrivateHandCardSnapshot(CardId("c"), CardType.C),
+            )
+        val private =
+            ClientGameStateReducer.applyPrivateGetResponse(
+                current =
+                    GameUiState(
+                        activePlayerId = aliceId,
+                        turnPhase = TurnPhase.REINFORCEMENTS,
+                    ),
+                response =
+                    GameStatePrivateGetResponse(
+                        lobbyCode = lobbyCode,
+                        recipientPlayerId = aliceId,
+                        stateVersion = 1,
+                        privateHandCards = cards,
+                    ),
+            )
+        val selected =
+            cards.fold(private) { current, card ->
+                ClientGameStateReducer.toggleTradeInCard(current, card.cardId)
+            }
+        val updated =
+            ClientGameStateReducer.applyPlayerHandUpdatedEvent(
+                current = selected,
+                event =
+                    PlayerHandUpdatedEvent(
+                        lobbyCode = lobbyCode,
+                        recipientPlayerId = aliceId,
+                        stateVersion = 2,
+                        handCards = listOf(cards.first()),
+                    ),
+            )
+
+        assertEquals(3, selected.privateHandCards.size)
+        assertTrue(selected.canTradeInCards(aliceId))
+        assertEquals(setOf(CardId("a")), updated.selectedTradeInCardIds)
+        assertEquals(1, updated.privateHandCards.size)
+        assertFalse(
+            ClientGameStateReducer
+                .toggleTradeInCard(updated, CardId("missing"))
+                .selectedTradeInCardIds
+                .contains(CardId("missing")),
+        )
     }
 
     @Test

--- a/app/src/test/kotlin/at/aau/pulverfass/app/game/ClientGameStateReducerTest.kt
+++ b/app/src/test/kotlin/at/aau/pulverfass/app/game/ClientGameStateReducerTest.kt
@@ -598,6 +598,102 @@ class ClientGameStateReducerTest {
     }
 
     @Test
+    fun `reinforcement phase updates retain local pool and guard card selection`() {
+        val cards =
+            listOf(
+                PrivateHandCardUi(CardId("a"), CardType.A),
+                PrivateHandCardUi(CardId("b"), CardType.B),
+                PrivateHandCardUi(CardId("c"), CardType.C),
+                PrivateHandCardUi(CardId("d"), CardType.JOKER),
+            )
+        val initial =
+            GameUiState(
+                stateVersion = 1,
+                activePlayerId = aliceId,
+                turnPhase = TurnPhase.REINFORCEMENTS,
+                reinforcementState = ReinforcementUiState(aliceId, pendingAmount = 4),
+                privateHandCards = cards,
+                selectedTradeInCardIds = setOf(CardId("a"), CardId("b"), CardId("c")),
+            )
+
+        val boundary =
+            ClientGameStateReducer.applyPhaseBoundary(
+                initial,
+                PhaseBoundaryEvent(
+                    lobbyCode = lobbyCode,
+                    stateVersion = 2,
+                    previousPhase = TurnPhase.ATTACK,
+                    nextPhase = TurnPhase.REINFORCEMENTS,
+                    activePlayerId = aliceId,
+                    turnCount = 2,
+                ),
+            )
+        val turn =
+            ClientGameStateReducer.applyTurnStateGetResponse(
+                initial,
+                TurnStateGetResponse(
+                    lobbyCode = lobbyCode,
+                    activePlayerId = aliceId,
+                    turnPhase = TurnPhase.REINFORCEMENTS,
+                    turnCount = 2,
+                    startPlayerId = aliceId,
+                ),
+            )
+        val publicUpdate =
+            ClientGameStateReducer.applyDelta(
+                current = initial,
+                delta =
+                    GameStateDeltaEvent(
+                        lobbyCode = lobbyCode,
+                        fromVersion = 1,
+                        toVersion = 2,
+                        events =
+                            listOf(
+                                TurnStateUpdatedEvent(
+                                    lobbyCode = lobbyCode,
+                                    activePlayerId = aliceId,
+                                    turnPhase = TurnPhase.REINFORCEMENTS,
+                                    turnCount = 2,
+                                    startPlayerId = aliceId,
+                                ),
+                            ),
+                    ),
+                players = players,
+            ).state
+        val deselected = ClientGameStateReducer.toggleTradeInCard(initial, CardId("a"))
+        val capped = ClientGameStateReducer.toggleTradeInCard(initial, CardId("d"))
+        val unrelatedPendingEvent =
+            ClientGameStateReducer.applyDelta(
+                current = initial,
+                delta =
+                    GameStateDeltaEvent(
+                        lobbyCode = lobbyCode,
+                        fromVersion = 1,
+                        toVersion = 2,
+                        events =
+                            listOf(
+                                PendingReinforcementsChangedEvent(
+                                    lobbyCode = lobbyCode,
+                                    playerId = bobId,
+                                    delta = -1,
+                                ),
+                            ),
+                    ),
+                players = players,
+            ).state
+
+        assertEquals(initial.reinforcementState, boundary.reinforcementState)
+        assertEquals(initial.selectedTradeInCardIds, boundary.selectedTradeInCardIds)
+        assertEquals(initial.reinforcementState, turn.reinforcementState)
+        assertEquals(initial.selectedTradeInCardIds, turn.selectedTradeInCardIds)
+        assertEquals(initial.reinforcementState, publicUpdate.reinforcementState)
+        assertEquals(initial.selectedTradeInCardIds, publicUpdate.selectedTradeInCardIds)
+        assertEquals(setOf(CardId("b"), CardId("c")), deselected.selectedTradeInCardIds)
+        assertEquals(initial, capped)
+        assertEquals(initial.reinforcementState, unrelatedPendingEvent.reinforcementState)
+    }
+
+    @Test
     fun `region selection toggles source target and card visibility`() {
         val sourceSelected =
             ClientGameStateReducer.selectRegion(

--- a/app/src/test/kotlin/at/aau/pulverfass/app/lobby/GameErrorTextMapperTest.kt
+++ b/app/src/test/kotlin/at/aau/pulverfass/app/lobby/GameErrorTextMapperTest.kt
@@ -1,11 +1,17 @@
 package at.aau.pulverfass.app.lobby
 
+import at.aau.pulverfass.shared.message.lobby.response.error.ConfirmReinforcementsDoneErrorCode
+import at.aau.pulverfass.shared.message.lobby.response.error.ConfirmReinforcementsDoneErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.GameStateCatchUpErrorCode
 import at.aau.pulverfass.shared.message.lobby.response.error.GameStateCatchUpErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.GameStatePrivateGetErrorCode
 import at.aau.pulverfass.shared.message.lobby.response.error.GameStatePrivateGetErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.MapGetErrorCode
 import at.aau.pulverfass.shared.message.lobby.response.error.MapGetErrorResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.PlaceReinforcementsErrorCode
+import at.aau.pulverfass.shared.message.lobby.response.error.PlaceReinforcementsErrorResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.TradeInCardsErrorCode
+import at.aau.pulverfass.shared.message.lobby.response.error.TradeInCardsErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.TurnAdvanceErrorCode
 import at.aau.pulverfass.shared.message.lobby.response.error.TurnAdvanceErrorResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.TurnStateGetErrorCode
@@ -120,5 +126,122 @@ class GameErrorTextMapperTest {
                 TurnAdvanceErrorResponse(TurnAdvanceErrorCode.GAME_NOT_FOUND, "raw"),
             ),
         )
+    }
+
+    @Test
+    fun `reinforcement placement errors are translated for UI`() {
+        val messages =
+            PlaceReinforcementsErrorCode.entries.associateWith { code ->
+                GameErrorTextMapper.map(PlaceReinforcementsErrorResponse(code, "raw"))
+            }
+
+        assertTrue(
+            messages.getValue(
+                PlaceReinforcementsErrorCode.REQUESTER_MISMATCH,
+            ).contains("Spielerzuordnung"),
+        )
+        assertTrue(
+            messages.getValue(
+                PlaceReinforcementsErrorCode.NOT_ACTIVE_PLAYER,
+            ).contains("eigenen Zug"),
+        )
+        assertEquals(
+            "Das Spiel ist aktuell pausiert.",
+            messages.getValue(PlaceReinforcementsErrorCode.GAME_PAUSED),
+        )
+        assertTrue(
+            messages.getValue(PlaceReinforcementsErrorCode.PHASE_MISMATCH).contains("beendet"),
+        )
+        assertEquals(
+            GameErrorTextMapper.GAME_NOT_FOUND_TEXT,
+            messages.getValue(PlaceReinforcementsErrorCode.GAME_NOT_FOUND),
+        )
+        assertTrue(
+            messages.getValue(
+                PlaceReinforcementsErrorCode.TERRITORY_NOT_OWNED,
+            ).contains("eigene Gebiete"),
+        )
+        assertTrue(messages.getValue(PlaceReinforcementsErrorCode.OVERSPEND).contains("genügend"))
+        assertTrue(
+            messages.getValue(PlaceReinforcementsErrorCode.INVALID_PLACEMENT).contains("ungültig"),
+        )
+        assertTrue(
+            messages.getValue(
+                PlaceReinforcementsErrorCode.FORCED_TRADE_REQUIRED,
+            ).contains("Kartenset"),
+        )
+    }
+
+    @Test
+    fun `reinforcement finish errors are translated for UI`() {
+        val messages =
+            ConfirmReinforcementsDoneErrorCode.entries.associateWith { code ->
+                GameErrorTextMapper.map(ConfirmReinforcementsDoneErrorResponse(code, "raw"))
+            }
+
+        assertTrue(
+            messages.getValue(
+                ConfirmReinforcementsDoneErrorCode.REQUESTER_MISMATCH,
+            ).contains("Spielerzuordnung"),
+        )
+        assertTrue(
+            messages.getValue(
+                ConfirmReinforcementsDoneErrorCode.NOT_ACTIVE_PLAYER,
+            ).contains("eigenen Zug"),
+        )
+        assertEquals(
+            "Das Spiel ist aktuell pausiert.",
+            messages.getValue(ConfirmReinforcementsDoneErrorCode.GAME_PAUSED),
+        )
+        assertTrue(
+            messages.getValue(
+                ConfirmReinforcementsDoneErrorCode.PHASE_MISMATCH,
+            ).contains("beendet"),
+        )
+        assertEquals(
+            GameErrorTextMapper.GAME_NOT_FOUND_TEXT,
+            messages.getValue(ConfirmReinforcementsDoneErrorCode.GAME_NOT_FOUND),
+        )
+        assertTrue(
+            messages.getValue(
+                ConfirmReinforcementsDoneErrorCode.PENDING_REINFORCEMENTS_REMAINING,
+            ).contains("Verbleibende"),
+        )
+        assertTrue(
+            messages.getValue(
+                ConfirmReinforcementsDoneErrorCode.FORCED_TRADE_REQUIRED,
+            ).contains("Kartenset"),
+        )
+    }
+
+    @Test
+    fun `card trade errors are translated for UI`() {
+        val messages =
+            TradeInCardsErrorCode.entries.associateWith { code ->
+                GameErrorTextMapper.map(TradeInCardsErrorResponse(code, "raw"))
+            }
+
+        assertTrue(
+            messages.getValue(
+                TradeInCardsErrorCode.REQUESTER_MISMATCH,
+            ).contains("Spielerzuordnung"),
+        )
+        assertTrue(
+            messages.getValue(TradeInCardsErrorCode.NOT_ACTIVE_PLAYER).contains("eigenen Zug"),
+        )
+        assertEquals(
+            "Das Spiel ist aktuell pausiert.",
+            messages.getValue(TradeInCardsErrorCode.GAME_PAUSED),
+        )
+        assertTrue(
+            messages.getValue(TradeInCardsErrorCode.PHASE_MISMATCH).contains("Verstärkungsphase"),
+        )
+        assertEquals(
+            GameErrorTextMapper.GAME_NOT_FOUND_TEXT,
+            messages.getValue(TradeInCardsErrorCode.GAME_NOT_FOUND),
+        )
+        assertTrue(messages.getValue(TradeInCardsErrorCode.CARDS_NOT_OWNED).contains("Hand"))
+        assertTrue(messages.getValue(TradeInCardsErrorCode.INVALID_SET).contains("gültiges Set"))
+        assertTrue(messages.getValue(TradeInCardsErrorCode.INVALID_REQUEST).contains("genau drei"))
     }
 }

--- a/app/src/test/kotlin/at/aau/pulverfass/app/lobby/LobbyControllerTest.kt
+++ b/app/src/test/kotlin/at/aau/pulverfass/app/lobby/LobbyControllerTest.kt
@@ -44,6 +44,12 @@ import at.aau.pulverfass.shared.message.lobby.response.PublicDeterminismMetadata
 import at.aau.pulverfass.shared.message.lobby.response.PublicTurnStateSnapshot
 import at.aau.pulverfass.shared.message.lobby.response.StartGameResponse
 import at.aau.pulverfass.shared.message.lobby.response.TradeInCardsResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.ConfirmReinforcementsDoneErrorCode
+import at.aau.pulverfass.shared.message.lobby.response.error.ConfirmReinforcementsDoneErrorResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.PlaceReinforcementsErrorCode
+import at.aau.pulverfass.shared.message.lobby.response.error.PlaceReinforcementsErrorResponse
+import at.aau.pulverfass.shared.message.lobby.response.error.TradeInCardsErrorCode
+import at.aau.pulverfass.shared.message.lobby.response.error.TradeInCardsErrorResponse
 import at.aau.pulverfass.shared.message.protocol.NetworkMessagePayload
 import at.aau.pulverfass.shared.network.codec.MessageCodec
 import io.ktor.server.application.install
@@ -460,7 +466,11 @@ class LobbyControllerTest {
             val lobbyCode = LobbyCode("RF12")
             val playerId = PlayerId(1)
             val cardIds = listOf(CardId("card-a"), CardId("card-b"), CardId("card-c"))
+            val config = LobbyControllerConfig()
             val seenPayloads = Collections.synchronizedList(mutableListOf<Any>())
+            var placeAttempts = 0
+            var tradeInAttempts = 0
+            var confirmAttempts = 0
             val server =
                 startProtocolServer { payload, outgoing ->
                     seenPayloads += payload
@@ -573,63 +583,110 @@ class LobbyControllerTest {
                                 ),
                             )
                         is PlaceReinforcementsRequest -> {
-                            outgoing.send(
-                                Frame.Binary(
-                                    true,
-                                    MessageCodec.encode(
-                                        GameStateDeltaEvent(
-                                            lobbyCode = lobbyCode,
-                                            fromVersion = 2,
-                                            toVersion = 3,
-                                            events =
-                                                listOf(
-                                                    PendingReinforcementsChangedEvent(
-                                                        lobbyCode = lobbyCode,
-                                                        playerId = playerId,
-                                                        delta = -2,
-                                                    ),
-                                                ),
+                            placeAttempts += 1
+                            if (placeAttempts == 1) {
+                                outgoing.send(
+                                    Frame.Binary(
+                                        true,
+                                        MessageCodec.encode(
+                                            PlaceReinforcementsErrorResponse(
+                                                PlaceReinforcementsErrorCode.TERRITORY_NOT_OWNED,
+                                                "not owned",
+                                            ),
                                         ),
                                     ),
-                                ),
-                            )
-                            outgoing.send(
-                                Frame.Binary(
-                                    true,
-                                    MessageCodec.encode(PlaceReinforcementsResponse(lobbyCode)),
-                                ),
-                            )
+                                )
+                            } else {
+                                outgoing.send(
+                                    Frame.Binary(
+                                        true,
+                                        MessageCodec.encode(
+                                            GameStateDeltaEvent(
+                                                lobbyCode = lobbyCode,
+                                                fromVersion = 2,
+                                                toVersion = 3,
+                                                events =
+                                                    listOf(
+                                                        PendingReinforcementsChangedEvent(
+                                                            lobbyCode = lobbyCode,
+                                                            playerId = playerId,
+                                                            delta = -2,
+                                                        ),
+                                                    ),
+                                            ),
+                                        ),
+                                    ),
+                                )
+                                outgoing.send(
+                                    Frame.Binary(
+                                        true,
+                                        MessageCodec.encode(PlaceReinforcementsResponse(lobbyCode)),
+                                    ),
+                                )
+                            }
                         }
                         is TradeInCardsRequest -> {
-                            outgoing.send(
-                                Frame.Binary(
-                                    true,
-                                    MessageCodec.encode(TradeInCardsResponse(lobbyCode)),
-                                ),
-                            )
-                            outgoing.send(
-                                Frame.Binary(
-                                    true,
-                                    MessageCodec.encode(
-                                        PlayerHandUpdatedEvent(
-                                            lobbyCode = lobbyCode,
-                                            recipientPlayerId = playerId,
-                                            stateVersion = 3,
-                                            handCards = emptyList(),
+                            tradeInAttempts += 1
+                            if (tradeInAttempts == 1) {
+                                outgoing.send(
+                                    Frame.Binary(
+                                        true,
+                                        MessageCodec.encode(
+                                            TradeInCardsErrorResponse(
+                                                TradeInCardsErrorCode.INVALID_SET,
+                                                "invalid set",
+                                            ),
                                         ),
                                     ),
-                                ),
-                            )
-                        }
-                        is ConfirmReinforcementsDoneRequest ->
-                            outgoing.send(
-                                Frame.Binary(
-                                    true,
-                                    MessageCodec.encode(
-                                        ConfirmReinforcementsDoneResponse(lobbyCode),
+                                )
+                            } else {
+                                outgoing.send(
+                                    Frame.Binary(
+                                        true,
+                                        MessageCodec.encode(TradeInCardsResponse(lobbyCode)),
                                     ),
-                                ),
-                            )
+                                )
+                                outgoing.send(
+                                    Frame.Binary(
+                                        true,
+                                        MessageCodec.encode(
+                                            PlayerHandUpdatedEvent(
+                                                lobbyCode = lobbyCode,
+                                                recipientPlayerId = playerId,
+                                                stateVersion = 3,
+                                                handCards = emptyList(),
+                                            ),
+                                        ),
+                                    ),
+                                )
+                            }
+                        }
+                        is ConfirmReinforcementsDoneRequest -> {
+                            confirmAttempts += 1
+                            if (confirmAttempts == 1) {
+                                outgoing.send(
+                                    Frame.Binary(
+                                        true,
+                                        MessageCodec.encode(
+                                            ConfirmReinforcementsDoneErrorResponse(
+                                                ConfirmReinforcementsDoneErrorCode
+                                                    .PENDING_REINFORCEMENTS_REMAINING,
+                                                "pending",
+                                            ),
+                                        ),
+                                    ),
+                                )
+                            } else {
+                                outgoing.send(
+                                    Frame.Binary(
+                                        true,
+                                        MessageCodec.encode(
+                                            ConfirmReinforcementsDoneResponse(lobbyCode),
+                                        ),
+                                    ),
+                                )
+                            }
+                        }
                     }
                 }
             val controller = createController()
@@ -642,26 +699,56 @@ class LobbyControllerTest {
                 waitUntil { controller.state.value.gameState.reinforcementState.pendingAmount == 2 }
                 waitUntil { controller.state.value.gameState.privateHandCards.size == 3 }
 
+                controller.placeReinforcements()
+                assertEquals(
+                    config.errorReinforcementTargetMissing,
+                    controller.state.value.errorText,
+                )
+                controller.confirmReinforcementsDone()
+                assertEquals(config.errorReinforcementsNotAllowed, controller.state.value.errorText)
+
                 controller.selectGameRegion("brazil")
                 controller.adjustReinforcementPlacementAmount(1)
                 controller.placeReinforcements()
-                waitUntil { seenPayloads.any { it is PlaceReinforcementsRequest } }
-                val placement = seenPayloads.filterIsInstance<PlaceReinforcementsRequest>().single()
+                waitUntil {
+                    controller.state.value.errorText ==
+                        "Verstärkungen können nur auf eigene Gebiete gesetzt werden."
+                }
+                controller.placeReinforcements()
+                waitUntil { seenPayloads.filterIsInstance<PlaceReinforcementsRequest>().size == 2 }
+                val placement = seenPayloads.filterIsInstance<PlaceReinforcementsRequest>().last()
                 assertEquals(TerritoryId("brasilien"), placement.placements.single().territoryId)
                 assertEquals(2, placement.placements.single().amount)
                 waitUntil { controller.state.value.gameState.reinforcementState.pendingAmount == 0 }
 
+                controller.placeReinforcements()
+                assertEquals(config.errorReinforcementsNotAllowed, controller.state.value.errorText)
+                controller.tradeInCards()
+                assertEquals(config.errorTradeInNotAllowed, controller.state.value.errorText)
+
                 cardIds.forEach(controller::toggleTradeInCard)
                 controller.tradeInCards()
-                waitUntil { seenPayloads.any { it is TradeInCardsRequest } }
+                waitUntil {
+                    controller.state.value.errorText ==
+                        "Die gewählten Karten bilden kein gültiges Set."
+                }
+                controller.tradeInCards()
+                waitUntil { seenPayloads.filterIsInstance<TradeInCardsRequest>().size == 2 }
                 assertEquals(
                     cardIds.toSet(),
-                    seenPayloads.filterIsInstance<TradeInCardsRequest>().single().cardIds.toSet(),
+                    seenPayloads.filterIsInstance<TradeInCardsRequest>().last().cardIds.toSet(),
                 )
                 waitUntil { controller.state.value.gameState.privateHandCards.isEmpty() }
 
                 controller.confirmReinforcementsDone()
-                waitUntil { seenPayloads.any { it is ConfirmReinforcementsDoneRequest } }
+                waitUntil {
+                    controller.state.value.errorText ==
+                        "Verbleibende Verstärkungen müssen zuerst platziert werden."
+                }
+                controller.confirmReinforcementsDone()
+                waitUntil {
+                    seenPayloads.filterIsInstance<ConfirmReinforcementsDoneRequest>().size == 2
+                }
                 waitUntil {
                     !controller.state.value.pendingCommandKeys.contains(
                         LobbyCommandKey.CONFIRM_REINFORCEMENTS_DONE,
@@ -671,6 +758,24 @@ class LobbyControllerTest {
                 controller.close()
                 server.close()
             }
+        }
+    }
+
+    @Test
+    fun `reinforcement actions require a local player context`() {
+        val config = LobbyControllerConfig()
+        val controller = createController(config = config)
+        try {
+            controller.placeReinforcements()
+            assertEquals(config.errorPlayerIdMissing, controller.state.value.errorText)
+
+            controller.confirmReinforcementsDone()
+            assertEquals(config.errorPlayerIdMissing, controller.state.value.errorText)
+
+            controller.tradeInCards()
+            assertEquals(config.errorPlayerIdMissing, controller.state.value.errorText)
+        } finally {
+            controller.close()
         }
     }
 

--- a/app/src/test/kotlin/at/aau/pulverfass/app/lobby/LobbyControllerTest.kt
+++ b/app/src/test/kotlin/at/aau/pulverfass/app/lobby/LobbyControllerTest.kt
@@ -1,27 +1,49 @@
 package at.aau.pulverfass.app.lobby
 
 import at.aau.pulverfass.app.storage.ReconnectSessionStore
+import at.aau.pulverfass.shared.ids.CardId
 import at.aau.pulverfass.shared.ids.LobbyCode
 import at.aau.pulverfass.shared.ids.PlayerId
 import at.aau.pulverfass.shared.ids.SessionToken
+import at.aau.pulverfass.shared.ids.TerritoryId
+import at.aau.pulverfass.shared.lobby.event.PendingReinforcementsChangedEvent
+import at.aau.pulverfass.shared.lobby.state.CardType
+import at.aau.pulverfass.shared.lobby.state.TurnPhase
 import at.aau.pulverfass.shared.message.connection.request.ReconnectRequest
 import at.aau.pulverfass.shared.message.connection.response.ConnectionResponse
 import at.aau.pulverfass.shared.message.connection.response.ReconnectErrorCode
 import at.aau.pulverfass.shared.message.connection.response.ReconnectResponse
 import at.aau.pulverfass.shared.message.lobby.event.GameStartedEvent
+import at.aau.pulverfass.shared.message.lobby.event.GameStateDeltaEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerConnectionLostReason
+import at.aau.pulverfass.shared.message.lobby.event.PlayerHandUpdatedEvent
 import at.aau.pulverfass.shared.message.lobby.event.PlayerJoinedLobbyEvent
+import at.aau.pulverfass.shared.message.lobby.event.PrivateHandCardSnapshot
+import at.aau.pulverfass.shared.message.lobby.event.ReinforcementsGrantedEvent
+import at.aau.pulverfass.shared.message.lobby.request.ConfirmReinforcementsDoneRequest
 import at.aau.pulverfass.shared.message.lobby.request.CreateLobbyRequest
 import at.aau.pulverfass.shared.message.lobby.request.GameStateCatchUpRequest
 import at.aau.pulverfass.shared.message.lobby.request.GameStatePrivateGetRequest
 import at.aau.pulverfass.shared.message.lobby.request.JoinLobbyRequest
 import at.aau.pulverfass.shared.message.lobby.request.MapGetRequest
+import at.aau.pulverfass.shared.message.lobby.request.PlaceReinforcementsRequest
 import at.aau.pulverfass.shared.message.lobby.request.StartGameRequest
+import at.aau.pulverfass.shared.message.lobby.request.TradeInCardsRequest
 import at.aau.pulverfass.shared.message.lobby.request.TurnStateGetRequest
+import at.aau.pulverfass.shared.message.lobby.response.ConfirmReinforcementsDoneResponse
 import at.aau.pulverfass.shared.message.lobby.response.CreateLobbyResponse
+import at.aau.pulverfass.shared.message.lobby.response.GameStateCatchUpResponse
+import at.aau.pulverfass.shared.message.lobby.response.GameStatePrivateGetResponse
 import at.aau.pulverfass.shared.message.lobby.response.JoinLobbyResponse
+import at.aau.pulverfass.shared.message.lobby.response.MapDefinitionSnapshot
+import at.aau.pulverfass.shared.message.lobby.response.MapTerritoryDefinitionSnapshot
+import at.aau.pulverfass.shared.message.lobby.response.MapTerritoryStateSnapshot
+import at.aau.pulverfass.shared.message.lobby.response.PlaceReinforcementsResponse
+import at.aau.pulverfass.shared.message.lobby.response.PublicDeterminismMetadataSnapshot
+import at.aau.pulverfass.shared.message.lobby.response.PublicTurnStateSnapshot
 import at.aau.pulverfass.shared.message.lobby.response.StartGameResponse
+import at.aau.pulverfass.shared.message.lobby.response.TradeInCardsResponse
 import at.aau.pulverfass.shared.message.protocol.NetworkMessagePayload
 import at.aau.pulverfass.shared.network.codec.MessageCodec
 import io.ktor.server.application.install
@@ -425,6 +447,226 @@ class LobbyControllerTest {
                 waitUntil { seenPayloads.any { it is MapGetRequest } }
                 waitUntil { seenPayloads.any { it is TurnStateGetRequest } }
                 waitUntil { seenPayloads.any { it is GameStatePrivateGetRequest } }
+            } finally {
+                controller.close()
+                server.close()
+            }
+        }
+    }
+
+    @Test
+    fun `reinforcement actions send backend requests and consume private card updates`() {
+        runBlocking {
+            val lobbyCode = LobbyCode("RF12")
+            val playerId = PlayerId(1)
+            val cardIds = listOf(CardId("card-a"), CardId("card-b"), CardId("card-c"))
+            val seenPayloads = Collections.synchronizedList(mutableListOf<Any>())
+            val server =
+                startProtocolServer { payload, outgoing ->
+                    seenPayloads += payload
+                    when (payload) {
+                        is JoinLobbyRequest -> {
+                            outgoing.send(
+                                Frame.Binary(
+                                    true,
+                                    MessageCodec.encode(JoinLobbyResponse(payload.lobbyCode)),
+                                ),
+                            )
+                            outgoing.send(
+                                Frame.Binary(
+                                    true,
+                                    MessageCodec.encode(
+                                        PlayerJoinedLobbyEvent(
+                                            lobbyCode = lobbyCode,
+                                            playerId = playerId,
+                                            playerDisplayName = payload.playerDisplayName,
+                                        ),
+                                    ),
+                                ),
+                            )
+                            outgoing.send(
+                                Frame.Binary(
+                                    true,
+                                    MessageCodec.encode(
+                                        GameStateCatchUpResponse(
+                                            lobbyCode = lobbyCode,
+                                            stateVersion = 1,
+                                            determinism =
+                                                PublicDeterminismMetadataSnapshot(
+                                                    mapHash = "hash",
+                                                    schemaVersion = 1,
+                                                ),
+                                            turnState =
+                                                PublicTurnStateSnapshot(
+                                                    activePlayerId = playerId,
+                                                    turnPhase = TurnPhase.REINFORCEMENTS,
+                                                    turnCount = 1,
+                                                    startPlayerId = playerId,
+                                                ),
+                                            definition =
+                                                MapDefinitionSnapshot(
+                                                    territories =
+                                                        listOf(
+                                                            MapTerritoryDefinitionSnapshot(
+                                                                territoryId =
+                                                                    TerritoryId(
+                                                                        "brasilien",
+                                                                    ),
+                                                                edges = emptyList(),
+                                                            ),
+                                                        ),
+                                                    continents = emptyList(),
+                                                ),
+                                            territoryStates =
+                                                listOf(
+                                                    MapTerritoryStateSnapshot(
+                                                        territoryId = TerritoryId("brasilien"),
+                                                        ownerId = playerId,
+                                                        troopCount = 1,
+                                                    ),
+                                                ),
+                                        ),
+                                    ),
+                                ),
+                            )
+                            outgoing.send(
+                                Frame.Binary(
+                                    true,
+                                    MessageCodec.encode(
+                                        GameStateDeltaEvent(
+                                            lobbyCode = lobbyCode,
+                                            fromVersion = 1,
+                                            toVersion = 2,
+                                            events =
+                                                listOf(
+                                                    ReinforcementsGrantedEvent(
+                                                        lobbyCode = lobbyCode,
+                                                        playerId = playerId,
+                                                        amount = 2,
+                                                        territoryBonus = 2,
+                                                        continentBonus = 0,
+                                                        cardBonus = 0,
+                                                    ),
+                                                ),
+                                        ),
+                                    ),
+                                ),
+                            )
+                        }
+                        is GameStatePrivateGetRequest ->
+                            outgoing.send(
+                                Frame.Binary(
+                                    true,
+                                    MessageCodec.encode(
+                                        GameStatePrivateGetResponse(
+                                            lobbyCode = lobbyCode,
+                                            recipientPlayerId = playerId,
+                                            stateVersion = 2,
+                                            privateHandCards =
+                                                listOf(
+                                                    PrivateHandCardSnapshot(cardIds[0], CardType.A),
+                                                    PrivateHandCardSnapshot(cardIds[1], CardType.B),
+                                                    PrivateHandCardSnapshot(cardIds[2], CardType.C),
+                                                ),
+                                        ),
+                                    ),
+                                ),
+                            )
+                        is PlaceReinforcementsRequest -> {
+                            outgoing.send(
+                                Frame.Binary(
+                                    true,
+                                    MessageCodec.encode(
+                                        GameStateDeltaEvent(
+                                            lobbyCode = lobbyCode,
+                                            fromVersion = 2,
+                                            toVersion = 3,
+                                            events =
+                                                listOf(
+                                                    PendingReinforcementsChangedEvent(
+                                                        lobbyCode = lobbyCode,
+                                                        playerId = playerId,
+                                                        delta = -2,
+                                                    ),
+                                                ),
+                                        ),
+                                    ),
+                                ),
+                            )
+                            outgoing.send(
+                                Frame.Binary(
+                                    true,
+                                    MessageCodec.encode(PlaceReinforcementsResponse(lobbyCode)),
+                                ),
+                            )
+                        }
+                        is TradeInCardsRequest -> {
+                            outgoing.send(
+                                Frame.Binary(
+                                    true,
+                                    MessageCodec.encode(TradeInCardsResponse(lobbyCode)),
+                                ),
+                            )
+                            outgoing.send(
+                                Frame.Binary(
+                                    true,
+                                    MessageCodec.encode(
+                                        PlayerHandUpdatedEvent(
+                                            lobbyCode = lobbyCode,
+                                            recipientPlayerId = playerId,
+                                            stateVersion = 3,
+                                            handCards = emptyList(),
+                                        ),
+                                    ),
+                                ),
+                            )
+                        }
+                        is ConfirmReinforcementsDoneRequest ->
+                            outgoing.send(
+                                Frame.Binary(
+                                    true,
+                                    MessageCodec.encode(
+                                        ConfirmReinforcementsDoneResponse(lobbyCode),
+                                    ),
+                                ),
+                            )
+                    }
+                }
+            val controller = createController()
+            try {
+                controller.updateServerUrl(server.url)
+                controller.updatePlayerName("Alice")
+                controller.updateLobbyCode(lobbyCode.value)
+                controller.joinLobby { }
+
+                waitUntil { controller.state.value.gameState.reinforcementState.pendingAmount == 2 }
+                waitUntil { controller.state.value.gameState.privateHandCards.size == 3 }
+
+                controller.selectGameRegion("brazil")
+                controller.adjustReinforcementPlacementAmount(1)
+                controller.placeReinforcements()
+                waitUntil { seenPayloads.any { it is PlaceReinforcementsRequest } }
+                val placement = seenPayloads.filterIsInstance<PlaceReinforcementsRequest>().single()
+                assertEquals(TerritoryId("brasilien"), placement.placements.single().territoryId)
+                assertEquals(2, placement.placements.single().amount)
+                waitUntil { controller.state.value.gameState.reinforcementState.pendingAmount == 0 }
+
+                cardIds.forEach(controller::toggleTradeInCard)
+                controller.tradeInCards()
+                waitUntil { seenPayloads.any { it is TradeInCardsRequest } }
+                assertEquals(
+                    cardIds.toSet(),
+                    seenPayloads.filterIsInstance<TradeInCardsRequest>().single().cardIds.toSet(),
+                )
+                waitUntil { controller.state.value.gameState.privateHandCards.isEmpty() }
+
+                controller.confirmReinforcementsDone()
+                waitUntil { seenPayloads.any { it is ConfirmReinforcementsDoneRequest } }
+                waitUntil {
+                    !controller.state.value.pendingCommandKeys.contains(
+                        LobbyCommandKey.CONFIRM_REINFORCEMENTS_DONE,
+                    )
+                }
             } finally {
                 controller.close()
                 server.close()

--- a/app/src/testDebug/kotlin/at/aau/pulverfass/app/ui/screens/ScreenComposableTest.kt
+++ b/app/src/testDebug/kotlin/at/aau/pulverfass/app/ui/screens/ScreenComposableTest.kt
@@ -4,14 +4,19 @@ import androidx.activity.ComponentActivity
 import androidx.compose.material3.Text
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performSemanticsAction
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -20,14 +25,22 @@ import androidx.navigation.navArgument
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import at.aau.pulverfass.app.game.GamePlayerUi
 import at.aau.pulverfass.app.game.GameUiState
+import at.aau.pulverfass.app.game.PrivateHandCardUi
+import at.aau.pulverfass.app.game.ReinforcementUiState
+import at.aau.pulverfass.app.lobby.LobbyCommandKey
 import at.aau.pulverfass.app.lobby.LobbyController
 import at.aau.pulverfass.app.ui.navigation.Screen
 import at.aau.pulverfass.app.ui.theme.AndroidAppTheme
+import at.aau.pulverfass.shared.ids.CardId
 import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.lobby.state.CardType
+import at.aau.pulverfass.shared.lobby.state.TurnPhase
 import kotlinx.coroutines.delay
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @RunWith(AndroidJUnit4::class)
 class ScreenComposableTest {
@@ -252,5 +265,213 @@ class ScreenComposableTest {
 
         composeTestRule.onAllNodesWithTag("game_cards_panel").assertCountEquals(0)
         composeTestRule.onAllNodesWithText("Geheime Karte").assertCountEquals(0)
+    }
+
+    @Test
+    fun reinforcement_panel_stays_hidden_until_an_owned_target_is_selected() {
+        val playerId = PlayerId(1)
+
+        composeTestRule.setContent {
+            AndroidAppTheme {
+                GameScreenContent(
+                    contentState =
+                        GameScreenContentState(
+                            players = emptyList(),
+                            localPlayerId = playerId,
+                            uiState =
+                                GameUiState(
+                                    activePlayerId = playerId,
+                                    turnPhase = TurnPhase.REINFORCEMENTS,
+                                    reinforcementState =
+                                        ReinforcementUiState(
+                                            playerId = playerId,
+                                            pendingAmount = 2,
+                                        ),
+                                ),
+                            isConnected = true,
+                            pendingCommandKeys = emptySet(),
+                            mapPainter = ColorPainter(Color.White),
+                        ),
+                    actions =
+                        GameScreenActions(
+                            onRegionSelected = {},
+                            onToggleCards = {},
+                            onAdvanceTurn = {},
+                            onRefreshGameState = {},
+                        ),
+                )
+            }
+        }
+
+        composeTestRule.onAllNodesWithTag("reinforcement_panel").assertCountEquals(0)
+        composeTestRule.onNodeWithTag("end_round_button").assertIsNotEnabled()
+    }
+
+    @Test
+    fun reinforcement_panel_places_troops_and_typed_hand_submits_trade_in() {
+        val playerId = PlayerId(1)
+        val cardIds = listOf(CardId("a"), CardId("b"), CardId("c"))
+        var placementDelta = 0
+        var placed = false
+        var traded = false
+        var closedRegion: String? = null
+
+        composeTestRule.setContent {
+            AndroidAppTheme {
+                GameScreenContent(
+                    contentState =
+                        GameScreenContentState(
+                            players =
+                                listOf(
+                                    GamePlayerUi(
+                                        playerId = playerId,
+                                        name = "Alice",
+                                        avatarText = "A",
+                                        color = Color(0xFF6FD4C5),
+                                    ),
+                                ),
+                            localPlayerId = playerId,
+                            uiState =
+                                GameUiState(
+                                    activePlayerId = playerId,
+                                    turnPhase = TurnPhase.REINFORCEMENTS,
+                                    selectedRegionId = "brazil",
+                                    cardsVisible = true,
+                                    reinforcementState =
+                                        ReinforcementUiState(
+                                            playerId = playerId,
+                                            pendingAmount = 2,
+                                            territoryBonus = 2,
+                                            isBonusBreakdownKnown = true,
+                                        ),
+                                    privateHandCards =
+                                        listOf(
+                                            PrivateHandCardUi(cardIds[0], CardType.A),
+                                            PrivateHandCardUi(cardIds[1], CardType.B),
+                                            PrivateHandCardUi(cardIds[2], CardType.C),
+                                        ),
+                                    selectedTradeInCardIds = cardIds.toSet(),
+                                ),
+                            isConnected = true,
+                            pendingCommandKeys = emptySet(),
+                            mapPainter = ColorPainter(Color.White),
+                        ),
+                    actions =
+                        GameScreenActions(
+                            onRegionSelected = { closedRegion = it },
+                            onToggleCards = {},
+                            onAdvanceTurn = {},
+                            onAdjustReinforcementPlacementAmount = { placementDelta = it },
+                            onPlaceReinforcements = { placed = true },
+                            onTradeInCards = { traded = true },
+                            onRefreshGameState = {},
+                        ),
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("reinforcement_panel").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("reinforcement_remaining").assertTextEquals("Verfügbar: 2")
+        composeTestRule.onNodeWithText("Gebiet 2 · Kontinent 0 · Karten 0").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("reinforcement_increase").performClick()
+        composeTestRule
+            .onNodeWithTag("place_reinforcements_button")
+            .assertIsEnabled()
+            .performClick()
+        composeTestRule.onNodeWithText("Infanterie").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("trade_in_cards_button").assertIsEnabled()
+            .performSemanticsAction(SemanticsActions.OnClick)
+        composeTestRule.onNodeWithTag("close_reinforcement_panel").performClick()
+
+        assertEquals(1, placementDelta)
+        assertTrue(placed)
+        assertTrue(traded)
+        assertEquals("brazil", closedRegion)
+    }
+
+    @Test
+    fun phase_end_button_confirms_reinforcements_after_pool_is_empty_without_panel() {
+        val playerId = PlayerId(1)
+        var finished = false
+
+        composeTestRule.setContent {
+            AndroidAppTheme {
+                GameScreenContent(
+                    contentState =
+                        GameScreenContentState(
+                            players = emptyList(),
+                            localPlayerId = playerId,
+                            uiState =
+                                GameUiState(
+                                    activePlayerId = playerId,
+                                    turnPhase = TurnPhase.REINFORCEMENTS,
+                                    selectedRegionId = "brazil",
+                                    reinforcementState =
+                                        ReinforcementUiState(
+                                            playerId = playerId,
+                                            pendingAmount = 0,
+                                        ),
+                                ),
+                            isConnected = true,
+                            pendingCommandKeys = emptySet(),
+                            mapPainter = ColorPainter(Color.White),
+                        ),
+                    actions =
+                        GameScreenActions(
+                            onRegionSelected = {},
+                            onToggleCards = {},
+                            onAdvanceTurn = {},
+                            onConfirmReinforcementsDone = { finished = true },
+                            onRefreshGameState = {},
+                        ),
+                )
+            }
+        }
+
+        composeTestRule.onAllNodesWithTag("reinforcement_panel").assertCountEquals(0)
+        composeTestRule.onNodeWithTag("end_round_button")
+            .assertIsEnabled()
+            .performClick()
+        assertTrue(finished)
+    }
+
+    @Test
+    fun reinforcement_panel_blocks_placement_while_trade_in_is_pending() {
+        val playerId = PlayerId(1)
+
+        composeTestRule.setContent {
+            AndroidAppTheme {
+                GameScreenContent(
+                    contentState =
+                        GameScreenContentState(
+                            players = emptyList(),
+                            localPlayerId = playerId,
+                            uiState =
+                                GameUiState(
+                                    activePlayerId = playerId,
+                                    turnPhase = TurnPhase.REINFORCEMENTS,
+                                    selectedRegionId = "brazil",
+                                    reinforcementState =
+                                        ReinforcementUiState(
+                                            playerId = playerId,
+                                            pendingAmount = 2,
+                                        ),
+                                ),
+                            isConnected = true,
+                            pendingCommandKeys = setOf(LobbyCommandKey.TRADE_IN_CARDS),
+                            mapPainter = ColorPainter(Color.White),
+                        ),
+                    actions =
+                        GameScreenActions(
+                            onRegionSelected = {},
+                            onToggleCards = {},
+                            onAdvanceTurn = {},
+                            onRefreshGameState = {},
+                        ),
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("place_reinforcements_button").assertIsNotEnabled()
     }
 }

--- a/app/src/testDebug/kotlin/at/aau/pulverfass/app/ui/screens/ScreenComposableTest.kt
+++ b/app/src/testDebug/kotlin/at/aau/pulverfass/app/ui/screens/ScreenComposableTest.kt
@@ -213,8 +213,11 @@ class ScreenComposableTest {
         composeTestRule.setContent {
             AndroidAppTheme {
                 PrivateHandPanel(
-                    playerName = "Alice",
-                    handCards = listOf("Infanterie", "Infanterie", "Kavallerie"),
+                    state =
+                        PrivateHandPanelState(
+                            playerName = "Alice",
+                            handCards = listOf("Infanterie", "Infanterie", "Kavallerie"),
+                        ),
                 )
             }
         }

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/GameStatePrivateGetResponse.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/GameStatePrivateGetResponse.kt
@@ -4,6 +4,7 @@ import at.aau.pulverfass.shared.ids.LobbyCode
 import at.aau.pulverfass.shared.ids.PlayerId
 import at.aau.pulverfass.shared.lobby.state.GameState
 import at.aau.pulverfass.shared.message.lobby.event.PrivateGameStatePayload
+import at.aau.pulverfass.shared.message.lobby.event.PrivateHandCardSnapshot
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.MissingFieldException
 import kotlinx.serialization.Serializable
@@ -27,6 +28,7 @@ import kotlinx.serialization.encoding.Encoder
  * @property stateVersion öffentliche State-Version, zu der dieser private Snapshot passt
  * @property handCards private Handkarten des Spielers
  * @property secretObjectives private Missions- oder Zielinformationen des Spielers
+ * @property privateHandCards typisierte Handkarten inklusive der für Trade-ins nötigen IDs
  */
 @Serializable(with = GameStatePrivateGetResponseSerializer::class)
 data class GameStatePrivateGetResponse(
@@ -35,6 +37,7 @@ data class GameStatePrivateGetResponse(
     val stateVersion: Long,
     val handCards: List<String> = emptyList(),
     val secretObjectives: List<String> = emptyList(),
+    val privateHandCards: List<PrivateHandCardSnapshot> = emptyList(),
 ) : PrivateGameStatePayload {
     companion object {
         fun fromGameState(
@@ -49,6 +52,7 @@ data class GameStatePrivateGetResponse(
  */
 object GameStatePrivateGetResponseSerializer : KSerializer<GameStatePrivateGetResponse> {
     private val stringListSerializer = ListSerializer(String.serializer())
+    private val privateHandCardsSerializer = ListSerializer(PrivateHandCardSnapshot.serializer())
 
     override val descriptor =
         buildClassSerialDescriptor(
@@ -59,6 +63,7 @@ object GameStatePrivateGetResponseSerializer : KSerializer<GameStatePrivateGetRe
             element<Long>("stateVersion")
             element("handCards", stringListSerializer.descriptor)
             element("secretObjectives", stringListSerializer.descriptor)
+            element("privateHandCards", privateHandCardsSerializer.descriptor, isOptional = true)
         }
 
     override fun serialize(
@@ -81,6 +86,12 @@ object GameStatePrivateGetResponseSerializer : KSerializer<GameStatePrivateGetRe
             stringListSerializer,
             value.secretObjectives,
         )
+        composite.encodeSerializableElement(
+            descriptor,
+            5,
+            privateHandCardsSerializer,
+            value.privateHandCards,
+        )
         composite.endStructure(descriptor)
     }
 
@@ -91,6 +102,7 @@ object GameStatePrivateGetResponseSerializer : KSerializer<GameStatePrivateGetRe
         var stateVersion: Long? = null
         var handCards: List<String>? = null
         var secretObjectives: List<String>? = null
+        var privateHandCards: List<PrivateHandCardSnapshot> = emptyList()
 
         loop@ while (true) {
             when (val index = composite.decodeElementIndex(descriptor)) {
@@ -115,6 +127,13 @@ object GameStatePrivateGetResponseSerializer : KSerializer<GameStatePrivateGetRe
                 4 ->
                     secretObjectives =
                         composite.decodeSerializableElement(descriptor, 4, stringListSerializer)
+                5 ->
+                    privateHandCards =
+                        composite.decodeSerializableElement(
+                            descriptor,
+                            5,
+                            privateHandCardsSerializer,
+                        )
                 CompositeDecoder.DECODE_DONE -> break@loop
                 else -> throw IllegalArgumentException("Unexpected index $index")
             }
@@ -137,6 +156,7 @@ object GameStatePrivateGetResponseSerializer : KSerializer<GameStatePrivateGetRe
             secretObjectives =
                 secretObjectives
                     ?: throw MissingFieldException("secretObjectives", descriptor.serialName),
+            privateHandCards = privateHandCards,
         )
     }
 }
@@ -154,5 +174,6 @@ internal fun GameState.toGameStatePrivateGetResponse(
         stateVersion = stateVersion,
         handCards = emptyList(),
         secretObjectives = emptyList(),
+        privateHandCards = handOf(recipientPlayerId).map(PrivateHandCardSnapshot::from),
     )
 }

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/GameStatePrivateGetMessageTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/GameStatePrivateGetMessageTest.kt
@@ -3,7 +3,10 @@ package at.aau.pulverfass.shared.network.message
 import at.aau.pulverfass.shared.ids.CardId
 import at.aau.pulverfass.shared.ids.LobbyCode
 import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.lobby.state.CardState
 import at.aau.pulverfass.shared.lobby.state.CardType
+import at.aau.pulverfass.shared.lobby.state.GameState
+import at.aau.pulverfass.shared.lobby.state.HandState
 import at.aau.pulverfass.shared.message.lobby.event.PrivateHandCardSnapshot
 import at.aau.pulverfass.shared.message.lobby.request.GameStatePrivateGetRequest
 import at.aau.pulverfass.shared.message.lobby.response.GameStatePrivateGetResponse
@@ -85,5 +88,28 @@ class GameStatePrivateGetMessageTest {
             )
 
         assertEquals(response, deserialized)
+    }
+
+    @Test
+    fun `response from game state exposes only recipient typed hand`() {
+        val recipient = PlayerId(2)
+        val card = CardState(CardId("card-private"), CardType.JOKER)
+        val gameState =
+            GameState(
+                lobbyCode = LobbyCode("GH56"),
+                players = listOf(recipient),
+                turnOrder = listOf(recipient),
+                stateVersion = 11,
+                handState = HandState(mapOf(recipient to listOf(card))),
+            )
+
+        val response = GameStatePrivateGetResponse.fromGameState(gameState, recipient)
+
+        assertEquals(recipient, response.recipientPlayerId)
+        assertEquals(11, response.stateVersion)
+        assertEquals(
+            listOf(PrivateHandCardSnapshot(card.cardId, card.type)),
+            response.privateHandCards,
+        )
     }
 }

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/GameStatePrivateGetMessageTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/GameStatePrivateGetMessageTest.kt
@@ -1,7 +1,10 @@
 package at.aau.pulverfass.shared.network.message
 
+import at.aau.pulverfass.shared.ids.CardId
 import at.aau.pulverfass.shared.ids.LobbyCode
 import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.lobby.state.CardType
+import at.aau.pulverfass.shared.message.lobby.event.PrivateHandCardSnapshot
 import at.aau.pulverfass.shared.message.lobby.request.GameStatePrivateGetRequest
 import at.aau.pulverfass.shared.message.lobby.response.GameStatePrivateGetResponse
 import at.aau.pulverfass.shared.message.lobby.response.error.GameStatePrivateGetErrorCode
@@ -42,6 +45,10 @@ class GameStatePrivateGetMessageTest {
                 stateVersion = 9,
                 handCards = listOf("infantry", "cavalry"),
                 secretObjectives = listOf("hold_europe"),
+                privateHandCards =
+                    listOf(
+                        PrivateHandCardSnapshot(CardId("card-a"), CardType.A),
+                    ),
             )
 
         val serialized = json.encodeToString(GameStatePrivateGetResponse.serializer(), response)
@@ -54,6 +61,7 @@ class GameStatePrivateGetMessageTest {
         assertTrue(serialized.contains("recipientPlayerId"))
         assertTrue(serialized.contains("stateVersion"))
         assertTrue(serialized.contains("handCards"))
+        assertTrue(serialized.contains("privateHandCards"))
         assertEquals(response, deserialized)
     }
 


### PR DESCRIPTION
## Summary
- connect the Android game screen to the server-authoritative reinforcement pool, placement requests, phase completion, and response/error handling
- render the private typed card hand and submit trade-in selections without exposing private state through public snapshots
- improve the phase-one interaction by opening placement controls only for owned territories and reusing the existing phase action when no troops remain
- keep the startup transition immersive and make the server status marker less intrusive
- refactor panel inputs and reinforcement response routing to satisfy new-code maintainability findings
- cover local validation, retryable server errors, retained reinforcement state and typed private hand projection

## Testing
- `./gradlew :shared:test :app:testDebugUnitTest :app:compileDebugAndroidTestKotlin :app:jacocoDebugUnitTestReport --stacktrace`
- `./gradlew ktlintFormat ktlintCheck :shared:test :app:testDebugUnitTest :app:compileDebugAndroidTestKotlin :app:jacocoDebugUnitTestReport :shared:jacocoTestReport --stacktrace`
- app line coverage after the Sonar follow-up tests: `87.42%`

## Issues
Closes #247
Closes #311
Closes #315
Closes #317

Partially addresses #316: typed card selection and trade-in requests are wired; highlighting only valid set combinations remains open.

For #311, invalid taps on foreign territories are intentionally ignored instead of displaying a banner. This follows the refined interaction decision that the placement UI only opens for owned territories.