### PR TITLE
Switch CI to Docker Buildx and optimize Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,4 +15,8 @@ local.properties
 !build/documentation/
 !build/documentation/html/
 !build/documentation/html/**
+!server/build/
+!server/build/install/
+!server/build/install/server/
+!server/build/install/server/**
 !.env.example

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,7 +347,7 @@ jobs:
       - name: Show container logs on failure
         if: failure()
         run: |
-          docker logs se2risiko-server-smoke
+          docker logs se2risiko-server-smoke || true
 
       - name: Cleanup smoke test container
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,7 @@ jobs:
           ./gradlew
           :shared:assemble
           :server:assemble
+          :server:installDist
           :e2e:assemble
           :shared:test
           :server:test
@@ -127,6 +128,13 @@ jobs:
             **/build/reports/tests/**
             **/build/test-results/**
           if-no-files-found: ignore
+
+      - name: Upload server distribution
+        uses: actions/upload-artifact@v4
+        with:
+          name: server-install
+          path: server/build/install/server/**
+          if-no-files-found: error
 
       - name: Cleanup test PostgreSQL
         if: always()
@@ -287,6 +295,15 @@ jobs:
             echo "local_tag=${local_tag}"
           } >> "${GITHUB_OUTPUT}"
 
+      - name: Download server distribution artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: server-install
+          path: server/build/install/server
+
+      - name: Verify server distribution artifact
+        run: test -f server/build/install/server/bin/server
+
       - name: Build server image
         uses: docker/build-push-action@v6
         with:
@@ -298,7 +315,7 @@ jobs:
             APP_VERSION=${{ steps.metadata.outputs.app_version }}
             COMMIT_SHA=${{ github.sha }}
           cache-from: type=gha,scope=server
-          cache-to: type=gha,mode=max,scope=server,ignore-error=true
+          cache-to: type=gha,mode=min,scope=server,ignore-error=true
 
       - name: Verify server image
         run: docker image inspect "${{ steps.metadata.outputs.local_tag }}" >/dev/null
@@ -368,7 +385,7 @@ jobs:
           load: true
           tags: se2risiko-dokka-pr
           cache-from: type=gha,scope=dokka
-          cache-to: type=gha,mode=max,scope=dokka,ignore-error=true
+          cache-to: type=gha,mode=min,scope=dokka,ignore-error=true
 
       - name: Verify Dokka image
         run: docker image inspect se2risiko-dokka-pr >/dev/null
@@ -445,6 +462,15 @@ jobs:
             echo "created=${created}"
           } >> "${GITHUB_OUTPUT}"
 
+      - name: Download server distribution artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: server-install
+          path: server/build/install/server
+
+      - name: Verify server distribution artifact
+        run: test -f server/build/install/server/bin/server
+
       - name: Build server image
         uses: docker/build-push-action@v6
         with:
@@ -461,7 +487,7 @@ jobs:
             org.opencontainers.image.version=${{ steps.metadata.outputs.app_version }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
           cache-from: type=gha,scope=server
-          cache-to: type=gha,mode=max,scope=server,ignore-error=true
+          cache-to: type=gha,mode=min,scope=server,ignore-error=true
 
       - name: Verify server image
         run: docker image inspect "${{ steps.metadata.outputs.server_local_tag }}" >/dev/null
@@ -488,7 +514,7 @@ jobs:
             org.opencontainers.image.version=${{ steps.metadata.outputs.app_version }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
           cache-from: type=gha,scope=dokka
-          cache-to: type=gha,mode=max,scope=dokka,ignore-error=true
+          cache-to: type=gha,mode=min,scope=dokka,ignore-error=true
 
       - name: Verify Dokka image
         run: docker image inspect "${{ steps.metadata.outputs.dokka_local_tag }}" >/dev/null
@@ -581,6 +607,15 @@ jobs:
             echo "created=${created}"
           } >> "${GITHUB_OUTPUT}"
 
+      - name: Download server distribution artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: server-install
+          path: server/build/install/server
+
+      - name: Verify server distribution artifact
+        run: test -f server/build/install/server/bin/server
+
       - name: Build server image
         uses: docker/build-push-action@v6
         with:
@@ -597,7 +632,7 @@ jobs:
             org.opencontainers.image.version=${{ steps.metadata.outputs.app_version }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
           cache-from: type=gha,scope=server
-          cache-to: type=gha,mode=max,scope=server,ignore-error=true
+          cache-to: type=gha,mode=min,scope=server,ignore-error=true
 
       - name: Verify server image
         run: docker image inspect "${{ steps.metadata.outputs.server_local_tag }}" >/dev/null
@@ -624,7 +659,7 @@ jobs:
             org.opencontainers.image.version=${{ steps.metadata.outputs.app_version }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
           cache-from: type=gha,scope=dokka
-          cache-to: type=gha,mode=max,scope=dokka,ignore-error=true
+          cache-to: type=gha,mode=min,scope=dokka,ignore-error=true
 
       - name: Verify Dokka image
         run: docker image inspect "${{ steps.metadata.outputs.dokka_local_tag }}" >/dev/null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,14 +256,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Temurin JDK 25
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: '25'
-
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Derive image and version metadata
         id: metadata
@@ -294,12 +288,20 @@ jobs:
           } >> "${GITHUB_OUTPUT}"
 
       - name: Build server image
-        run: >
-          docker build
-          --build-arg APP_VERSION=${{ steps.metadata.outputs.app_version }}
-          --build-arg COMMIT_SHA=${{ github.sha }}
-          --tag ${{ steps.metadata.outputs.local_tag }}
-          .
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          load: true
+          tags: ${{ steps.metadata.outputs.local_tag }}
+          build-args: |
+            APP_VERSION=${{ steps.metadata.outputs.app_version }}
+            COMMIT_SHA=${{ github.sha }}
+          cache-from: type=gha,scope=server
+          cache-to: type=gha,mode=max,scope=server,ignore-error=true
+
+      - name: Verify server image
+        run: docker image inspect "${{ steps.metadata.outputs.local_tag }}" >/dev/null
 
       - name: Smoke test container
         run: |
@@ -339,9 +341,6 @@ jobs:
     runs-on: self-hosted
     if: github.event_name == 'pull_request'
     needs: dokka-build
-    env:
-      ANDROID_SDK_ROOT: ${{ github.workspace }}/android-sdk
-      ANDROID_HOME: ${{ github.workspace }}/android-sdk
     permissions:
       contents: read
 
@@ -349,38 +348,30 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Temurin JDK 25
-        uses: actions/setup-java@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Download Dokka site artifact
+        uses: actions/download-artifact@v4
         with:
-          distribution: temurin
-          java-version: '25'
+          name: dokka-site
+          path: build/documentation/html
 
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
-
-      - name: Cache Android SDK
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/android-sdk
-          key: ${{ runner.os }}-android-sdk-35
-          restore-keys: |
-            ${{ runner.os }}-android-sdk-
-
-      - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
-        with:
-          packages: 'platform-tools platforms;android-35 build-tools;35.0.0'
-          accept-android-sdk-licenses: true
-          log-accepted-android-sdk-licenses: false
-
-      - name: Make Gradle wrapper executable
-        run: chmod +x ./gradlew
-
-      - name: Build Dokka site
-        run: ./gradlew dokkaGenerate --stacktrace
+      - name: Verify Dokka artifact
+        run: test -f build/documentation/html/index.html
 
       - name: Build Dokka image
-        run: docker build -f Dockerfile.dokka --tag se2risiko-dokka-pr .
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.dokka
+          load: true
+          tags: se2risiko-dokka-pr
+          cache-from: type=gha,scope=dokka
+          cache-to: type=gha,mode=max,scope=dokka,ignore-error=true
+
+      - name: Verify Dokka image
+        run: docker image inspect se2risiko-dokka-pr >/dev/null
 
       - name: Smoke test Dokka container
         run: |
@@ -410,8 +401,6 @@ jobs:
       contents: read
       packages: write
     env:
-      ANDROID_SDK_ROOT: ${{ github.workspace }}/android-sdk
-      ANDROID_HOME: ${{ github.workspace }}/android-sdk
       GHCR_USERNAME: ${{ vars.GHCR_USERNAME || secrets.GHCR_USERNAME || github.actor }}
       GHCR_TOKEN: ${{ secrets.GHCR_TOKEN || github.token }}
 
@@ -421,14 +410,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Temurin JDK 25
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: '25'
-
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Derive image and version metadata
         id: metadata
@@ -462,45 +445,53 @@ jobs:
             echo "created=${created}"
           } >> "${GITHUB_OUTPUT}"
 
-      - name: Cache Android SDK
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/android-sdk
-          key: ${{ runner.os }}-android-sdk-35
-          restore-keys: |
-            ${{ runner.os }}-android-sdk-
-
-      - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
-        with:
-          packages: 'platform-tools platforms;android-35 build-tools;35.0.0'
-          accept-android-sdk-licenses: true
-          log-accepted-android-sdk-licenses: false
-
       - name: Build server image
-        run: >
-          docker build
-          --build-arg APP_VERSION=${{ steps.metadata.outputs.app_version }}
-          --build-arg COMMIT_SHA=${{ github.sha }}
-          --label org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
-          --label org.opencontainers.image.revision=${{ github.sha }}
-          --label org.opencontainers.image.version=${{ steps.metadata.outputs.app_version }}
-          --label org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-          --tag ${{ steps.metadata.outputs.server_local_tag }}
-          .
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          load: true
+          tags: ${{ steps.metadata.outputs.server_local_tag }}
+          build-args: |
+            APP_VERSION=${{ steps.metadata.outputs.app_version }}
+            COMMIT_SHA=${{ github.sha }}
+          labels: |
+            org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.metadata.outputs.app_version }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+          cache-from: type=gha,scope=server
+          cache-to: type=gha,mode=max,scope=server,ignore-error=true
+
+      - name: Verify server image
+        run: docker image inspect "${{ steps.metadata.outputs.server_local_tag }}" >/dev/null
+
+      - name: Download Dokka site artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dokka-site
+          path: build/documentation/html
+
+      - name: Verify Dokka artifact
+        run: test -f build/documentation/html/index.html
 
       - name: Build Dokka image
-        run: |
-          chmod +x ./gradlew
-          ./gradlew dokkaGenerate --stacktrace
-          docker build \
-            -f Dockerfile.dokka \
-            --label org.opencontainers.image.created=${{ steps.metadata.outputs.created }} \
-            --label org.opencontainers.image.revision=${{ github.sha }} \
-            --label org.opencontainers.image.version=${{ steps.metadata.outputs.app_version }} \
-            --label org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }} \
-            --tag ${{ steps.metadata.outputs.dokka_local_tag }} \
-            .
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.dokka
+          load: true
+          tags: ${{ steps.metadata.outputs.dokka_local_tag }}
+          labels: |
+            org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.metadata.outputs.app_version }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+          cache-from: type=gha,scope=dokka
+          cache-to: type=gha,mode=max,scope=dokka,ignore-error=true
+
+      - name: Verify Dokka image
+        run: docker image inspect "${{ steps.metadata.outputs.dokka_local_tag }}" >/dev/null
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -535,8 +526,6 @@ jobs:
       contents: read
       packages: write
     env:
-      ANDROID_SDK_ROOT: ${{ github.workspace }}/android-sdk
-      ANDROID_HOME: ${{ github.workspace }}/android-sdk
       GHCR_USERNAME: ${{ vars.GHCR_USERNAME || secrets.GHCR_USERNAME || github.actor }}
       GHCR_TOKEN: ${{ secrets.GHCR_TOKEN || github.token }}
     outputs:
@@ -552,14 +541,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Temurin JDK 25
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: '25'
-
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Derive image and version metadata
         id: metadata
@@ -598,45 +581,53 @@ jobs:
             echo "created=${created}"
           } >> "${GITHUB_OUTPUT}"
 
-      - name: Cache Android SDK
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/android-sdk
-          key: ${{ runner.os }}-android-sdk-35
-          restore-keys: |
-            ${{ runner.os }}-android-sdk-
-
-      - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
-        with:
-          packages: 'platform-tools platforms;android-35 build-tools;35.0.0'
-          accept-android-sdk-licenses: true
-          log-accepted-android-sdk-licenses: false
-
       - name: Build server image
-        run: >
-          docker build
-          --build-arg APP_VERSION=${{ steps.metadata.outputs.app_version }}
-          --build-arg COMMIT_SHA=${{ github.sha }}
-          --label org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
-          --label org.opencontainers.image.revision=${{ github.sha }}
-          --label org.opencontainers.image.version=${{ steps.metadata.outputs.app_version }}
-          --label org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-          --tag ${{ steps.metadata.outputs.server_local_tag }}
-          .
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          load: true
+          tags: ${{ steps.metadata.outputs.server_local_tag }}
+          build-args: |
+            APP_VERSION=${{ steps.metadata.outputs.app_version }}
+            COMMIT_SHA=${{ github.sha }}
+          labels: |
+            org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.metadata.outputs.app_version }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+          cache-from: type=gha,scope=server
+          cache-to: type=gha,mode=max,scope=server,ignore-error=true
+
+      - name: Verify server image
+        run: docker image inspect "${{ steps.metadata.outputs.server_local_tag }}" >/dev/null
+
+      - name: Download Dokka site artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dokka-site
+          path: build/documentation/html
+
+      - name: Verify Dokka artifact
+        run: test -f build/documentation/html/index.html
 
       - name: Build Dokka image
-        run: |
-          chmod +x ./gradlew
-          ./gradlew dokkaGenerate --stacktrace
-          docker build \
-            -f Dockerfile.dokka \
-            --label org.opencontainers.image.created=${{ steps.metadata.outputs.created }} \
-            --label org.opencontainers.image.revision=${{ github.sha }} \
-            --label org.opencontainers.image.version=${{ steps.metadata.outputs.app_version }} \
-            --label org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }} \
-            --tag ${{ steps.metadata.outputs.dokka_local_tag }} \
-            .
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.dokka
+          load: true
+          tags: ${{ steps.metadata.outputs.dokka_local_tag }}
+          labels: |
+            org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.metadata.outputs.app_version }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+          cache-from: type=gha,scope=dokka
+          cache-to: type=gha,mode=max,scope=dokka,ignore-error=true
+
+      - name: Verify Dokka image
+        run: docker image inspect "${{ steps.metadata.outputs.dokka_local_tag }}" >/dev/null
 
       - name: Log in to GHCR
         uses: docker/login-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,3 @@
-FROM eclipse-temurin:25-jdk AS builder
-
-WORKDIR /workspace
-
-COPY gradle/ gradle/
-COPY gradlew settings.gradle.kts build.gradle.kts gradle.properties ./
-COPY shared/build.gradle.kts shared/build.gradle.kts
-COPY server/build.gradle.kts server/build.gradle.kts
-
-RUN sed -i '/include(":app")/d' settings.gradle.kts && \
-    sed -i '/include(":e2e")/d' settings.gradle.kts && \
-    sed -i 's/\r$//' ./gradlew && \
-    chmod +x ./gradlew
-
-RUN ./gradlew --no-daemon :server:dependencies
-
-COPY shared/src/ shared/src/
-COPY server/src/ server/src/
-
-RUN ./gradlew --no-daemon :server:installDist
-
 FROM eclipse-temurin:25-jre AS runtime
 
 ARG APP_VERSION=dev
@@ -34,8 +13,9 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends curl && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /workspace/server/build/install/server/ ./
+COPY server/build/install/server/ ./
 
+RUN chmod +x bin/server
 RUN groupadd --system appuser && useradd --system --gid appuser --create-home --home-dir /home/appuser appuser
 RUN chown -R appuser:appuser /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,21 @@ FROM eclipse-temurin:25-jdk AS builder
 
 WORKDIR /workspace
 
-COPY . .
+COPY gradle/ gradle/
+COPY gradlew settings.gradle.kts build.gradle.kts gradle.properties ./
+COPY shared/build.gradle.kts shared/build.gradle.kts
+COPY server/build.gradle.kts server/build.gradle.kts
 
 RUN sed -i '/include(":app")/d' settings.gradle.kts && \
     sed -i '/include(":e2e")/d' settings.gradle.kts && \
     sed -i 's/\r$//' ./gradlew && \
     chmod +x ./gradlew
+
+RUN ./gradlew --no-daemon :server:dependencies
+
+COPY shared/src/ shared/src/
+COPY server/src/ server/src/
+
 RUN ./gradlew --no-daemon :server:installDist
 
 FROM eclipse-temurin:25-jre AS runtime

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.caching=true
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true

--- a/server/README.md
+++ b/server/README.md
@@ -12,7 +12,10 @@ Das Modul `:server` stellt den Ktor-WebSocket-Server, die Lobby-Runtime und die 
 
 Default-Port im Container: `8080`
 
+Aus dem Repo-Root:
+
 ```bash
+./gradlew :server:installDist
 docker build -t se2risiko-server .
 docker run --rm -p 8080:8080 se2risiko-server
 ```
@@ -106,6 +109,7 @@ Für einen lokalen Build ohne GHCR-Pull gibt es zusätzlich `compose.local.yaml`
 ```bash
 export POSTGRES_PASSWORD='<SET_LOCALLY>'
 export DB_PASSWORD='<SET_LOCALLY>'
+./gradlew :server:installDist dokkaGenerate
 docker compose -f compose.yaml -f compose.local.yaml up --build
 ```
 


### PR DESCRIPTION
Replace setup-java/setup-gradle and Android SDK steps across CI jobs with docker/setup-buildx and docker/build-push-action to build and load images via Buildx (with cache-from/cache-to). Download Dokka artifact instead of building it in all PR jobs, add verification steps for built images/artifacts, and remove Android SDK env/caching. Dockerfile updated to enable layered Gradle caching: copy Gradle wrapper/settings and build scripts, prefetch server dependencies, then copy sources. Also enable Gradle build cache via gradle.properties (org.gradle.caching=true). These changes speed up CI image builds and reduce runner setup complexity.