### PR TITLE
Introduce attack rule constants and apply them

### DIFF
--- a/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
@@ -19,6 +19,7 @@ import at.aau.pulverfass.shared.lobby.command.FortifyMoveValidationError
 import at.aau.pulverfass.shared.lobby.command.FortifyMoveValidator
 import at.aau.pulverfass.shared.lobby.command.InvalidMapCommandException
 import at.aau.pulverfass.shared.lobby.command.MapCommandRuleService
+import at.aau.pulverfass.shared.lobby.command.MIN_ATTACK_COMMITTED_TROOPS
 import at.aau.pulverfass.shared.lobby.event.AttackResolvedEvent
 import at.aau.pulverfass.shared.lobby.event.CardSetTradedInEvent
 import at.aau.pulverfass.shared.lobby.event.LobbyEvent
@@ -1457,7 +1458,7 @@ class MainServerLobbyRoutingService(
         require(currentTurnState.activePlayerId == payload.playerId) { "NOT_ACTIVE_PLAYER" }
         check(!(currentTurnState.isPaused)) { "GAME_PAUSED" }
         require(currentTurnState.turnPhase == TurnPhase.ATTACK) { "PHASE_MISMATCH" }
-        require(payload.attackTroops >= 2) { "INVALID_REQUEST" }
+        require(payload.attackTroops >= MIN_ATTACK_COMMITTED_TROOPS) { "INVALID_REQUEST" }
         require(payload.moveAfterCapture > 0) { "INVALID_MOVE_AFTER_CAPTURE" }
         require(state.territoryStateOf(payload.fromTerritoryId) != null) { "INVALID_REQUEST" }
         require(state.territoryStateOf(payload.toTerritoryId) != null) { "INVALID_REQUEST" }

--- a/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
@@ -18,8 +18,8 @@ import at.aau.pulverfass.shared.lobby.command.FortifyMoveCommand
 import at.aau.pulverfass.shared.lobby.command.FortifyMoveValidationError
 import at.aau.pulverfass.shared.lobby.command.FortifyMoveValidator
 import at.aau.pulverfass.shared.lobby.command.InvalidMapCommandException
-import at.aau.pulverfass.shared.lobby.command.MapCommandRuleService
 import at.aau.pulverfass.shared.lobby.command.MIN_ATTACK_COMMITTED_TROOPS
+import at.aau.pulverfass.shared.lobby.command.MapCommandRuleService
 import at.aau.pulverfass.shared.lobby.event.AttackResolvedEvent
 import at.aau.pulverfass.shared.lobby.event.CardSetTradedInEvent
 import at.aau.pulverfass.shared.lobby.event.LobbyEvent

--- a/server/src/test/kotlin/at/aau/pulverfass/server/ApplicationTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/ApplicationTest.kt
@@ -1,5 +1,10 @@
 package at.aau.pulverfass.server
 
+import at.aau.pulverfass.server.persistence.DatabaseBackedLobbyPersistenceGateway
+import at.aau.pulverfass.server.persistence.FakeConnectionScript
+import at.aau.pulverfass.server.persistence.FakeJdbcDataSource
+import at.aau.pulverfass.server.persistence.FakePreparedStatementScript
+import at.aau.pulverfass.server.persistence.JdbcLobbyReconnectSessionStore
 import at.aau.pulverfass.server.persistence.LobbyPersistenceCallbacks
 import at.aau.pulverfass.server.session.SessionContextRegistry
 import at.aau.pulverfass.server.transport.ServerWebSocketTransport
@@ -35,6 +40,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -207,6 +213,26 @@ class ApplicationTest {
     }
 
     @Test
+    fun `configured readiness probe is postgres typed without connecting`() {
+        val probe =
+            createDatabaseReadinessProbe(
+                DatabaseRuntimeConfig(
+                    host = "127.0.0.1",
+                    port = 5432,
+                    name = "pulverfass",
+                    user = "postgres",
+                    password = "postgres",
+                ),
+            )
+
+        try {
+            assertInstanceOf(PostgresDatabaseReadinessProbe::class.java, probe)
+        } finally {
+            probe.close()
+        }
+    }
+
+    @Test
     fun `createDatabaseReadinessProbe returns postgres probe when database is configured`() {
         val config = requireExternalTestDatabaseConfig()
         val probe = createDatabaseReadinessProbe(config)
@@ -231,6 +257,29 @@ class ApplicationTest {
                 callbacks.readiness(),
             )
         }
+
+    @Test
+    fun `configured persistence callbacks are database backed without connecting`() {
+        val callbacks =
+            createLobbyPersistenceCallbacks(
+                DatabaseRuntimeConfig(
+                    host = "127.0.0.1",
+                    port = 5432,
+                    name = "pulverfass",
+                    user = "postgres",
+                    password = "postgres",
+                ),
+            )
+
+        try {
+            assertInstanceOf(
+                DatabaseBackedLobbyPersistenceGateway::class.java,
+                callbacks,
+            )
+        } finally {
+            callbacks.close()
+        }
+    }
 
     @Test
     fun `createLobbyPersistenceCallbacks returns active callbacks when database is configured`() {
@@ -313,6 +362,47 @@ class ApplicationTest {
     }
 
     @Test
+    fun `persistReconnectSessionIfPossible upserts session for player context`() {
+        val delete =
+            FakePreparedStatementScript(
+                expectedSqlFragment = "DELETE FROM lobby_reconnect_sessions",
+                updateCount = 1,
+            )
+        val insert =
+            FakePreparedStatementScript(
+                expectedSqlFragment = "INSERT INTO lobby_reconnect_sessions",
+                updateCount = 1,
+            )
+        val connection = FakeConnectionScript(listOf(delete, insert))
+        val store =
+            JdbcLobbyReconnectSessionStore(
+                FakeJdbcDataSource(listOf(connection)),
+            )
+        val network = ServerNetwork()
+        val sessionToken = SessionToken("123e4567-e89b-12d3-a456-426614174603")
+        val sessionContextRegistry = SessionContextRegistry()
+
+        network.sessionManager.restoreDetachedSession(
+            sessionToken = sessionToken,
+            expiresAtEpochMillis = System.currentTimeMillis() + 60_000,
+        )
+        sessionContextRegistry.assignPlayer(sessionToken, PlayerId(21))
+        sessionContextRegistry.updateLobbyContext(sessionToken, LobbyCode("AB12"), "Alice")
+
+        persistReconnectSessionIfPossible(
+            network = network,
+            sessionStore = store,
+            sessionContextRegistry = sessionContextRegistry,
+            sessionToken = sessionToken,
+        )
+
+        assertTrue(connection.committed)
+        assertEquals(21L, delete.lastParameters[1])
+        assertEquals("AB12", insert.lastParameters[3])
+        assertEquals("Alice", insert.lastParameters[4])
+    }
+
+    @Test
     fun `module exposes health endpoint`() =
         testApplication {
             application {
@@ -338,6 +428,19 @@ class ApplicationTest {
 
             assertEquals(HttpStatusCode.OK, response.status)
             assertEquals("v1.2.3", response.bodyAsText())
+        }
+
+    @Test
+    fun `transport only module still exposes standard http endpoints`() =
+        testApplication {
+            application {
+                module(ServerWebSocketTransport())
+            }
+
+            val response = client.get("/health")
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals("OK", response.bodyAsText())
         }
 
     @Test

--- a/server/src/test/kotlin/at/aau/pulverfass/server/DatabaseSchemaMigrationTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/DatabaseSchemaMigrationTest.kt
@@ -5,6 +5,11 @@ import org.junit.jupiter.api.Test
 
 class DatabaseSchemaMigrationTest {
     @Test
+    fun `migrateDatabaseSchema returns early when database config is disabled`() {
+        migrateDatabaseSchema(DatabaseRuntimeConfig())
+    }
+
+    @Test
     fun `redactJdbcUrl masks authority credentials`() {
         val jdbcUrl = "jdbc:postgresql://pulverfass:secret@db.internal:5432/pulverfass"
 

--- a/server/src/test/kotlin/at/aau/pulverfass/server/persistence/FakeJdbc.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/persistence/FakeJdbc.kt
@@ -1,0 +1,196 @@
+package at.aau.pulverfass.server.persistence
+
+import java.io.PrintWriter
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Proxy
+import java.sql.Connection
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+import java.sql.SQLFeatureNotSupportedException
+import java.sql.Timestamp
+import java.util.ArrayDeque
+import java.util.logging.Logger
+import javax.sql.DataSource
+
+class FakeJdbcDataSource(
+    connectionScripts: List<FakeConnectionScript>,
+) : DataSource {
+    private val remainingScripts = ArrayDeque(connectionScripts)
+    var openedConnections: Int = 0
+        private set
+
+    override fun getConnection(): Connection {
+        openedConnections += 1
+        val script =
+            remainingScripts.removeFirstIfPresent()
+                ?: error("Keine Connection mehr konfiguriert.")
+        return script.asConnection()
+    }
+
+    override fun getConnection(
+        username: String?,
+        password: String?,
+    ): Connection = getConnection()
+
+    override fun getLogWriter(): PrintWriter? = null
+
+    override fun setLogWriter(out: PrintWriter?) = Unit
+
+    override fun setLoginTimeout(seconds: Int) = Unit
+
+    override fun getLoginTimeout(): Int = 0
+
+    override fun getParentLogger(): Logger = throw SQLFeatureNotSupportedException()
+
+    override fun <T : Any?> unwrap(iface: Class<T>?): T = throw SQLFeatureNotSupportedException()
+
+    override fun isWrapperFor(iface: Class<*>?): Boolean = false
+}
+
+class FakeConnectionScript(
+    statements: List<FakePreparedStatementScript>,
+) {
+    private val remainingStatements = ArrayDeque(statements)
+
+    var autoCommit: Boolean = true
+    var committed: Boolean = false
+    var rolledBack: Boolean = false
+    var closed: Boolean = false
+    val preparedSql = mutableListOf<String>()
+
+    fun asConnection(): Connection =
+        proxy(Connection::class.java) { method, args ->
+            when (method.name) {
+                "prepareStatement" -> {
+                    val sql = args[0] as String
+                    preparedSql += sql
+                    val script =
+                        remainingStatements.removeFirstIfPresent()
+                            ?: error("Unerwartetes prepareStatement ohne Script für SQL: $sql")
+                    script.assertSql(sql)
+                    script.asPreparedStatement()
+                }
+                "getAutoCommit" -> autoCommit
+                "setAutoCommit" -> {
+                    autoCommit = args[0] as Boolean
+                    Unit
+                }
+                "commit" -> {
+                    committed = true
+                    Unit
+                }
+                "rollback" -> {
+                    rolledBack = true
+                    Unit
+                }
+                "close" -> {
+                    closed = true
+                    Unit
+                }
+                "isClosed" -> closed
+                "toString" -> "FakeConnection"
+                else -> unsupported(method.name)
+            }
+        }
+}
+
+class FakePreparedStatementScript(
+    private val expectedSqlFragment: String,
+    private val rows: List<Map<Any, Any?>> = emptyList(),
+    private val updateCount: Int = 0,
+    private val onExecuteUpdate: ((Map<Int, Any?>) -> Int)? = null,
+    private val failure: Exception? = null,
+) {
+    var executed: Boolean = false
+        private set
+    var closed: Boolean = false
+        private set
+    var lastParameters: Map<Int, Any?> = emptyMap()
+        private set
+
+    fun assertSql(sql: String) {
+        val normalizedSql = sql.normalizeWhitespace()
+        val normalizedExpected = expectedSqlFragment.normalizeWhitespace()
+        check(normalizedSql.contains(normalizedExpected)) {
+            "Erwartete SQL mit Fragment '$expectedSqlFragment', war aber '$sql'."
+        }
+    }
+
+    fun asPreparedStatement(): PreparedStatement {
+        val parameters = linkedMapOf<Int, Any?>()
+
+        return proxy(PreparedStatement::class.java) { method, args ->
+            when (method.name) {
+                "setString", "setLong", "setInt", "setTimestamp", "setObject" -> {
+                    parameters[args[0] as Int] = args[1]
+                    Unit
+                }
+                "executeQuery" -> {
+                    executed = true
+                    lastParameters = parameters.toMap()
+                    failure?.let { throw it }
+                    FakeResultSetScript(rows).asResultSet()
+                }
+                "executeUpdate" -> {
+                    executed = true
+                    lastParameters = parameters.toMap()
+                    failure?.let { throw it }
+                    onExecuteUpdate?.invoke(lastParameters) ?: updateCount
+                }
+                "close" -> {
+                    closed = true
+                    Unit
+                }
+                "toString" -> "FakePreparedStatement"
+                else -> unsupported(method.name)
+            }
+        }
+    }
+}
+
+private class FakeResultSetScript(
+    private val rows: List<Map<Any, Any?>>,
+) {
+    private var index = -1
+
+    fun asResultSet(): ResultSet =
+        proxy(ResultSet::class.java) { method, args ->
+            when (method.name) {
+                "next" -> {
+                    index += 1
+                    index < rows.size
+                }
+                "getString" -> currentRow().getColumn(args[0]) as String?
+                "getLong" -> (currentRow().getColumn(args[0]) as Number).toLong()
+                "getInt" -> (currentRow().getColumn(args[0]) as Number).toInt()
+                "getTimestamp" -> currentRow().getColumn(args[0]) as Timestamp?
+                "close" -> Unit
+                "toString" -> "FakeResultSet"
+                else -> unsupported(method.name)
+            }
+        }
+
+    private fun currentRow(): Map<Any, Any?> =
+        rows.getOrNull(index) ?: error("ResultSet steht auf keiner gültigen Zeile.")
+
+    private fun Map<Any, Any?>.getColumn(key: Any?): Any? = this[key] ?: this[key.toString()]
+}
+
+private fun String.normalizeWhitespace(): String = trim().replace(Regex("\\s+"), " ")
+
+private fun <T> ArrayDeque<T>.removeFirstIfPresent(): T? = if (isEmpty()) null else removeFirst()
+
+private fun unsupported(methodName: String): Nothing =
+    throw UnsupportedOperationException("Nicht unterstützter JDBC-Testaufruf: $methodName")
+
+private fun <T> proxy(
+    type: Class<T>,
+    block: (method: java.lang.reflect.Method, args: Array<out Any?>) -> Any?,
+): T =
+    type.cast(
+        Proxy.newProxyInstance(
+            type.classLoader,
+            arrayOf(type),
+            InvocationHandler { _, method, args -> block(method, args ?: emptyArray()) },
+        ),
+    )

--- a/server/src/test/kotlin/at/aau/pulverfass/server/persistence/JdbcLobbyPersistenceStoreTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/persistence/JdbcLobbyPersistenceStoreTest.kt
@@ -1,0 +1,335 @@
+package at.aau.pulverfass.server.persistence
+
+import at.aau.pulverfass.shared.ids.LobbyCode
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.postgresql.util.PGobject
+import java.sql.Timestamp
+import java.time.Instant
+
+class JdbcLobbyPersistenceStoreTest {
+    @Test
+    fun `retention policy validates bounds and clamps minimum round`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            LobbyPersistenceRetentionPolicy(eventRoundsToKeep = 0)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            LobbyPersistenceRetentionPolicy(snapshotsToKeep = 0)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            LobbyPersistenceRetentionPolicy().minimumRoundToKeep(-1)
+        }
+
+        val policy = LobbyPersistenceRetentionPolicy(eventRoundsToKeep = 3)
+
+        assertEquals(0, policy.minimumRoundToKeep(1))
+        assertEquals(3, policy.minimumRoundToKeep(5))
+    }
+
+    @Test
+    fun `appendEvent validates arguments before opening a connection`() {
+        val dataSource = FakeJdbcDataSource(emptyList())
+        val store = JdbcLobbyPersistenceStore(dataSource)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            store.appendEvent(LobbyCode("AB12"), -1, 0, "event", jsonPayload("x"))
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            store.appendEvent(LobbyCode("AB12"), 1, -1, "event", jsonPayload("x"))
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            store.appendEvent(LobbyCode("AB12"), 1, 0, " ", jsonPayload("x"))
+        }
+
+        assertEquals(0, dataSource.openedConnections)
+    }
+
+    @Test
+    fun `appendEvent inserts jsonb payload cleans old rounds and commits`() {
+        val insert =
+            FakePreparedStatementScript(
+                expectedSqlFragment = "INSERT INTO lobby_events",
+                updateCount = 1,
+            )
+        val cleanup =
+            FakePreparedStatementScript(
+                expectedSqlFragment = "DELETE FROM lobby_events",
+                updateCount = 2,
+            )
+        val connection = FakeConnectionScript(listOf(insert, cleanup))
+        val store =
+            JdbcLobbyPersistenceStore(
+                dataSource = FakeJdbcDataSource(listOf(connection)),
+                retentionPolicy = LobbyPersistenceRetentionPolicy(eventRoundsToKeep = 2),
+            )
+
+        store.appendEvent(
+            lobbyCode = LobbyCode("AB12"),
+            stateVersion = 4,
+            turnCount = 3,
+            eventType = "turn_state_updated",
+            eventJson = jsonPayload("payload"),
+        )
+
+        assertTrue(connection.committed)
+        assertEquals("AB12", insert.lastParameters[1])
+        assertEquals(4L, insert.lastParameters[2])
+        assertEquals(3, insert.lastParameters[3])
+        assertEquals("turn_state_updated", insert.lastParameters[4])
+        val jsonb = assertInstanceOf(PGobject::class.java, insert.lastParameters[5])
+        assertEquals("jsonb", jsonb.type)
+        assertEquals("""{"value":"payload"}""", jsonb.value)
+        assertEquals("AB12", cleanup.lastParameters[1])
+        assertEquals(2, cleanup.lastParameters[2])
+    }
+
+    @Test
+    fun `appendSnapshot inserts jsonb payload cleans stale snapshots and commits`() {
+        val insert =
+            FakePreparedStatementScript(
+                expectedSqlFragment = "INSERT INTO lobby_snapshots",
+                updateCount = 1,
+            )
+        val cleanup =
+            FakePreparedStatementScript(
+                expectedSqlFragment = "DELETE FROM lobby_snapshots",
+                updateCount = 1,
+            )
+        val connection = FakeConnectionScript(listOf(insert, cleanup))
+        val store =
+            JdbcLobbyPersistenceStore(
+                dataSource = FakeJdbcDataSource(listOf(connection)),
+                retentionPolicy = LobbyPersistenceRetentionPolicy(snapshotsToKeep = 4),
+            )
+
+        store.appendSnapshot(
+            lobbyCode = LobbyCode("CD34"),
+            stateVersion = 8,
+            turnCount = 5,
+            snapshotJson = jsonPayload("snapshot"),
+        )
+
+        assertTrue(connection.committed)
+        assertEquals("CD34", insert.lastParameters[1])
+        assertEquals(8L, insert.lastParameters[2])
+        assertEquals(5, insert.lastParameters[3])
+        val jsonb = assertInstanceOf(PGobject::class.java, insert.lastParameters[4])
+        assertEquals("""{"value":"snapshot"}""", jsonb.value)
+        assertEquals("CD34", cleanup.lastParameters[1])
+        assertEquals("CD34", cleanup.lastParameters[2])
+        assertEquals(4, cleanup.lastParameters[3])
+    }
+
+    @Test
+    fun `cleanup methods delegate delete counts through a transaction`() {
+        val cleanupEvents =
+            FakePreparedStatementScript(
+                expectedSqlFragment = "DELETE FROM lobby_events",
+                updateCount = 3,
+            )
+        val cleanupSnapshots =
+            FakePreparedStatementScript(
+                expectedSqlFragment = "DELETE FROM lobby_snapshots",
+                updateCount = 2,
+            )
+        val store =
+            JdbcLobbyPersistenceStore(
+                dataSource =
+                    FakeJdbcDataSource(
+                        listOf(
+                            FakeConnectionScript(listOf(cleanupEvents)),
+                            FakeConnectionScript(listOf(cleanupSnapshots)),
+                        ),
+                    ),
+            )
+
+        assertEquals(3, store.cleanupEventsForLobby(LobbyCode("EF56"), currentRound = 0))
+        assertEquals("EF56", cleanupEvents.lastParameters[1])
+        assertEquals(0, cleanupEvents.lastParameters[2])
+        assertEquals(2, store.cleanupSnapshotsForLobby(LobbyCode("EF56")))
+        assertEquals("EF56", cleanupSnapshots.lastParameters[1])
+        assertEquals("EF56", cleanupSnapshots.lastParameters[2])
+    }
+
+    @Test
+    fun `list methods map persisted rows into records`() {
+        val createdAt = Timestamp.from(Instant.parse("2026-01-01T00:00:00Z"))
+        val eventsQuery =
+            FakePreparedStatementScript(
+                expectedSqlFragment = "FROM lobby_events WHERE lobby_code = ?",
+                rows =
+                    listOf(
+                        mapOf(
+                            "id" to 1L,
+                            "lobby_code" to "AB12",
+                            "state_version" to 3L,
+                            "turn_count" to 2,
+                            "event_type" to "turn_state_updated",
+                            "event_json" to """{"value":"event"}""",
+                            "created_at" to createdAt,
+                        ),
+                    ),
+            )
+        val snapshotsQuery =
+            FakePreparedStatementScript(
+                expectedSqlFragment = "FROM lobby_snapshots WHERE lobby_code = ?",
+                rows =
+                    listOf(
+                        mapOf(
+                            "id" to 4L,
+                            "lobby_code" to "AB12",
+                            "state_version" to 5L,
+                            "turn_count" to 3,
+                            "snapshot_json" to """{"value":"snapshot"}""",
+                            "created_at" to createdAt,
+                        ),
+                    ),
+            )
+        val store =
+            JdbcLobbyPersistenceStore(
+                FakeJdbcDataSource(
+                    listOf(
+                        FakeConnectionScript(listOf(eventsQuery)),
+                        FakeConnectionScript(listOf(snapshotsQuery)),
+                    ),
+                ),
+            )
+
+        assertEquals(
+            listOf(
+                PersistedLobbyEventRecord(
+                    id = 1L,
+                    lobbyCode = LobbyCode("AB12"),
+                    stateVersion = 3L,
+                    turnCount = 2,
+                    eventType = "turn_state_updated",
+                    eventJson = """{"value":"event"}""",
+                    createdAt = createdAt.toInstant(),
+                ),
+            ),
+            store.listEvents(LobbyCode("AB12")),
+        )
+        assertEquals(
+            listOf(
+                PersistedLobbySnapshotRecord(
+                    id = 4L,
+                    lobbyCode = LobbyCode("AB12"),
+                    stateVersion = 5L,
+                    turnCount = 3,
+                    snapshotJson = """{"value":"snapshot"}""",
+                    createdAt = createdAt.toInstant(),
+                ),
+            ),
+            store.listSnapshots(LobbyCode("AB12")),
+        )
+    }
+
+    @Test
+    fun `load helpers and delete lobby state map records and union lobby codes`() {
+        val createdAt = Timestamp.from(Instant.parse("2026-01-02T00:00:00Z"))
+        val latestSnapshot =
+            FakePreparedStatementScript(
+                expectedSqlFragment = "FROM lobby_snapshots WHERE lobby_code = ?",
+                rows =
+                    listOf(
+                        mapOf(
+                            "id" to 6L,
+                            "lobby_code" to "GH78",
+                            "state_version" to 9L,
+                            "turn_count" to 4,
+                            "snapshot_json" to """{"value":"latest"}""",
+                            "created_at" to createdAt,
+                        ),
+                    ),
+            )
+        val eventsAfter =
+            FakePreparedStatementScript(
+                expectedSqlFragment =
+                    "FROM lobby_events WHERE lobby_code = ? AND state_version > ?",
+                rows =
+                    listOf(
+                        mapOf(
+                            "id" to 7L,
+                            "lobby_code" to "GH78",
+                            "state_version" to 10L,
+                            "turn_count" to 5,
+                            "event_type" to "player_joined",
+                            "event_json" to """{"value":"delta"}""",
+                            "created_at" to createdAt,
+                        ),
+                    ),
+            )
+        val lobbyCodes =
+            FakePreparedStatementScript(
+                expectedSqlFragment =
+                    "SELECT lobby_code FROM lobby_events UNION SELECT lobby_code " +
+                        "FROM lobby_snapshots",
+                rows =
+                    listOf(
+                        mapOf("lobby_code" to "GH78"),
+                        mapOf("lobby_code" to "IJ90"),
+                    ),
+            )
+        val deleteEvents =
+            FakePreparedStatementScript(
+                expectedSqlFragment = "DELETE FROM lobby_events",
+                updateCount = 1,
+            )
+        val deleteSnapshots =
+            FakePreparedStatementScript(
+                expectedSqlFragment = "DELETE FROM lobby_snapshots",
+                updateCount = 1,
+            )
+        val store =
+            JdbcLobbyPersistenceStore(
+                FakeJdbcDataSource(
+                    listOf(
+                        FakeConnectionScript(listOf(latestSnapshot)),
+                        FakeConnectionScript(listOf(eventsAfter)),
+                        FakeConnectionScript(listOf(lobbyCodes)),
+                        FakeConnectionScript(listOf(deleteEvents, deleteSnapshots)),
+                    ),
+                ),
+            )
+
+        assertEquals(9L, store.loadLatestSnapshot(LobbyCode("GH78"))?.stateVersion)
+        assertEquals(
+            listOf(10L),
+            store.loadEventsAfter(LobbyCode("GH78"), 9L).map { it.stateVersion },
+        )
+        assertEquals(
+            setOf(LobbyCode("GH78"), LobbyCode("IJ90")),
+            store.findLobbyCodesWithPersistedState(),
+        )
+
+        store.deleteLobbyState(LobbyCode("GH78"))
+
+        assertEquals("GH78", deleteEvents.lastParameters[1])
+        assertEquals("GH78", deleteSnapshots.lastParameters[1])
+    }
+
+    @Test
+    fun `loadLatestSnapshot returns null when no snapshot exists`() {
+        val latestSnapshot =
+            FakePreparedStatementScript(
+                expectedSqlFragment = "FROM lobby_snapshots WHERE lobby_code = ?",
+                rows = emptyList(),
+            )
+        val store =
+            JdbcLobbyPersistenceStore(
+                FakeJdbcDataSource(listOf(FakeConnectionScript(listOf(latestSnapshot)))),
+            )
+
+        assertEquals(null, store.loadLatestSnapshot(LobbyCode("ZZ99")))
+    }
+
+    private fun jsonPayload(value: String) =
+        buildJsonObject {
+            put("value", value)
+        }
+}

--- a/server/src/test/kotlin/at/aau/pulverfass/server/persistence/JdbcLobbyReconnectSessionStoreTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/persistence/JdbcLobbyReconnectSessionStoreTest.kt
@@ -1,0 +1,258 @@
+package at.aau.pulverfass.server.persistence
+
+import at.aau.pulverfass.server.session.Session
+import at.aau.pulverfass.server.session.SessionReconnectContext
+import at.aau.pulverfass.shared.ids.ConnectionId
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.ids.SessionToken
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.security.MessageDigest
+import java.sql.SQLException
+import java.sql.Timestamp
+import java.time.Instant
+
+class JdbcLobbyReconnectSessionStoreTest {
+    @Test
+    fun `loadSession returns null when token is not persisted`() {
+        val query =
+            FakePreparedStatementScript(
+                expectedSqlFragment = "FROM lobby_reconnect_sessions WHERE session_token_hash = ?",
+                rows = emptyList(),
+            )
+        val dataSource = FakeJdbcDataSource(listOf(FakeConnectionScript(listOf(query))))
+        val store = JdbcLobbyReconnectSessionStore(dataSource)
+        val sessionToken = SessionToken("123e4567-e89b-12d3-a456-426614174900")
+
+        val loaded = store.loadSession(sessionToken)
+
+        assertNull(loaded)
+        assertEquals(sessionToken.storageHashForTest(), query.lastParameters[1])
+    }
+
+    @Test
+    fun `loadSession maps nullable lobby and revoked timestamp fields`() {
+        val expiresAt = Timestamp.from(Instant.parse("2026-01-01T00:00:00Z"))
+        val query =
+            FakePreparedStatementScript(
+                expectedSqlFragment = "FROM lobby_reconnect_sessions WHERE session_token_hash = ?",
+                rows =
+                    listOf(
+                        mapOf(
+                            "player_id" to 41L,
+                            "lobby_code" to " ",
+                            "player_display_name" to "Alice",
+                            "expires_at" to expiresAt,
+                            "revoked_at" to null,
+                        ),
+                    ),
+            )
+        val store =
+            JdbcLobbyReconnectSessionStore(
+                FakeJdbcDataSource(listOf(FakeConnectionScript(listOf(query)))),
+            )
+
+        val loaded = store.loadSession(SessionToken("123e4567-e89b-12d3-a456-426614174901"))
+
+        assertEquals(
+            SessionReconnectContext(
+                playerId = PlayerId(41),
+                lobbyCode = null,
+                playerDisplayName = "Alice",
+            ),
+            loaded?.context,
+        )
+        assertEquals(expiresAt.toInstant().toEpochMilli(), loaded?.expiresAtEpochMillis)
+        assertNull(loaded?.revokedAtEpochMillis)
+    }
+
+    @Test
+    fun `loadContext delegates to loadSession context projection`() {
+        val query =
+            FakePreparedStatementScript(
+                expectedSqlFragment = "FROM lobby_reconnect_sessions WHERE session_token_hash = ?",
+                rows =
+                    listOf(
+                        mapOf(
+                            "player_id" to 7L,
+                            "lobby_code" to "AB12",
+                            "player_display_name" to "Bob",
+                            "expires_at" to Timestamp.from(Instant.parse("2026-01-01T00:00:00Z")),
+                            "revoked_at" to Timestamp.from(Instant.parse("2026-01-01T00:01:00Z")),
+                        ),
+                    ),
+            )
+        val store =
+            JdbcLobbyReconnectSessionStore(
+                FakeJdbcDataSource(listOf(FakeConnectionScript(listOf(query)))),
+            )
+
+        val context = store.loadContext(SessionToken("123e4567-e89b-12d3-a456-426614174902"))
+
+        assertEquals(
+            SessionReconnectContext(
+                playerId = PlayerId(7),
+                lobbyCode = LobbyCode("AB12"),
+                playerDisplayName = "Bob",
+            ),
+            context,
+        )
+    }
+
+    @Test
+    fun `upsertSession deletes prior tokens inserts current session and commits`() {
+        val delete =
+            FakePreparedStatementScript(
+                expectedSqlFragment = "DELETE FROM lobby_reconnect_sessions",
+                updateCount = 1,
+            )
+        val insert =
+            FakePreparedStatementScript(
+                expectedSqlFragment = "INSERT INTO lobby_reconnect_sessions",
+                updateCount = 1,
+            )
+        val connection = FakeConnectionScript(listOf(delete, insert))
+        val store = JdbcLobbyReconnectSessionStore(FakeJdbcDataSource(listOf(connection)))
+        val sessionToken = SessionToken("123e4567-e89b-12d3-a456-426614174903")
+        val session =
+            Session(
+                sessionToken = sessionToken,
+                connectionId = ConnectionId(4),
+                expiresAtEpochMillis = 1_700_000_000_000,
+            )
+        val context =
+            SessionReconnectContext(
+                playerId = PlayerId(11),
+                lobbyCode = LobbyCode("AB12"),
+                playerDisplayName = "Alice",
+            )
+
+        store.upsertSession(session, context)
+
+        assertTrue(connection.committed)
+        assertTrue(!connection.rolledBack)
+        assertTrue(connection.autoCommit)
+        assertEquals(11L, delete.lastParameters[1])
+        assertEquals(sessionToken.storageHashForTest(), delete.lastParameters[2])
+        assertEquals(sessionToken.storageHashForTest(), insert.lastParameters[1])
+        assertEquals(11L, insert.lastParameters[2])
+        assertEquals("AB12", insert.lastParameters[3])
+        assertEquals("Alice", insert.lastParameters[4])
+        assertEquals(
+            Timestamp.from(Instant.ofEpochMilli(1_700_000_000_000)),
+            insert.lastParameters[5],
+        )
+        assertNull(insert.lastParameters[6])
+    }
+
+    @Test
+    fun `upsertSession rolls back transaction and restores autoCommit on statement failure`() {
+        val delete =
+            FakePreparedStatementScript(
+                expectedSqlFragment = "DELETE FROM lobby_reconnect_sessions",
+                updateCount = 1,
+            )
+        val insert =
+            FakePreparedStatementScript(
+                expectedSqlFragment = "INSERT INTO lobby_reconnect_sessions",
+                failure = SQLException("boom"),
+            )
+        val connection = FakeConnectionScript(listOf(delete, insert))
+        val store = JdbcLobbyReconnectSessionStore(FakeJdbcDataSource(listOf(connection)))
+
+        val exception =
+            assertThrows(SQLException::class.java) {
+                store.upsertSession(
+                    session =
+                        Session(
+                            sessionToken = SessionToken("123e4567-e89b-12d3-a456-426614174904"),
+                            connectionId = ConnectionId(5),
+                            expiresAtEpochMillis = 1_700_000_000_100,
+                        ),
+                    context =
+                        SessionReconnectContext(
+                            playerId = PlayerId(12),
+                            lobbyCode = LobbyCode("CD34"),
+                            playerDisplayName = "Carol",
+                        ),
+                )
+            }
+
+        assertEquals("boom", exception.message)
+        assertTrue(connection.rolledBack)
+        assertTrue(!connection.committed)
+        assertTrue(connection.autoCommit)
+    }
+
+    @Test
+    fun `upsertSession rejects missing player id before opening a database connection`() {
+        val dataSource = FakeJdbcDataSource(emptyList())
+        val store = JdbcLobbyReconnectSessionStore(dataSource)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            store.upsertSession(
+                session =
+                    Session(
+                        sessionToken = SessionToken("123e4567-e89b-12d3-a456-426614174905"),
+                        connectionId = ConnectionId(6),
+                        expiresAtEpochMillis = 1_700_000_000_200,
+                    ),
+                context =
+                    SessionReconnectContext(
+                        playerId = null,
+                        lobbyCode = LobbyCode("EF56"),
+                        playerDisplayName = "Dora",
+                    ),
+            )
+        }
+
+        assertEquals(0, dataSource.openedConnections)
+    }
+
+    @Test
+    fun `clear delete and max lookup delegate to sql statements`() {
+        val clear =
+            FakePreparedStatementScript(
+                expectedSqlFragment = "UPDATE lobby_reconnect_sessions",
+                updateCount = 2,
+            )
+        val delete =
+            FakePreparedStatementScript(
+                expectedSqlFragment = "DELETE FROM lobby_reconnect_sessions",
+                updateCount = 1,
+            )
+        val maxQuery =
+            FakePreparedStatementScript(
+                expectedSqlFragment = "SELECT COALESCE(MAX(player_id), 0)",
+                rows = listOf(mapOf(1 to 17L)),
+            )
+        val store =
+            JdbcLobbyReconnectSessionStore(
+                FakeJdbcDataSource(
+                    listOf(
+                        FakeConnectionScript(listOf(clear)),
+                        FakeConnectionScript(listOf(delete)),
+                        FakeConnectionScript(listOf(maxQuery)),
+                    ),
+                ),
+            )
+
+        assertEquals(2, store.clearLobbyContextForLobby(LobbyCode("GH78")))
+        assertEquals("GH78", clear.lastParameters[1])
+        assertEquals(1, store.deleteSession(SessionToken("123e4567-e89b-12d3-a456-426614174906")))
+        assertEquals(
+            SessionToken("123e4567-e89b-12d3-a456-426614174906").storageHashForTest(),
+            delete.lastParameters[1],
+        )
+        assertEquals(17L, store.maxPersistedPlayerId())
+    }
+
+    private fun SessionToken.storageHashForTest(): String =
+        MessageDigest.getInstance("SHA-256")
+            .digest(value.toByteArray(Charsets.UTF_8))
+            .joinToString(separator = "") { byte -> "%02x".format(byte) }
+}

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/command/AttackRules.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/command/AttackRules.kt
@@ -1,0 +1,4 @@
+package at.aau.pulverfass.shared.lobby.command
+
+const val MIN_ATTACK_COMMITTED_TROOPS = 2
+const val MIN_SOURCE_TROOPS_FOR_ATTACK = MIN_ATTACK_COMMITTED_TROOPS + 1

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/command/DefaultMapCommandRuleService.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/command/DefaultMapCommandRuleService.kt
@@ -192,9 +192,10 @@ class DefaultMapCommandRuleService(
         command: AttackCommand,
     ): Int {
         val sourceTroops = state.troopCountOf(command.fromTerritoryId)
-        if (sourceTroops < 2) {
+        if (sourceTroops < MIN_SOURCE_TROOPS_FOR_ATTACK) {
             throw InvalidMapCommandException(
-                "Attack von '${command.fromTerritoryId.value}' benötigt mindestens 2 Truppen, " +
+                "Attack von '${command.fromTerritoryId.value}' benötigt mindestens " +
+                    "$MIN_SOURCE_TROOPS_FOR_ATTACK Truppen, " +
                     "vorhanden sind $sourceTroops.",
             )
         }
@@ -210,9 +211,10 @@ class DefaultMapCommandRuleService(
                 ?: throw InvalidMapCommandException(
                     "Attack benötigt committedTroopCount für ein replayfaehiges Ergebnis-Event.",
                 )
-        if (committedTroopCount < 2) {
+        if (committedTroopCount < MIN_ATTACK_COMMITTED_TROOPS) {
             throw InvalidMapCommandException(
-                "AttackCommand.committedTroopCount muss mindestens 2 sein, war aber " +
+                "AttackCommand.committedTroopCount muss mindestens " +
+                    "$MIN_ATTACK_COMMITTED_TROOPS sein, war aber " +
                     "$committedTroopCount.",
             )
         }

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/event/AttackResolvedEvent.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/event/AttackResolvedEvent.kt
@@ -3,6 +3,8 @@ package at.aau.pulverfass.shared.lobby.event
 import at.aau.pulverfass.shared.ids.LobbyCode
 import at.aau.pulverfass.shared.ids.PlayerId
 import at.aau.pulverfass.shared.ids.TerritoryId
+import at.aau.pulverfass.shared.lobby.command.MIN_ATTACK_COMMITTED_TROOPS
+import at.aau.pulverfass.shared.lobby.command.MIN_SOURCE_TROOPS_FOR_ATTACK
 import kotlinx.serialization.Serializable
 
 /**
@@ -39,11 +41,13 @@ data class AttackResolvedEvent(
     val stateVersion: Long? = null,
 ) : InternalLobbyEvent {
     init {
-        require(attackTroops >= 2) {
-            "AttackResolvedEvent.attackTroops muss mindestens 2 sein."
+        require(attackTroops >= MIN_ATTACK_COMMITTED_TROOPS) {
+            "AttackResolvedEvent.attackTroops muss mindestens " +
+                "$MIN_ATTACK_COMMITTED_TROOPS sein."
         }
-        require(sourceTroopsBefore >= 2) {
-            "AttackResolvedEvent.sourceTroopsBefore muss mindestens 2 sein."
+        require(sourceTroopsBefore >= MIN_SOURCE_TROOPS_FOR_ATTACK) {
+            "AttackResolvedEvent.sourceTroopsBefore muss mindestens " +
+                "$MIN_SOURCE_TROOPS_FOR_ATTACK sein."
         }
         require(targetTroopsBefore >= 1) {
             "AttackResolvedEvent.targetTroopsBefore muss mindestens 1 sein."

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/GameState.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/GameState.kt
@@ -6,6 +6,7 @@ import at.aau.pulverfass.shared.ids.ContinentId
 import at.aau.pulverfass.shared.ids.LobbyCode
 import at.aau.pulverfass.shared.ids.PlayerId
 import at.aau.pulverfass.shared.ids.TerritoryId
+import at.aau.pulverfass.shared.lobby.command.MIN_SOURCE_TROOPS_FOR_ATTACK
 import at.aau.pulverfass.shared.map.config.MapDefinition
 import at.aau.pulverfass.shared.map.config.TerritoryEdgeDefinition
 
@@ -389,7 +390,7 @@ data class GameState(
         }
 
         val source = requireTerritoryState(territoryId)
-        if (source.ownerId != playerId || source.troopCount < 2) {
+        if (source.ownerId != playerId || source.troopCount < MIN_SOURCE_TROOPS_FOR_ATTACK) {
             return false
         }
 
@@ -411,7 +412,7 @@ data class GameState(
         }
 
         val source = requireTerritoryState(fromTerritoryId)
-        if (source.ownerId != playerId || source.troopCount < 2) {
+        if (source.ownerId != playerId || source.troopCount < MIN_SOURCE_TROOPS_FOR_ATTACK) {
             return emptyList()
         }
 

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/request/AttackRequest.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/request/AttackRequest.kt
@@ -3,6 +3,7 @@ package at.aau.pulverfass.shared.message.lobby.request
 import at.aau.pulverfass.shared.ids.LobbyCode
 import at.aau.pulverfass.shared.ids.PlayerId
 import at.aau.pulverfass.shared.ids.TerritoryId
+import at.aau.pulverfass.shared.lobby.command.MIN_ATTACK_COMMITTED_TROOPS
 import at.aau.pulverfass.shared.message.protocol.NetworkMessagePayload
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.MissingFieldException
@@ -24,8 +25,9 @@ data class AttackRequest(
     val requestId: String? = null,
 ) : NetworkMessagePayload {
     init {
-        require(attackTroops >= 2) {
-            "AttackRequest.attackTroops muss mindestens 2 sein, war aber $attackTroops."
+        require(attackTroops >= MIN_ATTACK_COMMITTED_TROOPS) {
+            "AttackRequest.attackTroops muss mindestens $MIN_ATTACK_COMMITTED_TROOPS sein, " +
+                "war aber $attackTroops."
         }
         require(moveAfterCapture > 0) {
             "AttackRequest.moveAfterCapture muss positiv sein, war aber $moveAfterCapture."

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/command/DefaultMapCommandRuleServiceTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/command/DefaultMapCommandRuleServiceTest.kt
@@ -466,9 +466,9 @@ class DefaultMapCommandRuleServiceTest {
             expectedMessagePart = "beide Territorien",
         )
         assertMapCommandFailure(
-            state = attackState(rngState = 2L, sourceTroops = 1, targetTroops = 2),
+            state = attackState(rngState = 2L, sourceTroops = 2, targetTroops = 2),
             command = attackCommand(attacker = attacker),
-            expectedMessagePart = "mindestens 2 Truppen",
+            expectedMessagePart = "mindestens 3 Truppen",
         )
         assertMapCommandFailure(
             state = attackState(rngState = 2L, sourceTroops = 5, targetTroops = 2),

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/event/AttackResolvedEventTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/event/AttackResolvedEventTest.kt
@@ -43,9 +43,9 @@ class AttackResolvedEventTest {
                 { validEvent(attackTroops = 1) },
                 {
                     validEvent(
-                        sourceTroopsBefore = 1,
-                        attackerRemaining = 1,
-                        attackTroops = 1,
+                        sourceTroopsBefore = 2,
+                        attackerRemaining = 2,
+                        attackTroops = 2,
                     )
                 },
                 {

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/state/GameStateTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/state/GameStateTest.kt
@@ -271,7 +271,7 @@ class GameStateTest {
         val blockedState =
             reducer.apply(
                 ownedState,
-                TerritoryTroopsChangedEvent(lobbyCode, TerritoryId("alpha"), 1),
+                TerritoryTroopsChangedEvent(lobbyCode, TerritoryId("alpha"), 2),
             )
 
         assertFalse(blockedState.canAttackFrom(TerritoryId("alpha"), playerOne))
@@ -366,7 +366,7 @@ class GameStateTest {
                             ),
                             TerritoryOwnerChangedEvent(lobbyCode, TerritoryId("harbor"), attacker),
                         ),
-                        TerritoryTroopsChangedEvent(lobbyCode, TerritoryId("harbor"), 2),
+                        TerritoryTroopsChangedEvent(lobbyCode, TerritoryId("harbor"), 3),
                     ),
                     TerritoryOwnerChangedEvent(lobbyCode, TerritoryId("island"), defender),
                 ),

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/state/GameStateTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/state/GameStateTest.kt
@@ -310,6 +310,39 @@ class GameStateTest {
     }
 
     @Test
+    fun `should reject attack source owned by another player even with enough troops`() {
+        val playerOne = PlayerId(43)
+        val playerTwo = PlayerId(44)
+        val reducer = DefaultLobbyEventReducer()
+        val lobbyCode = LobbyCode("ATQ2")
+        val state =
+            reducer.apply(
+                reducer.apply(
+                    reducer.apply(
+                        reducer.apply(
+                            GameState.initial(
+                                lobbyCode = lobbyCode,
+                                mapDefinition = sampleMapDefinition(),
+                                players = listOf(playerOne, playerTwo),
+                            ),
+                            TerritoryOwnerChangedEvent(lobbyCode, TerritoryId("alpha"), playerTwo),
+                        ),
+                        TerritoryTroopsChangedEvent(lobbyCode, TerritoryId("alpha"), 4),
+                    ),
+                    TerritoryOwnerChangedEvent(lobbyCode, TerritoryId("beta"), playerOne),
+                ),
+                TerritoryTroopsChangedEvent(lobbyCode, TerritoryId("beta"), 1),
+            )
+
+        assertFalse(state.canAttackFrom(TerritoryId("alpha"), playerOne))
+        assertEquals(
+            emptyList<TerritoryId>(),
+            state.validAttackTargets(TerritoryId("alpha"), playerOne),
+        )
+        assertFalse(state.hasAnyValidAttack(playerOne))
+    }
+
+    @Test
     fun `should preserve adjacency order for valid attack targets`() {
         val playerOne = PlayerId(51)
         val playerTwo = PlayerId(52)

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/AttackMessageTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/AttackMessageTest.kt
@@ -47,6 +47,27 @@ class AttackMessageTest {
     }
 
     @Test
+    fun `attack request rejects less than minimum attack troops`() {
+        val exception =
+            assertThrows(IllegalArgumentException::class.java) {
+                AttackRequest(
+                    lobbyCode = LobbyCode("AT12"),
+                    playerId = PlayerId(7),
+                    fromTerritoryId = TerritoryId("alpha"),
+                    toTerritoryId = TerritoryId("beta"),
+                    attackTroops = 1,
+                    moveAfterCapture = 1,
+                    requestId = "req-invalid",
+                )
+            }
+
+        assertEquals(
+            "AttackRequest.attackTroops muss mindestens 2 sein, war aber 1.",
+            exception.message,
+        )
+    }
+
+    @Test
     fun `serializer roundtrip attack response`() {
         val response = AttackResponse(lobbyCode = LobbyCode("AT34"), requestId = "req-2")
 


### PR DESCRIPTION
Add centralized attack rule constants (MIN_ATTACK_COMMITTED_TROOPS = 2, MIN_SOURCE_TROOPS_FOR_ATTACK = 3) in AttackRules.kt and replace scattered magic numbers with these constants. Updated validations and error messages across server routing (MainServerLobbyRoutingService), command rule service (DefaultMapCommandRuleService), events (AttackResolvedEvent), request payload (AttackRequest) and game state checks (GameState). Adjusted tests to reflect the new minimum source/committed troop requirements. This centralizes attack-related rules and keeps validations consistent.