### PR TITLE
Distribute 60 start troops evenly at game start

### DIFF
--- a/server/src/test/kotlin/at/aau/pulverfass/server/StartGameIntegrationTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/StartGameIntegrationTest.kt
@@ -202,11 +202,20 @@ class StartGameIntegrationTest {
                     assertTrue(
                         (currentState?.pendingReinforcementsFor(expectedStartPlayer) ?: 0) >= 3,
                     )
+                    assertEquals(20, troopsOwnedBy(currentState, ownerId))
+                    assertEquals(20, troopsOwnedBy(currentState, player2Id))
+                    assertEquals(20, troopsOwnedBy(currentState, player3Id))
+                    assertEquals(
+                        60,
+                        currentState
+                            ?.allTerritoryStates()
+                            ?.sumOf { territory -> territory.troopCount },
+                    )
                     assertTrue(
                         currentState
                             ?.allTerritoryStates()
                             ?.all { territory ->
-                                territory.ownerId != null && territory.troopCount == 1
+                                territory.ownerId != null && territory.troopCount in 1..4
                             } == true,
                     )
 
@@ -222,7 +231,7 @@ class StartGameIntegrationTest {
         }
 
     @Test
-    fun `start game with insufficient players returns error`() =
+    fun `start game with two players returns error`() =
         testApplication {
             val network = ServerNetwork()
             val serverScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -235,7 +244,7 @@ class StartGameIntegrationTest {
             val playersByConnection = ConcurrentHashMap<ConnectionId, PlayerId>()
             val connectionsByPlayer = ConcurrentHashMap<PlayerId, ConnectionId>()
 
-            val lobbyCode = LobbyCode("STG2")
+            val lobbyCode = LobbyCode("STG3")
             val ownerId = PlayerId(1)
             val player2Id = PlayerId(2)
             lobbyManager.createLobby(
@@ -279,6 +288,14 @@ class StartGameIntegrationTest {
                             playersByConnection = playersByConnection,
                             connectionsByPlayer = connectionsByPlayer,
                         )
+                    val player2Session =
+                        connectSessionWithConnection(
+                            client = client,
+                            network = network,
+                            playerId = player2Id,
+                            playersByConnection = playersByConnection,
+                            connectionsByPlayer = connectionsByPlayer,
+                        )
 
                     val startRequest = StartGameRequest(lobbyCode = lobbyCode)
                     ownerSession.first.send(
@@ -291,9 +308,11 @@ class StartGameIntegrationTest {
                     val decoded = receivePayload(ownerSession.first)
                     assertTrue(decoded is StartGameErrorResponse)
                     assertNull(receivePayloadOrNull(ownerSession.first))
+                    assertNull(receivePayloadOrNull(player2Session.first))
                     assertEquals(2, lobbyManager.getLobby(lobbyCode)?.currentState()?.players?.size)
 
                     ownerSession.first.close()
+                    player2Session.first.close()
                 }
             } finally {
                 routingService.stop()
@@ -350,4 +369,14 @@ class StartGameIntegrationTest {
     }
 
     private fun defaultMapDefinition() = MapConfigLoader.loadDefault()
+
+    private fun troopsOwnedBy(
+        state: GameState?,
+        playerId: PlayerId,
+    ): Int =
+        state
+            ?.allTerritoryStates()
+            ?.filter { territoryState -> territoryState.ownerId == playerId }
+            ?.sumOf { territoryState -> territoryState.troopCount }
+            ?: 0
 }

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/GameStartPreparation.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/GameStartPreparation.kt
@@ -59,6 +59,11 @@ internal object GameStartPreparation {
         require(territoryIds.isNotEmpty()) {
             "Spielstart benötigt mindestens ein Territorium in der Map."
         }
+        require(territoryIds.size * MIN_TROOPS_PER_TERRITORY <= TOTAL_INITIAL_TROOPS) {
+            "Map kann nicht vorbereitet werden: ${territoryIds.size} Territorien benötigen mindestens " +
+                "${territoryIds.size * MIN_TROOPS_PER_TERRITORY} Starttruppen, aber es stehen nur " +
+                "$TOTAL_INITIAL_TROOPS zur Verfügung."
+        }
         require(territoryIds.size * MAX_TROOPS_PER_TERRITORY >= TOTAL_INITIAL_TROOPS) {
             "Map kann nicht vorbereitet werden: ${territoryIds.size} Territorien reichen " +
                 "mit maximal $MAX_TROOPS_PER_TERRITORY Truppen pro Territorium nicht für " +

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/GameStartPreparation.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/GameStartPreparation.kt
@@ -2,28 +2,42 @@ package at.aau.pulverfass.shared.lobby.state
 
 import at.aau.pulverfass.shared.ids.PlayerId
 import at.aau.pulverfass.shared.ids.TerritoryId
+import at.aau.pulverfass.shared.map.config.MapDefinition
 import kotlin.random.Random
 
 /**
  * Kapselt die Vorbereitungslogik für den eigentlichen Spielstart.
  *
- * Beim Start werden die Territorien zufällig, möglichst gleichmäßig verteilt,
- * jedes Territorium mit genau einer Einheit vorbelegt und die verbleibenden
- * Starttruppen pro Spieler berechnet.
+ * Beim Start werden die Territorien zufällig verteilt und direkt mit allen
+ * Starttruppen vorbelegt. Die Verteilung erfüllt dabei folgende Regeln:
+ *
+ * - insgesamt genau 60 Starttruppen
+ * - gleich viele Truppen pro Spieler
+ * - jedes Territorium besitzt mindestens 1 und höchstens 4 Truppen
+ * - jeder Kontinent mit mindestens zwei Territorien wird von mindestens zwei
+ *   verschiedenen Spielern geteilt, damit im ersten Zug kein Kontinentbonus
+ *   entsteht
  */
 internal object GameStartPreparation {
-    private val initialTroopsByPlayerCount =
-        mapOf(
-            3 to 35,
-            4 to 30,
-            5 to 25,
-            6 to 20,
-        )
+    private const val TOTAL_INITIAL_TROOPS = 60
+    private const val MIN_SUPPORTED_PLAYER_COUNT = 3
+    private const val MAX_SUPPORTED_PLAYER_COUNT = 6
+    private const val MIN_TROOPS_PER_TERRITORY = 1
+    private const val MAX_TROOPS_PER_TERRITORY = 4
+    private const val MIN_DISTINCT_PLAYERS_PER_CONTINENT = 2
 
     fun isSupportedPlayerCount(playerCount: Int): Boolean =
-        initialTroopsByPlayerCount.containsKey(playerCount)
+        initialTroopsPerPlayer(playerCount) != null
 
-    fun initialTroopsPerPlayer(playerCount: Int): Int? = initialTroopsByPlayerCount[playerCount]
+    fun initialTroopsPerPlayer(playerCount: Int): Int? =
+        if (
+            playerCount in MIN_SUPPORTED_PLAYER_COUNT..MAX_SUPPORTED_PLAYER_COUNT &&
+            TOTAL_INITIAL_TROOPS % playerCount == 0
+        ) {
+            TOTAL_INITIAL_TROOPS / playerCount
+        } else {
+            null
+        }
 
     fun prepare(
         state: GameState,
@@ -36,18 +50,31 @@ internal object GameStartPreparation {
                     "Spielstart ist nur für 3 bis 6 Spieler unterstützt, waren aber $playerCount.",
                 )
 
-        val territoryIds = state.allTerritoryStates().map { territory -> territory.territoryId }
+        val mapDefinition =
+            state.mapDefinition
+                ?: throw IllegalArgumentException(
+                    "Spielstart benötigt eine geladene Map-Definition.",
+                )
+        val territoryIds = mapDefinition.territories.map { territory -> territory.territoryId }
         require(territoryIds.isNotEmpty()) {
             "Spielstart benötigt mindestens ein Territorium in der Map."
+        }
+        require(territoryIds.size * MAX_TROOPS_PER_TERRITORY >= TOTAL_INITIAL_TROOPS) {
+            "Map kann nicht vorbereitet werden: ${territoryIds.size} Territorien reichen " +
+                "mit maximal $MAX_TROOPS_PER_TERRITORY Truppen pro Territorium nicht für " +
+                "$TOTAL_INITIAL_TROOPS Starttruppen."
         }
 
         val random = Random(randomSeed)
         val randomizedTurnOrder = state.players.shuffled(random)
-        val shuffledTerritories = territoryIds.shuffled(random)
         val territoryOwners =
-            shuffledTerritories.mapIndexed { index, territoryId ->
-                territoryId to randomizedTurnOrder[index % randomizedTurnOrder.size]
-            }.toMap()
+            assignTerritoryOwners(
+                mapDefinition = mapDefinition,
+                players = randomizedTurnOrder,
+                troopsPerPlayer = initialTroops,
+                random = random,
+            )
+        ensureNoInitialContinentOwner(mapDefinition, territoryOwners)
 
         val territoryCountsByPlayer =
             randomizedTurnOrder
@@ -55,30 +82,209 @@ internal object GameStartPreparation {
                     territoryOwners.values.count { ownerId -> ownerId == playerId }
                 }
 
-        val maxTerritoriesPerPlayer = territoryCountsByPlayer.values.maxOrNull() ?: 0
-        require(initialTroops >= maxTerritoriesPerPlayer) {
-            "Map kann mit $playerCount Spielern nicht vorbereitet werden: " +
-                "$maxTerritoriesPerPlayer Territorien pro Spieler " +
-                "überschreiten die $initialTroops Starttruppen."
+        territoryCountsByPlayer.forEach { (playerId, territoryCount) ->
+            require(territoryCount * MAX_TROOPS_PER_TERRITORY >= initialTroops) {
+                "Map kann mit $playerCount Spielern nicht vorbereitet werden: " +
+                    "Spieler '${playerId.value}' hat nur $territoryCount Territorien und kann " +
+                    "damit höchstens ${territoryCount * MAX_TROOPS_PER_TERRITORY} der " +
+                    "$initialTroops Starttruppen aufnehmen."
+            }
         }
+        val troopCountsByTerritory =
+            assignTroopCounts(
+                territoryIds = territoryIds,
+                territoryOwners = territoryOwners,
+                players = randomizedTurnOrder,
+                troopsPerPlayer = initialTroops,
+                random = random,
+            )
 
         val preparedTerritoryStates =
             state.territoryStates.mapValues { (territoryId, territoryState) ->
                 territoryState.copy(
                     ownerId = territoryOwners.getValue(territoryId),
-                    troopCount = 1,
+                    troopCount = troopCountsByTerritory.getValue(territoryId),
                 )
             }
         val setupTroopsToPlaceByPlayer =
-            randomizedTurnOrder.associateWith { playerId ->
-                initialTroops - territoryCountsByPlayer.getValue(playerId)
-            }
+            randomizedTurnOrder.associateWith { 0 }
 
         return PreparedGameStart(
             randomizedTurnOrder = randomizedTurnOrder,
             preparedTerritoryStates = preparedTerritoryStates,
             setupTroopsToPlaceByPlayer = setupTroopsToPlaceByPlayer,
         )
+    }
+
+    private fun assignTerritoryOwners(
+        mapDefinition: MapDefinition,
+        players: List<PlayerId>,
+        troopsPerPlayer: Int,
+        random: Random,
+    ): Map<TerritoryId, PlayerId> {
+        val assignments = linkedMapOf<TerritoryId, PlayerId>()
+        val assignedCounts = players.associateWith { 0 }.toMutableMap()
+        val minimumTerritoriesPerPlayer =
+            (troopsPerPlayer + MAX_TROOPS_PER_TERRITORY - 1) / MAX_TROOPS_PER_TERRITORY
+
+        mapDefinition.continents
+            .shuffled(random)
+            .forEach { continent ->
+                val shuffledTerritories =
+                    continent.territoryIds
+                        .filterNot(assignments::containsKey)
+                        .shuffled(random)
+                if (shuffledTerritories.size < MIN_DISTINCT_PLAYERS_PER_CONTINENT) {
+                    return@forEach
+                }
+
+                val firstPlayer =
+                    pickLeastAssignedPlayer(
+                        players = players,
+                        assignedCounts = assignedCounts,
+                        preferredMinimum = minimumTerritoriesPerPlayer,
+                        excludedPlayers = emptySet(),
+                        random = random,
+                    )
+                val secondPlayer =
+                    pickLeastAssignedPlayer(
+                        players = players,
+                        assignedCounts = assignedCounts,
+                        preferredMinimum = minimumTerritoriesPerPlayer,
+                        excludedPlayers = setOf(firstPlayer),
+                        random = random,
+                    )
+
+                listOf(firstPlayer, secondPlayer)
+                    .zip(shuffledTerritories.take(MIN_DISTINCT_PLAYERS_PER_CONTINENT))
+                    .forEach { (playerId, territoryId) ->
+                        assignments[territoryId] = playerId
+                        assignedCounts[playerId] = assignedCounts.getValue(playerId) + 1
+                    }
+            }
+
+        val remainingTerritories =
+            mapDefinition.continents
+                .shuffled(random)
+                .flatMap { continent ->
+                    continent.territoryIds
+                        .shuffled(random)
+                        .filterNot(assignments::containsKey)
+                }
+
+        remainingTerritories.forEach { territoryId ->
+            val playerId =
+                pickLeastAssignedPlayer(
+                    players = players,
+                    assignedCounts = assignedCounts,
+                    preferredMinimum = minimumTerritoriesPerPlayer,
+                    excludedPlayers = emptySet(),
+                    random = random,
+                )
+            assignments[territoryId] = playerId
+            assignedCounts[playerId] = assignedCounts.getValue(playerId) + 1
+        }
+
+        return assignments
+    }
+
+    private fun assignTroopCounts(
+        territoryIds: List<TerritoryId>,
+        territoryOwners: Map<TerritoryId, PlayerId>,
+        players: List<PlayerId>,
+        troopsPerPlayer: Int,
+        random: Random,
+    ): Map<TerritoryId, Int> {
+        val troopCounts = territoryIds.associateWith { MIN_TROOPS_PER_TERRITORY }.toMutableMap()
+
+        players.forEach { playerId ->
+            val ownedTerritories =
+                territoryIds.filter { territoryId ->
+                    territoryOwners.getValue(territoryId) == playerId
+                }
+            val remainingTroops = troopsPerPlayer - ownedTerritories.size
+            require(remainingTroops >= 0) {
+                "Spieler '${playerId.value}' besitzt mehr Territorien als Starttruppen."
+            }
+
+            repeat(remainingTroops) {
+                val eligibleTerritories =
+                    ownedTerritories.filter { territoryId ->
+                        troopCounts.getValue(territoryId) < MAX_TROOPS_PER_TERRITORY
+                    }
+                require(eligibleTerritories.isNotEmpty()) {
+                    "Spieler '${playerId.value}' kann nicht alle Starttruppen innerhalb der " +
+                        "Territoriumsgrenze von $MAX_TROOPS_PER_TERRITORY platzieren."
+                }
+                val territoryId = eligibleTerritories[random.nextInt(eligibleTerritories.size)]
+                troopCounts[territoryId] = troopCounts.getValue(territoryId) + 1
+            }
+        }
+
+        require(troopCounts.values.sum() == TOTAL_INITIAL_TROOPS) {
+            "Interner Fehler beim Spielstart: ${troopCounts.values.sum()} statt " +
+                "$TOTAL_INITIAL_TROOPS Starttruppen verteilt."
+        }
+        require(
+            troopCounts.values.all { troopCount ->
+                troopCount in MIN_TROOPS_PER_TERRITORY..MAX_TROOPS_PER_TERRITORY
+            },
+        ) {
+            "Interner Fehler beim Spielstart: Truppenzahlen liegen außerhalb der erlaubten Grenzen."
+        }
+
+        return troopCounts
+    }
+
+    private fun ensureNoInitialContinentOwner(
+        mapDefinition: MapDefinition,
+        territoryOwners: Map<TerritoryId, PlayerId>,
+    ) {
+        mapDefinition.continents.forEach { continent ->
+            if (continent.territoryIds.size < MIN_DISTINCT_PLAYERS_PER_CONTINENT) {
+                return@forEach
+            }
+
+            val distinctOwners =
+                continent.territoryIds
+                    .map { territoryId -> territoryOwners.getValue(territoryId) }
+                    .distinct()
+
+            require(distinctOwners.size >= MIN_DISTINCT_PLAYERS_PER_CONTINENT) {
+                "Kontinent '${continent.continentId.value}' muss zum Spielstart von mindestens " +
+                    "$MIN_DISTINCT_PLAYERS_PER_CONTINENT Spielern geteilt werden."
+            }
+        }
+    }
+
+    private fun pickLeastAssignedPlayer(
+        players: List<PlayerId>,
+        assignedCounts: Map<PlayerId, Int>,
+        preferredMinimum: Int,
+        excludedPlayers: Set<PlayerId>,
+        random: Random,
+    ): PlayerId {
+        val availablePlayers = players.filterNot(excludedPlayers::contains)
+        val playersBelowPreferredMinimum =
+            availablePlayers.filter { playerId ->
+                assignedCounts.getValue(playerId) < preferredMinimum
+            }
+        val candidates =
+            if (playersBelowPreferredMinimum.isNotEmpty()) {
+                playersBelowPreferredMinimum
+            } else {
+                availablePlayers
+            }
+        val minimumAssignedCount =
+            candidates.minOf { playerId ->
+                assignedCounts.getValue(playerId)
+            }
+        val tiedCandidates =
+            candidates.filter { playerId ->
+                assignedCounts.getValue(playerId) == minimumAssignedCount
+            }
+
+        return tiedCandidates[random.nextInt(tiedCandidates.size)]
     }
 }
 

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/GameStartPreparation.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/GameStartPreparation.kt
@@ -60,8 +60,10 @@ internal object GameStartPreparation {
             "Spielstart benötigt mindestens ein Territorium in der Map."
         }
         require(territoryIds.size * MIN_TROOPS_PER_TERRITORY <= TOTAL_INITIAL_TROOPS) {
-            "Map kann nicht vorbereitet werden: ${territoryIds.size} Territorien benötigen mindestens " +
-                "${territoryIds.size * MIN_TROOPS_PER_TERRITORY} Starttruppen, aber es stehen nur " +
+            "Map kann nicht vorbereitet werden: " +
+                "${territoryIds.size} Territorien benötigen mindestens " +
+                "${territoryIds.size * MIN_TROOPS_PER_TERRITORY} Starttruppen, " +
+                "aber es stehen nur " +
                 "$TOTAL_INITIAL_TROOPS zur Verfügung."
         }
         require(territoryIds.size * MAX_TROOPS_PER_TERRITORY >= TOTAL_INITIAL_TROOPS) {

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/reducer/DefaultLobbyEventReducerTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/reducer/DefaultLobbyEventReducerTest.kt
@@ -39,6 +39,7 @@ import at.aau.pulverfass.shared.lobby.state.TurnPauseReasons
 import at.aau.pulverfass.shared.lobby.state.TurnPhase
 import at.aau.pulverfass.shared.lobby.state.TurnState
 import at.aau.pulverfass.shared.map.config.ContinentDefinition
+import at.aau.pulverfass.shared.map.config.MapConfigLoader
 import at.aau.pulverfass.shared.map.config.MapDefinition
 import at.aau.pulverfass.shared.map.config.TerritoryDefinition
 import at.aau.pulverfass.shared.map.config.TerritoryEdgeDefinition
@@ -1199,16 +1200,9 @@ class DefaultLobbyEventReducerTest {
         val player2 = PlayerId(2)
         val player3 = PlayerId(3)
         val seed = 123L
+        val mapDefinition = defaultMapDefinition()
         val random = Random(seed)
         val expectedTurnOrder = listOf(owner, player2, player3).shuffled(random)
-        val expectedTerritoryOwners =
-            sampleMapDefinition()
-                .territories
-                .map { territory -> territory.territoryId }
-                .shuffled(random)
-                .mapIndexed { index, territoryId ->
-                    territoryId to expectedTurnOrder[index % expectedTurnOrder.size]
-                }.toMap()
         val stateWithOwner =
             GameState(
                 lobbyCode = lobbyCode,
@@ -1216,9 +1210,9 @@ class DefaultLobbyEventReducerTest {
                 players = listOf(owner, player2, player3),
                 turnOrder = listOf(owner, player2, player3),
                 activePlayer = owner,
-                mapDefinition = sampleMapDefinition(),
+                mapDefinition = mapDefinition,
                 territoryStates =
-                    sampleMapDefinition().territories.associate { territory ->
+                    mapDefinition.territories.associate { territory ->
                         territory.territoryId to TerritoryState(territory.territoryId)
                     },
                 status = GameStatus.WAITING_FOR_PLAYERS,
@@ -1236,16 +1230,48 @@ class DefaultLobbyEventReducerTest {
         assertEquals(expectedTurnOrder.first(), started.turnState?.startPlayerId)
         assertEquals(false, started.turnState?.isPaused)
         assertEquals(null, started.turnState?.pauseReason)
-        assertEquals(34, started.setupTroopsToPlaceFor(owner))
-        assertEquals(34, started.setupTroopsToPlaceFor(player2))
-        assertEquals(34, started.setupTroopsToPlaceFor(player3))
-        started.allTerritoryStates().forEach { territoryState ->
-            assertEquals(
-                expectedTerritoryOwners[territoryState.territoryId],
-                territoryState.ownerId,
-            )
-            assertEquals(1, territoryState.troopCount)
-        }
+        assertEquals(0, started.setupTroopsToPlaceFor(owner))
+        assertEquals(0, started.setupTroopsToPlaceFor(player2))
+        assertEquals(0, started.setupTroopsToPlaceFor(player3))
+        assertEquals(
+            60,
+            started.allTerritoryStates().sumOf { territoryState -> territoryState.troopCount },
+        )
+        assertEquals(
+            20,
+            started.allTerritoryStates()
+                .filter { territoryState -> territoryState.ownerId == owner }
+                .sumOf { territoryState -> territoryState.troopCount },
+        )
+        assertEquals(
+            20,
+            started.allTerritoryStates()
+                .filter { territoryState -> territoryState.ownerId == player2 }
+                .sumOf { territoryState -> territoryState.troopCount },
+        )
+        assertEquals(
+            20,
+            started.allTerritoryStates()
+                .filter { territoryState -> territoryState.ownerId == player3 }
+                .sumOf { territoryState -> territoryState.troopCount },
+        )
+        assertEquals(
+            true,
+            started.allTerritoryStates().all { territoryState ->
+                territoryState.ownerId != null && territoryState.troopCount in 1..4
+            },
+        )
+        assertEquals(
+            true,
+            mapDefinition.continents
+                .filter { continent -> continent.territoryIds.size >= 2 }
+                .all { continent ->
+                    continent.territoryIds
+                        .map { territoryId -> started.requireTerritoryState(territoryId).ownerId }
+                        .distinct()
+                        .size >= 2
+                },
+        )
     }
 
     @Test
@@ -1260,9 +1286,9 @@ class DefaultLobbyEventReducerTest {
                 players = listOf(owner, player2),
                 turnOrder = listOf(owner, player2),
                 activePlayer = owner,
-                mapDefinition = sampleMapDefinition(),
+                mapDefinition = defaultMapDefinition(),
                 territoryStates =
-                    sampleMapDefinition().territories.associate { territory ->
+                    defaultMapDefinition().territories.associate { territory ->
                         territory.territoryId to TerritoryState(territory.territoryId)
                     },
                 status = GameStatus.WAITING_FOR_PLAYERS,
@@ -1402,9 +1428,9 @@ class DefaultLobbyEventReducerTest {
                 configuredStartPlayerId = player2,
                 turnOrder = listOf(owner, player2, player3),
                 activePlayer = player2,
-                mapDefinition = sampleMapDefinition(),
+                mapDefinition = defaultMapDefinition(),
                 territoryStates =
-                    sampleMapDefinition().territories.associate { territory ->
+                    defaultMapDefinition().territories.associate { territory ->
                         territory.territoryId to TerritoryState(territory.territoryId)
                     },
                 turnState =
@@ -2077,4 +2103,6 @@ class DefaultLobbyEventReducerTest {
                     ),
                 ),
         )
+
+    private fun defaultMapDefinition(): MapDefinition = MapConfigLoader.loadDefault()
 }

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/state/GameStartPreparationTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/state/GameStartPreparationTest.kt
@@ -1,0 +1,69 @@
+package at.aau.pulverfass.shared.lobby.state
+
+import at.aau.pulverfass.shared.ids.LobbyCode
+import at.aau.pulverfass.shared.ids.PlayerId
+import at.aau.pulverfass.shared.map.config.MapConfigLoader
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class GameStartPreparationTest {
+    @Test
+    fun `prepare rejects lobbies with fewer than three players`() {
+        val mapDefinition = MapConfigLoader.loadDefault()
+        val state =
+            GameState.initial(
+                lobbyCode = LobbyCode("GP10"),
+                mapDefinition = mapDefinition,
+                players = listOf(PlayerId(1), PlayerId(2)),
+            )
+
+        val exception =
+            assertThrows(IllegalArgumentException::class.java) {
+                GameStartPreparation.prepare(state, randomSeed = 123L)
+            }
+
+        assertEquals(
+            "Spielstart ist nur für 3 bis 6 Spieler unterstützt, waren aber 2.",
+            exception.message,
+        )
+    }
+
+    @Test
+    fun `prepare gives three players 20 troops each without continent bonus`() {
+        val players = listOf(PlayerId(1), PlayerId(2), PlayerId(3))
+        val mapDefinition = MapConfigLoader.loadDefault()
+        val state =
+            GameState.initial(
+                lobbyCode = LobbyCode("GP30"),
+                mapDefinition = mapDefinition,
+                players = players,
+            )
+
+        val prepared = GameStartPreparation.prepare(state, randomSeed = 456L)
+        val startedState = state.copy(territoryStates = prepared.preparedTerritoryStates)
+
+        players.forEach { playerId ->
+            assertEquals(20, troopsOf(playerId, prepared.preparedTerritoryStates.values))
+            assertEquals(0, startedState.continentsOwnedBy(playerId).size)
+        }
+        assertEquals(
+            60,
+            prepared.preparedTerritoryStates.values.sumOf(TerritoryState::troopCount),
+        )
+        assertEquals(
+            true,
+            prepared.preparedTerritoryStates.values.all { territoryState ->
+                territoryState.ownerId != null && territoryState.troopCount in 1..4
+            },
+        )
+    }
+
+    private fun troopsOf(
+        playerId: PlayerId,
+        territoryStates: Collection<TerritoryState>,
+    ): Int =
+        territoryStates
+            .filter { territoryState -> territoryState.ownerId == playerId }
+            .sumOf(TerritoryState::troopCount)
+}


### PR DESCRIPTION
Refactor GameStartPreparation to allocate a total of 60 start troops evenly across players with per-territory limits and continent-splitting rules. Introduces constants for limits, validation checks (player count, map capacity, territory capacity), and new helpers: assignTerritoryOwners, assignTroopCounts, ensureNoInitialContinentOwner and pickLeastAssignedPlayer. Updated tests and expectations: DefaultLobbyEventReducerTest now asserts total troops = 60, per-player totals (e.g. 20 for 3 players), per-territory troop range (1..4) and continent ownership requirements; StartGameIntegrationTest adjusted to reflect new distribution and adds a troopsOwnedBy helper; added GameStartPreparationTest to validate error for <3 players and correct distribution for 3 players. Overall ensures fair start (equal troops per player, no instant continent bonuses) and stronger input validation.