### PR TITLE
docs: add comments

### DIFF
--- a/app/src/main/kotlin/at/aau/pulverfass/app/lobby/GameErrorTextMapper.kt
+++ b/app/src/main/kotlin/at/aau/pulverfass/app/lobby/GameErrorTextMapper.kt
@@ -182,6 +182,12 @@ object GameErrorTextMapper {
                 "In diesem Zug wurde bereits eine Truppenverschiebung genutzt."
         }
 
+    /*
+     * Der Server liefert beim Schummelbonus einen stabilen Fehlercode. Diese
+     * Funktion übersetzt ihn in einen Text, der für Spieler verständlich ist.
+     * Dadurch bleibt die Netzwerklogik technisch sauber, während die App frei
+     * formulieren kann, was im UI angezeigt wird.
+     */
     fun map(error: ClaimCheatReinforcementBonusErrorResponse): String =
         when (error.code) {
             ClaimCheatReinforcementBonusErrorCode.REQUESTER_MISMATCH -> REQUESTER_MISMATCH_TEXT

--- a/app/src/main/kotlin/at/aau/pulverfass/app/lobby/LobbyCommandDispatcher.kt
+++ b/app/src/main/kotlin/at/aau/pulverfass/app/lobby/LobbyCommandDispatcher.kt
@@ -21,6 +21,7 @@ enum class LobbyCommandKey {
     TURN_ADVANCE,
     PLACE_REINFORCEMENTS,
     CLAIM_CHEAT_REINFORCEMENT_BONUS,
+
     /*
      * Eigener Pending-Key für Cheat-Meldungen. Dadurch kann die UI genau diesen
      * Button sperren, ohne andere Spielaktionen unnötig zu blockieren.

--- a/app/src/main/kotlin/at/aau/pulverfass/app/lobby/LobbyCommandDispatcher.kt
+++ b/app/src/main/kotlin/at/aau/pulverfass/app/lobby/LobbyCommandDispatcher.kt
@@ -21,6 +21,10 @@ enum class LobbyCommandKey {
     TURN_ADVANCE,
     PLACE_REINFORCEMENTS,
     CLAIM_CHEAT_REINFORCEMENT_BONUS,
+    /*
+     * Eigener Pending-Key für Cheat-Meldungen. Dadurch kann die UI genau diesen
+     * Button sperren, ohne andere Spielaktionen unnötig zu blockieren.
+     */
     REPORT_CHEAT,
     CONFIRM_REINFORCEMENTS_DONE,
     TRADE_IN_CARDS,

--- a/app/src/main/kotlin/at/aau/pulverfass/app/lobby/LobbyController.kt
+++ b/app/src/main/kotlin/at/aau/pulverfass/app/lobby/LobbyController.kt
@@ -974,6 +974,11 @@ class LobbyController(
         val snapshot = state.value
         val lobbyCode = snapshot.activeLobbyCode
         val playerId = snapshot.ownPlayerId
+        /*
+         * Die App prüft zuerst den lokalen Zustand, damit offensichtliche Fehler
+         * sofort im UI landen und nicht unnötig über das Netzwerk gehen. Der
+         * Server prüft dieselben Regeln später trotzdem noch einmal verbindlich.
+         */
         if (lobbyCode == null || playerId == null) {
             _state.update { it.copy(errorText = config.errorPlayerIdMissing) }
             return
@@ -984,6 +989,11 @@ class LobbyController(
         }
 
         scope.launch {
+            /*
+             * keepPendingUntilResponse sorgt dafür, dass der Cheat-Button nicht
+             * mehrfach gedrückt werden kann, während die Serverantwort noch
+             * unterwegs ist.
+             */
             sendCommand(
                 command =
                     LobbyCommand(
@@ -1007,6 +1017,11 @@ class LobbyController(
         val snapshot = state.value
         val lobbyCode = snapshot.activeLobbyCode
         val reporterPlayerId = snapshot.ownPlayerId
+        /*
+         * Für die Meldung braucht die App beide Identitäten:
+         * - activeLobbyCode sagt dem Server, in welcher Lobby geprüft wird.
+         * - ownPlayerId ist der Reporter und muss zur WebSocket-Connection passen.
+         */
         if (lobbyCode == null || reporterPlayerId == null) {
             _state.update { it.copy(errorText = config.errorPlayerIdMissing) }
             return
@@ -1021,6 +1036,11 @@ class LobbyController(
         }
 
         scope.launch {
+            /*
+             * Alte Meldungstexte werden vor dem neuen Request gelöscht. Sonst
+             * könnte während eines neuen Pending-Requests noch das Ergebnis der
+             * vorherigen Meldung sichtbar sein.
+             */
             _state.update { it.copy(cheatReportNoticeText = null) }
             /*
              * Die App schickt nur, wer wen meldet. Ob die Meldung stimmt,
@@ -2147,6 +2167,11 @@ class LobbyController(
             }
             is ReportCheatResponse -> {
                 clearPendingCommand(LobbyCommandKey.REPORT_CHEAT)
+                /*
+                 * Eine ReportCheatResponse bedeutet: Der Server konnte den Report
+                 * auswerten. Das Ergebnis kann trotzdem negativ sein, denn eine
+                 * falsche Verdächtigung ist ein gültiger Spielzug mit Strafe.
+                 */
                 val reportNotice =
                     if (payload.correct) {
                         "Deine Meldung war korrekt. Du erhältst in deiner nächsten " +
@@ -2165,6 +2190,11 @@ class LobbyController(
             }
             is ReportCheatErrorResponse -> {
                 clearPendingCommand(LobbyCommandKey.REPORT_CHEAT)
+                /*
+                 * Eine ErrorResponse bedeutet nicht "falsch verdächtigt", sondern
+                 * "die Meldung war formal ungültig", z.B. Selbstmeldung oder
+                 * falscher Reporter zur Connection.
+                 */
                 updateGameError(payload.reason)
             }
             is JoinLobbyErrorResponse -> {

--- a/app/src/main/kotlin/at/aau/pulverfass/app/lobby/LobbyUiState.kt
+++ b/app/src/main/kotlin/at/aau/pulverfass/app/lobby/LobbyUiState.kt
@@ -37,6 +37,11 @@ data class LobbyUiState(
     val autoAttackEnabled: Boolean = false,
     val characterSelectError: String? = null,
     val autoPhaseNoticeText: String? = null,
+    /*
+     * Kurze Ergebnis-Rückmeldung nach einer Cheat-Meldung. Sie liegt im
+     * LobbyUiState, obwohl sie im GameScreen angezeigt wird, weil die Antwort
+     * als Netzwerkpayload im LobbyController ankommt.
+     */
     val cheatReportNoticeText: String? = null,
     val autoPhaseNoticeQueue: List<String> = emptyList(),
 )

--- a/app/src/main/kotlin/at/aau/pulverfass/app/ui/screens/GameScreen.kt
+++ b/app/src/main/kotlin/at/aau/pulverfass/app/ui/screens/GameScreen.kt
@@ -145,9 +145,19 @@ private val CardsSidebarWidth = SidebarWidth
 private const val SYNC_FEEDBACK_DELAY_MILLIS = 500L
 private const val DISCONNECT_FEEDBACK_DELAY_MILLIS = 900L
 private const val AUTO_PHASE_NOTICE_DURATION_MILLIS = 2_000L
+/*
+ * Die Cheat-Meldung bleibt länger sichtbar als die automatische Phasenmeldung,
+ * weil sie eine echte Spielkonsequenz erklärt: Bonus, Malus oder Strafe in der
+ * nächsten Verstärkungsphase.
+ */
 private const val CHEAT_REPORT_NOTICE_DURATION_MILLIS = 4_000L
 private const val COUNTDOWN_STEP_MILLIS = 1_000L
 private const val COUNTDOWN_ZERO_MILLIS = 450L
+/*
+ * Für den Lichtsensor-Cheat wird nicht nur "dunkel" geprüft, sondern ein Wechsel
+ * von hell nach dunkel. Dadurch lösen normale niedrige Raumhelligkeit oder ein
+ * schon verdeckter Sensor beim Start des Screens nicht sofort den Bonus aus.
+ */
 private const val CHEAT_LIGHT_BASELINE_LUX = 8f
 private const val CHEAT_LIGHT_COVERED_LUX = 5f
 
@@ -891,6 +901,10 @@ private fun CheatReportNoticeOverlay(
     if (message == null) return
 
     LaunchedEffect(message) {
+        /*
+         * Das Overlay räumt sich selbst wieder weg. Der Text kommt aus dem
+         * LobbyController, weil dort die Serverantwort verarbeitet wird.
+         */
         delay(CHEAT_REPORT_NOTICE_DURATION_MILLIS)
         onDismiss()
     }
@@ -1004,7 +1018,9 @@ private fun OptionsOverlay(
         Spacer(modifier = Modifier.height(8.dp))
         /*
          * Die Meldefunktion liegt in den Optionen, weil sie nur selten gebraucht wird.
-         * So bleibt die Karte frei für die normalen Spielaktionen.
+         * So bleibt die Karte frei für die normalen Spielaktionen. Außerdem wird
+         * sie nur aktiviert, wenn es überhaupt einen anderen Spieler gibt und
+         * gerade keine Meldung auf Serverantwort wartet.
          */
         MainButton(
             text = "CHEAT MELDEN",
@@ -1019,6 +1035,8 @@ private fun OptionsOverlay(
             /*
              * Erst nach dem Klick auf "CHEAT MELDEN" zeige ich die Spielerliste an.
              * Dadurch nimmt die Funktion im normalen Optionsmenü wenig Platz weg.
+             * Der eigene Spieler wurde vorher aus reportablePlayers entfernt,
+             * damit Selbstmeldungen gar nicht erst auswählbar sind.
              */
             Text(
                 text = "SPIELER AUSWÄHLEN",
@@ -1306,6 +1324,11 @@ private fun LightSensorCheatTrigger(
         previousLux = null
         var triggered = false
 
+        /*
+         * Der Sensor wird nur registriert, solange der Cheat gerade fachlich
+         * erlaubt ist. Sobald die Phase wechselt oder der Spieler nicht mehr am
+         * Zug ist, räumt DisposableEffect den Listener wieder auf.
+         */
         val sensorManager =
             context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
         val lightSensor = sensorManager.getDefaultSensor(Sensor.TYPE_LIGHT)
@@ -1321,6 +1344,11 @@ private fun LightSensorCheatTrigger(
                     val wasBright = previousLux?.let { it >= CHEAT_LIGHT_BASELINE_LUX } ?: false
                     val isCovered = lux <= CHEAT_LIGHT_COVERED_LUX
 
+                    /*
+                     * Der Bonus wird nur einmal pro Aktivierung ausgelöst. Danach
+                     * bleibt triggered=true, bis der Effekt durch enabled/context
+                     * neu gestartet wird.
+                     */
                     if (wasBright && isCovered && !triggered) {
                         triggered = true
                         currentOnTriggered.value()

--- a/app/src/main/kotlin/at/aau/pulverfass/app/ui/screens/GameScreen.kt
+++ b/app/src/main/kotlin/at/aau/pulverfass/app/ui/screens/GameScreen.kt
@@ -145,6 +145,7 @@ private val CardsSidebarWidth = SidebarWidth
 private const val SYNC_FEEDBACK_DELAY_MILLIS = 500L
 private const val DISCONNECT_FEEDBACK_DELAY_MILLIS = 900L
 private const val AUTO_PHASE_NOTICE_DURATION_MILLIS = 2_000L
+
 /*
  * Die Cheat-Meldung bleibt länger sichtbar als die automatische Phasenmeldung,
  * weil sie eine echte Spielkonsequenz erklärt: Bonus, Malus oder Strafe in der
@@ -153,6 +154,7 @@ private const val AUTO_PHASE_NOTICE_DURATION_MILLIS = 2_000L
 private const val CHEAT_REPORT_NOTICE_DURATION_MILLIS = 4_000L
 private const val COUNTDOWN_STEP_MILLIS = 1_000L
 private const val COUNTDOWN_ZERO_MILLIS = 450L
+
 /*
  * Für den Lichtsensor-Cheat wird nicht nur "dunkel" geprüft, sondern ein Wechsel
  * von hell nach dunkel. Dadurch lösen normale niedrige Raumhelligkeit oder ein

--- a/app/src/test/kotlin/at/aau/pulverfass/app/lobby/GameErrorTextMapperTest.kt
+++ b/app/src/test/kotlin/at/aau/pulverfass/app/lobby/GameErrorTextMapperTest.kt
@@ -381,6 +381,11 @@ class GameErrorTextMapperTest {
 
     @Test
     fun `cheat reinforcement bonus errors are translated for UI`() {
+        /*
+         * Der Server liefert technische Fehlercodes. Dieser Test stellt sicher,
+         * dass jeder Cheatbonus-Fehler einen verständlichen UI-Text bekommt und
+         * nicht als roher Servertext beim Spieler landet.
+         */
         val messages =
             ClaimCheatReinforcementBonusErrorCode.entries.associateWith { code ->
                 GameErrorTextMapper.map(ClaimCheatReinforcementBonusErrorResponse(code, "raw"))

--- a/app/src/test/kotlin/at/aau/pulverfass/app/lobby/LobbyControllerTest.kt
+++ b/app/src/test/kotlin/at/aau/pulverfass/app/lobby/LobbyControllerTest.kt
@@ -1041,6 +1041,11 @@ class LobbyControllerTest {
 
     @Test
     fun `reinforcement actions require a local player context`() {
+        /*
+         * Ohne ownPlayerId kann der Controller keine spielbezogenen Requests
+         * sinnvoll adressieren. Der Test stellt sicher, dass diese Fehler lokal
+         * abgefangen werden, statt kaputte Payloads an den Server zu schicken.
+         */
         val config = LobbyControllerConfig()
         val controller = createController(config = config)
         try {
@@ -1075,6 +1080,13 @@ class LobbyControllerTest {
     @Test
     fun `report cheat response should show result notice`() {
         runBlocking {
+            /*
+             * Dieser Test deckt die App-Seite der Cheat-Meldung ab:
+             * - Selbstmeldung wird lokal blockiert.
+             * - Korrekte Serverantwort erzeugt einen positiven Hinweis.
+             * - Falsche Serverantwort erzeugt einen Malus-Hinweis.
+             * - Formale Serverfehler landen als errorText.
+             */
             val lobbyCode = LobbyCode("RC42")
             val playerId = PlayerId(1)
             val accusedPlayerId = PlayerId(2)

--- a/app/src/testDebug/kotlin/at/aau/pulverfass/app/ui/screens/ScreenComposableTest.kt
+++ b/app/src/testDebug/kotlin/at/aau/pulverfass/app/ui/screens/ScreenComposableTest.kt
@@ -354,6 +354,11 @@ class ScreenComposableTest {
 
     @Test
     fun game_screen_shows_cheat_report_notice_for_four_seconds() {
+        /*
+         * Das Overlay soll nicht sofort verschwinden: Die Meldung erklärt eine
+         * spätere Konsequenz im Spiel. Mit deaktivierter Auto-Advance-Clock kann
+         * der Test exakt prüfen, dass es nach ca. vier Sekunden geschlossen wird.
+         */
         composeTestRule.mainClock.autoAdvance = false
         var dismissed = false
         val noticeText =
@@ -405,6 +410,11 @@ class ScreenComposableTest {
 
     @Test
     fun game_screen_options_reports_selected_cheat_player() {
+        /*
+         * Dieser UI-Test prüft nicht die Serverlogik, sondern nur die Bedienung:
+         * Optionsmenü öffnen, "CHEAT MELDEN" anklicken, Gegner auswählen und
+         * sicherstellen, dass dessen PlayerId an den Callback geht.
+         */
         val localPlayerId = PlayerId(1)
         val accusedPlayerId = PlayerId(2)
         var reportedPlayerId: PlayerId? = null

--- a/server/src/main/kotlin/at/aau/pulverfass/server/persistence/LobbyPersistenceGateway.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/persistence/LobbyPersistenceGateway.kt
@@ -344,6 +344,11 @@ private fun LobbyEvent.toPersistedPayload(): PersistedEventPayload =
                 "playerId" to playerId.value,
                 "delta" to delta,
             )
+        /*
+         * Der verbrauchte Cheatbonus muss im Eventlog landen. Sonst könnte ein
+         * Spieler nach einem Server-Neustart denselben einmaligen Bonus erneut
+         * benutzen, obwohl der GameState ihn vor dem Neustart schon verbraucht hatte.
+         */
         is CheatReinforcementBonusUsedEvent ->
             persistedPayload(
                 type = "cheat_reinforcement_bonus_used",

--- a/server/src/main/kotlin/at/aau/pulverfass/server/persistence/LobbyRecoveryLoader.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/persistence/LobbyRecoveryLoader.kt
@@ -551,6 +551,11 @@ internal fun PersistedLobbyEventRecord.toLobbyEvent(): LobbyEvent {
                 playerId = PlayerId(jsonObject.long("playerId")),
                 delta = jsonObject.int("delta"),
             )
+        /*
+         * Beim Wiederherstellen der Lobby wird aus dem persistierten Typ wieder
+         * dasselbe Domain-Event gebaut. Der Reducer setzt daraus erneut
+         * usedCheatReinforcementBonusByPlayer im GameState.
+         */
         "cheat_reinforcement_bonus_used" ->
             CheatReinforcementBonusUsedEvent(
                 lobbyCode = lobbyCode,

--- a/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
@@ -195,26 +195,59 @@ class MainServerLobbyRoutingService(
         const val CHARACTER_ALREADY_ASSIGNED_ERROR_CODE = "CHARACTER_ALREADY_ASSIGNED"
         const val PLAYER_CONTEXT_MISSING_ERROR_CODE = "PLAYER_CONTEXT_MISSING"
         const val ATTACK_AUTO_ADVANCE_DELAY_MILLIS = 2_500L
+        /*
+         * Cheat-Meldungen haben nur ein kurzes Zeitfenster. Die Idee dahinter:
+         * Andere Spieler sollen den Cheat melden können, sobald er sichtbar wird,
+         * aber niemand soll viele Runden später noch rückwirkend Bonus erhalten.
+         */
         const val CHEAT_REPORT_WINDOW_MILLIS = 20_000L
         const val CHEAT_REPORT_REWARD = 3
         const val CHEAT_REPORT_PENALTY = -3
     }
 
+    /**
+     * Serverinterner Marker für ein offenes Meldefenster.
+     *
+     * Es wird nur der Ablaufzeitpunkt gespeichert. Ein eigener Timer wäre hier
+     * unnötig, weil erst beim Eintreffen einer Meldung geprüft werden muss, ob
+     * das Fenster noch gültig ist.
+     */
     private data class CheatReportWindow(
         val expiresAtMillis: Long,
     )
 
+    /**
+     * Eindeutiger Schlüssel für "dieser Reporter hat diesen konkreten Cheat
+     * schon gemeldet".
+     *
+     * Das Ablaufdatum ist Teil des Schlüssels, damit ein Spieler denselben
+     * Cheater in einer späteren Runde wieder melden darf, falls ein neues
+     * Meldefenster geöffnet wurde.
+     */
     private data class CheatReportKey(
         val reporterPlayerId: PlayerId,
         val accusedPlayerId: PlayerId,
         val expiresAtMillis: Long,
     )
 
+    /**
+     * Ergebnis der serverseitigen Auswertung einer Cheat-Meldung.
+     *
+     * [correct] steuert die UI-Rückmeldung. [modifierDelta] ist der konkrete
+     * Bonus oder Malus, der für die nächste Verstärkungsphase des Reporters
+     * vorgemerkt wird.
+     */
     private data class CheatReportResult(
         val correct: Boolean,
         val modifierDelta: Int,
     )
 
+    /**
+     * Zusammenfassung aller vorgemerkten Cheat-Folgen für den aktiven Spieler.
+     *
+     * [modifier] betrifft den Reporter einer Meldung. [zeroReinforcements]
+     * betrifft den Spieler, der korrekt beim Cheaten erwischt wurde.
+     */
     private data class CheatReinforcementAdjustment(
         val modifier: Int,
         val zeroReinforcements: Boolean,
@@ -240,6 +273,8 @@ class MainServerLobbyRoutingService(
     /*
      * Die Cheat-Meldelogik bleibt auf dem Server.
      * Die App darf nur melden, aber nicht selbst entscheiden, ob die Meldung stimmt.
+     * Alle zugehörigen Maps werden gemeinsam unter diesem Lock verändert, damit
+     * parallele Reports keine doppelten oder widersprüchlichen Boni erzeugen.
      */
     private val cheatReportLock = Any()
 
@@ -948,6 +983,12 @@ class MainServerLobbyRoutingService(
         val payload = request.payload as ClaimCheatReinforcementBonusRequest
 
         runCatching {
+            /*
+             * Hier wird aus dem App-Signal ("Lichtsensor-Cheat wurde ausgelöst")
+             * ein serverautoritativer Spielzug. Der Server baut zuerst die Domain-
+             * Events und spielt sie in die Lobby ein. Erst danach antwortet er dem
+             * Client mit Erfolg.
+             */
             val events = buildClaimCheatReinforcementBonusEvents(request, payload)
             lobbyManager.submitAll(payload.lobbyCode, events, request.context)
             /*
@@ -994,6 +1035,12 @@ class MainServerLobbyRoutingService(
         val payload = request.payload as ReportCheatRequest
 
         runCatching {
+            /*
+             * Die Identitätsprüfung ist hier besonders wichtig: Ein Client darf
+             * nicht im Namen eines anderen Spielers melden. Die Connection wurde
+             * vorher einem PlayerId-Kontext zugeordnet, und genau dieser Kontext
+             * muss zur reporterPlayerId im Request passen.
+             */
             val lobby =
                 lobbyManager.getLobby(payload.lobbyCode)
                     ?: throw IllegalStateException("GAME_NOT_FOUND")
@@ -1012,6 +1059,11 @@ class MainServerLobbyRoutingService(
             }
             require(payload.reporterPlayerId != payload.accusedPlayerId) { "SELF_REPORT" }
 
+            /*
+             * Ab hier ist die Meldung formal gültig. Ob sie inhaltlich stimmt,
+             * entscheidet resolveCheatReport ausschließlich über das serverseitig
+             * gespeicherte Meldefenster.
+             */
             val result =
                 resolveCheatReport(
                     lobbyCode = payload.lobbyCode,
@@ -1269,8 +1321,10 @@ class MainServerLobbyRoutingService(
             synchronized(cheatReportLock) {
                 val activePlayerId = currentTurnState.activePlayerId
                 /*
-                 * Die gespeicherten Folgen einer Meldung werden hier verbraucht.
-                 * Danach wirken sie nicht versehentlich in einer späteren Runde noch einmal.
+                 * Die gespeicherten Folgen von Cheat-Meldungen werden genau beim
+                 * Start der nächsten Reinforcements-Phase verbraucht. Danach
+                 * werden sie sofort aus den Maps entfernt, damit ein Bonus oder
+                 * Malus nie versehentlich in einer späteren Runde erneut wirkt.
                  */
                 val modifiers = nextReinforcementModifierByLobby[lobbyCode]
                 val modifier = modifiers?.remove(activePlayerId) ?: 0
@@ -1294,6 +1348,10 @@ class MainServerLobbyRoutingService(
             /*
              * Die Cheater-Strafe ist stärker als ein möglicher Bonus oder Malus:
              * In dieser Verstärkungsphase soll der Spieler wirklich bei 0 landen.
+             * Darum wird zuerst der normale Basispool gesetzt und danach komplett
+             * wieder abgezogen. So bleibt der Ablauf für alle Clients derselbe:
+             * Sie sehen normale PendingReinforcement-Events und brauchen keine
+             * Sonderlogik für "Cheater bekommt 0".
              */
             if (breakdown.total > 0) {
                 lobbyManager.submit(
@@ -1311,6 +1369,9 @@ class MainServerLobbyRoutingService(
         /*
          * Der Malus darf den Verstärkungspool nicht negativ machen.
          * Falls ein Spieler weniger als 3 Verstärkungen bekommt, wird der Malus begrenzt.
+         * Beispiel: Hat jemand nur 2 Basisverstärkungen und bekommt -3, werden
+         * effektiv nur -2 angewendet. Der Pending-Pool endet also bei 0 und nicht
+         * bei einem fachlich sinnlosen negativen Wert.
          */
         val appliedModifier = adjustment.modifier.coerceAtLeast(-breakdown.total)
         if (appliedModifier != 0) {
@@ -2227,6 +2288,16 @@ class MainServerLobbyRoutingService(
             state.resolvedTurnState
                 ?: throw IllegalArgumentException("NOT_ACTIVE_PLAYER")
 
+        /*
+         * Auch wenn der Client den Cheatbutton nur in der passenden Situation
+         * anzeigen soll, vertraut der Server nie auf die UI. Hier werden deshalb
+         * alle fachlichen Voraussetzungen noch einmal geprüft:
+         * - Die Connection muss wirklich zum Spieler gehören.
+         * - Der Spieler muss aktiv am Match teilnehmen.
+         * - Er muss am Zug und in der Reinforcements-Phase sein.
+         * - Ein Pflicht-Kartentausch darf den Verstärkungszug nicht blockieren.
+         * - Der einmalige Bonus darf noch nicht verbraucht sein.
+         */
         require(!(contextPlayerId == null || contextPlayerId != payload.playerId)) {
             "REQUESTER_MISMATCH"
         }
@@ -2317,6 +2388,16 @@ class MainServerLobbyRoutingService(
             "ALREADY_USED"
         }
 
+        /*
+         * Der Bonus besteht bewusst aus zwei getrennten Events:
+         * 1. CheatReinforcementBonusUsedEvent merkt dauerhaft, dass der Spieler
+         *    seinen einmaligen Bonus verbraucht hat.
+         * 2. PendingReinforcementsChangedEvent erhöht den aktuellen Pool um 3.
+         *
+         * Dadurch bleibt das Eventlog verständlich und replaybar. Beim
+         * Nachspielen kann man genau sehen, warum der Spieler später nicht noch
+         * einmal cheaten darf und wo die zusätzlichen Truppen herkommen.
+         */
         return listOf(
             CheatReinforcementBonusUsedEvent(
                 lobbyCode = payload.lobbyCode,
@@ -2412,6 +2493,8 @@ class MainServerLobbyRoutingService(
                 /*
                  * Dieser Schlüssel enthält auch das Ablaufdatum des Fensters.
                  * Bei einem späteren Cheat desselben Spielers ist es dadurch wieder eine neue Meldung.
+                 * Ohne expiresAtMillis im Schlüssel würde ein Reporter denselben
+                 * Spieler nur ein einziges Mal im ganzen Match melden können.
                  */
             }
 
@@ -2419,6 +2502,11 @@ class MainServerLobbyRoutingService(
              * Korrekte Meldung: +3 für den Melder und 0 Truppen für den Cheater
              * in dessen nächster Verstärkungsphase.
              * Falsche Meldung: -3 für den meldenden Spieler.
+             *
+             * Wichtig: Auch falsche Meldungen sind kein Routingfehler. Sie sind
+             * spielerisch erlaubt, haben aber als Risiko den Malus. Nur formale
+             * Fehler wie Selbstmeldung oder falsche Connection landen in
+             * ReportCheatErrorResponse.
              */
             val modifierDelta =
                 if (correct) {

--- a/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
+++ b/server/src/main/kotlin/at/aau/pulverfass/server/routing/MainServerLobbyRoutingService.kt
@@ -195,6 +195,7 @@ class MainServerLobbyRoutingService(
         const val CHARACTER_ALREADY_ASSIGNED_ERROR_CODE = "CHARACTER_ALREADY_ASSIGNED"
         const val PLAYER_CONTEXT_MISSING_ERROR_CODE = "PLAYER_CONTEXT_MISSING"
         const val ATTACK_AUTO_ADVANCE_DELAY_MILLIS = 2_500L
+
         /*
          * Cheat-Meldungen haben nur ein kurzes Zeitfenster. Die Idee dahinter:
          * Andere Spieler sollen den Cheat melden können, sobald er sichtbar wird,

--- a/server/src/test/kotlin/at/aau/pulverfass/server/ClaimCheatReinforcementBonusIntegrationTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/ClaimCheatReinforcementBonusIntegrationTest.kt
@@ -49,6 +49,14 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.util.concurrent.ConcurrentHashMap
 
+/**
+ * Integrationstests für den kompletten Serverpfad des Cheatbonus.
+ *
+ * Diese Tests gehen bewusst über WebSocket-Pakete und nicht direkt über private
+ * Methoden. Damit wird derselbe Weg geprüft, den ein echter Android-Client geht:
+ * Payload kodieren, Server routen lassen, Domain-Events anwenden und Antwort
+ * wieder als Netzwerkpayload empfangen.
+ */
 class ClaimCheatReinforcementBonusIntegrationTest {
     @Test
     fun `valid request grants three pending reinforcements and marks bonus as used`() =
@@ -157,6 +165,13 @@ class ClaimCheatReinforcementBonusIntegrationTest {
     @Test
     fun `correct cheat report rewards reporter and zeroes cheater reinforcements`() =
         testApplication {
+            /*
+             * Hauptszenario der Meldefunktion:
+             * 1. Spieler 1 nutzt den Cheatbonus.
+             * 2. Die zusätzlichen Truppen werden sichtbar platziert.
+             * 3. Spieler 2 meldet rechtzeitig.
+             * 4. Spieler 2 bekommt später +3, Spieler 1 bekommt später 0.
+             */
             val lobbyCode = LobbyCode("CHR1")
             val playerOne = PlayerId(1)
             val playerTwo = PlayerId(2)
@@ -348,6 +363,12 @@ class ClaimCheatReinforcementBonusIntegrationTest {
     @Test
     fun `reporting cheat before visible reinforcement placement penalizes reporter`() =
         testApplication {
+            /*
+             * Der Cheat ist direkt nach dem Claim noch nicht sichtbar. Dieser Test
+             * beweist, dass das Meldefenster erst nach der ersten Platzierung der
+             * zusätzlichen Truppen geöffnet wird. Wer vorher meldet, liegt falsch
+             * und bekommt den -3-Malus.
+             */
             val lobbyCode = LobbyCode("CHR3")
             val playerOne = PlayerId(1)
             val playerTwo = PlayerId(2)
@@ -470,6 +491,10 @@ class ClaimCheatReinforcementBonusIntegrationTest {
     @Test
     fun `reporting player without open cheat window penalizes reporter`() =
         testApplication {
+            /*
+             * Falschmeldung ohne offenen Cheat: Der Server behandelt das nicht als
+             * technischen Fehler, sondern als gültige falsche Meldung mit Malus.
+             */
             val lobbyCode = LobbyCode("CHR2")
             val playerOne = PlayerId(1)
             val playerTwo = PlayerId(2)

--- a/server/src/test/kotlin/at/aau/pulverfass/server/persistence/LobbyPersistenceGatewayUnitTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/persistence/LobbyPersistenceGatewayUnitTest.kt
@@ -81,6 +81,11 @@ class LobbyPersistenceGatewayUnitTest {
                     "pending_reinforcements_set",
                 PendingReinforcementsChangedEvent(lobbyCode, hostId, delta = -2) to
                     "pending_reinforcements_changed",
+                /*
+                 * Der verbrauchte Cheatbonus muss denselben Weg gehen wie alle
+                 * anderen Domain-Events, damit Recovery später den korrekten
+                 * GameState wiederherstellen kann.
+                 */
                 CheatReinforcementBonusUsedEvent(lobbyCode, hostId) to
                     "cheat_reinforcement_bonus_used",
                 PlayerCardsRemovedEvent(

--- a/server/src/test/kotlin/at/aau/pulverfass/server/persistence/LobbyRecoveryLoaderTest.kt
+++ b/server/src/test/kotlin/at/aau/pulverfass/server/persistence/LobbyRecoveryLoaderTest.kt
@@ -489,6 +489,11 @@ class LobbyRecoveryLoaderTest {
             ).toLobbyEvent(),
         )
         assertEquals(
+            /*
+             * Recovery muss aus dem Persistenztyp wieder das Domain-Event bauen.
+             * Erst danach kann der Reducer den Spieler wieder als "Bonus bereits
+             * verwendet" markieren.
+             */
             CheatReinforcementBonusUsedEvent(
                 lobbyCode = lobbyCode,
                 playerId = PlayerId(5),

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/event/CheatReinforcementBonusUsedEvent.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/event/CheatReinforcementBonusUsedEvent.kt
@@ -5,6 +5,12 @@ import at.aau.pulverfass.shared.ids.PlayerId
 
 /**
  * Hält fest, dass ein Spieler seinen einmaligen Schummel-Verstärkungsbonus genutzt hat.
+ *
+ * Das Event enthält absichtlich nur die Lobby und den Spieler. Die zusätzlichen
+ * Truppen werden über ein separates PendingReinforcements-Event vergeben. So
+ * bleibt im Eventlog klar unterscheidbar, was passiert ist:
+ * 1. Der Spieler hat den Cheatbonus verbraucht.
+ * 2. Der Verstärkungspool wurde um den Bonuswert erhöht.
  */
 data class CheatReinforcementBonusUsedEvent(
     override val lobbyCode: LobbyCode,

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/reducer/DefaultLobbyEventReducer.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/reducer/DefaultLobbyEventReducer.kt
@@ -627,6 +627,14 @@ class DefaultLobbyEventReducer : LobbyEventReducer {
         state: GameState,
         event: CheatReinforcementBonusUsedEvent,
     ): GameState {
+        /*
+         * Der Reducer speichert nur, dass der Bonus verbraucht wurde.
+         * Die fachliche Prüfung, ob der Spieler gerade aktiv ist, in der
+         * Reinforcements-Phase steht und keinen Pflicht-Kartentausch offen hat,
+         * passiert vorher im Server-Routing. Diese Trennung ist wichtig:
+         * - Routing entscheidet, ob ein Request erlaubt ist.
+         * - Reducer macht aus einem gültigen Event deterministisch neuen State.
+         */
         requireKnownPlayer(state, event.playerId)
         if (event.playerId in state.usedCheatReinforcementBonusByPlayer) {
             throw InvalidLobbyEventException(
@@ -636,6 +644,11 @@ class DefaultLobbyEventReducer : LobbyEventReducer {
         }
 
         return state.copy(
+            /*
+             * Set statt Boolean pro Spieler: So bleibt die Information klein und
+             * lässt sich beim Entfernen eines Spielers einfach wieder aus dem
+             * State herausnehmen.
+             */
             usedCheatReinforcementBonusByPlayer =
                 state.usedCheatReinforcementBonusByPlayer + event.playerId,
         )

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/GameState.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/lobby/state/GameState.kt
@@ -38,7 +38,11 @@ import at.aau.pulverfass.shared.map.config.TerritoryEdgeDefinition
  * @property lastInvalidActionReason zuletzt erkannte ungültige Aktion, falls vorhanden
  * @property territoryCapturedThisTurn signalisiert, ob im aktuellen Zug mindestens ein Gebiet erobert wurde
  * @property usedCheatReinforcementBonusByPlayer Spieler, die ihren einmaligen
- * Schummel-Verstärkungsbonus bereits verwendet haben
+ * Schummel-Verstärkungsbonus bereits verwendet haben. Diese Information liegt
+ * im gemeinsamen Domain-State, weil sowohl Server-Regeln als auch Replays aus
+ * Events eindeutig wissen müssen, ob ein Spieler den Bonus noch benutzen darf.
+ * Die eigentliche Sensor-Auslösung passiert in der App, die Autorität über
+ * "schon benutzt oder nicht" bleibt aber im Spielzustand.
  * @property mapDefinition readonly Definition der Spielmap, falls bereits gesetzt
  * @property territoryStates mutierbarer Laufzeitzustand aller Territorien
  * @property setupTroopsToPlaceByPlayer verbleibende Starttruppen pro Spieler nach der initialen Gebietsverteilung
@@ -128,6 +132,12 @@ data class GameState(
         require(activePlayer == null || players.contains(activePlayer)) {
             "GameState.activePlayer muss Teil der Spielerliste sein."
         }
+        /*
+         * Der Cheatbonus ist an einen echten Lobby-Spieler gebunden. Wenn hier
+         * eine fremde PlayerId erlaubt wäre, könnten spätere Reducer- oder
+         * Routing-Schritte nicht mehr sauber unterscheiden, ob ein Spieler den
+         * Bonus wirklich schon verbraucht hat.
+         */
         require(usedCheatReinforcementBonusByPlayer.all(players::contains)) {
             "GameState.usedCheatReinforcementBonusByPlayer darf nur bekannte Spieler enthalten."
         }

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/codec/NetworkPayloadRegistry.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/codec/NetworkPayloadRegistry.kt
@@ -151,6 +151,11 @@ internal object NetworkPayloadRegistry {
                 MessageType.LOBBY_CHEAT_REINFORCEMENT_BONUS_RESPONSE,
             ClaimCheatReinforcementBonusErrorResponse::class.java to
                 MessageType.LOBBY_CHEAT_REINFORCEMENT_BONUS_ERROR_RESPONSE,
+            /*
+             * Drei Einträge gehören immer zusammen: Request, Erfolgsantwort und
+             * Fehlerantwort. Fehlt einer davon, kann MessageCodec die Payload
+             * entweder nicht typisieren oder nicht wieder dekodieren.
+             */
             ReportCheatRequest::class.java to MessageType.LOBBY_REPORT_CHEAT_REQUEST,
             ReportCheatResponse::class.java to MessageType.LOBBY_REPORT_CHEAT_RESPONSE,
             ReportCheatErrorResponse::class.java to

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/request/ClaimCheatReinforcementBonusRequest.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/request/ClaimCheatReinforcementBonusRequest.kt
@@ -14,6 +14,11 @@ import kotlinx.serialization.encoding.Encoder
 
 /**
  * Anfrage eines Clients, den einmaligen Schummel-Verstärkungsbonus zu beanspruchen.
+ *
+ * Diese Nachricht wird von der Android-App gesendet, wenn der Lichtsensor-Cheat
+ * ausgelöst wurde. Sie enthält nur die Identität der Lobby und des Spielers.
+ * Ob der Request wirklich erlaubt ist, entscheidet der Server anhand des
+ * aktuellen TurnState und des GameState.
  */
 @Serializable(with = ClaimCheatReinforcementBonusRequestSerializer::class)
 data class ClaimCheatReinforcementBonusRequest(
@@ -23,6 +28,12 @@ data class ClaimCheatReinforcementBonusRequest(
 
 object ClaimCheatReinforcementBonusRequestSerializer :
     KSerializer<ClaimCheatReinforcementBonusRequest> {
+    /*
+     * Für diese Nachricht wird ein expliziter Serializer verwendet, damit das
+     * Netzwerkformat stabil bleibt. Das ist bei Client-Server-Protokollen
+     * wichtig: Beide Seiten müssen dieselben Feldnamen und dieselbe Reihenfolge
+     * verstehen, auch wenn intern später Code umgebaut wird.
+     */
     override val descriptor =
         buildClassSerialDescriptor(
             "at.aau.pulverfass.shared.network.message.ClaimCheatReinforcementBonusRequest",

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/request/ReportCheatRequest.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/request/ReportCheatRequest.kt
@@ -7,6 +7,15 @@ import kotlinx.serialization.Serializable
 
 /**
  * Anfrage eines Spielers, einen vermuteten Cheat eines anderen Spielers zu melden.
+ *
+ * Die App sendet hier bewusst keine Begründung und keinen Sensorwert mit. Der
+ * Server entscheidet ausschließlich anhand seines eigenen Meldefensters, ob die
+ * Meldung stimmt. Dadurch kann ein manipulierter Client nicht einfach behaupten,
+ * dass ein anderer Spieler gecheatet hat.
+ *
+ * @property lobbyCode Lobby, in der die Meldung passiert.
+ * @property reporterPlayerId Spieler, der die Meldung abschickt.
+ * @property accusedPlayerId Spieler, der verdächtigt wird.
  */
 @Serializable
 data class ReportCheatRequest(

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/ClaimCheatReinforcementBonusResponse.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/ClaimCheatReinforcementBonusResponse.kt
@@ -13,6 +13,11 @@ import kotlinx.serialization.encoding.Encoder
 
 /**
  * Erfolgsantwort auf das Beanspruchen des einmaligen Schummel-Verstärkungsbonus.
+ *
+ * Die Antwort bestätigt nur, dass der Request angenommen wurde. Die sichtbare
+ * Spieländerung kommt zusätzlich über die normalen Game-State-Events beim
+ * Client an. Dadurch bleibt der Client immer auf dem serverautoritativen
+ * Zustand und muss den Bonus nicht selbst in den lokalen State hineinrechnen.
  */
 @Serializable(with = ClaimCheatReinforcementBonusResponseSerializer::class)
 data class ClaimCheatReinforcementBonusResponse(
@@ -21,6 +26,11 @@ data class ClaimCheatReinforcementBonusResponse(
 
 object ClaimCheatReinforcementBonusResponseSerializer :
     KSerializer<ClaimCheatReinforcementBonusResponse> {
+    /*
+     * Der explizite Serializer hält das Wire-Format der Erfolgsantwort klein
+     * und eindeutig: Es wird nur der LobbyCode übertragen, weil der konkrete
+     * State über die Event-/Snapshot-Schiene synchronisiert wird.
+     */
     override val descriptor =
         buildClassSerialDescriptor(
             "at.aau.pulverfass.shared.network.message.ClaimCheatReinforcementBonusResponse",

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/ReportCheatResponse.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/ReportCheatResponse.kt
@@ -7,6 +7,16 @@ import kotlinx.serialization.Serializable
 
 /**
  * Erfolgsantwort auf eine Cheat-Meldung.
+ *
+ * Erfolgreich bedeutet hier nur: Der Server konnte die Meldung fachlich
+ * auswerten. Ob sie richtig oder falsch war, steht in [correct]. Das ist
+ * Absicht, weil auch eine falsche Meldung ein gültiger Spielzug ist und eine
+ * Strafe für die nächste Verstärkungsphase auslöst.
+ *
+ * @property correct `true`, wenn für den beschuldigten Spieler noch ein gültiges
+ * Cheat-Meldefenster offen war.
+ * @property modifierDelta Bonus oder Malus, der beim meldenden Spieler für die
+ * nächste Reinforcements-Phase vorgemerkt wurde.
  */
 @Serializable
 data class ReportCheatResponse(

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/error/ClaimCheatReinforcementBonusErrorResponse.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/error/ClaimCheatReinforcementBonusErrorResponse.kt
@@ -12,20 +12,36 @@ import kotlinx.serialization.encoding.Encoder
 
 /**
  * Fehlercodes für das Beanspruchen des einmaligen Schummel-Verstärkungsbonus.
+ *
+ * Jeder Code steht für eine fachlich andere Ablehnung. Für die Prüfung ist hier
+ * wichtig: Der Server schickt nicht nur freien Text zurück, sondern einen
+ * maschinenlesbaren Grund. Die App kann daraus gezielt verständliche
+ * Fehlermeldungen bauen.
  */
 @Serializable
 enum class ClaimCheatReinforcementBonusErrorCode {
+    /** Die Connection gehört nicht zu dem Spieler, für den der Request gestellt wurde. */
     REQUESTER_MISMATCH,
+    /** Der Spieler ist gerade nicht am Zug. */
     NOT_ACTIVE_PLAYER,
+    /** Das Spiel wartet gerade auf einen getrennten Spieler. */
     GAME_PAUSED,
+    /** Der Bonus ist nur in der Reinforcements-Phase erlaubt. */
     PHASE_MISMATCH,
+    /** Die angefragte Lobby existiert serverseitig nicht. */
     GAME_NOT_FOUND,
+    /** Der Spieler hat seinen einmaligen Bonus bereits verbraucht. */
     ALREADY_USED,
+    /** Vor weiteren Verstärkungen muss wegen zu vieler Karten ein Trade-In passieren. */
     FORCED_TRADE_REQUIRED,
 }
 
 /**
  * Fehlantwort auf das Beanspruchen des einmaligen Schummel-Verstärkungsbonus.
+ *
+ * `code` ist für Programmlogik und Tests gedacht, `reason` für Logs und UI-nahe
+ * Fehlermeldungen. Diese Trennung macht die Tests stabiler, weil sie den Code
+ * prüfen können, ohne an jeder Formulierung des Textes zu hängen.
  */
 @Serializable(with = ClaimCheatReinforcementBonusErrorResponseSerializer::class)
 data class ClaimCheatReinforcementBonusErrorResponse(

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/error/ClaimCheatReinforcementBonusErrorResponse.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/error/ClaimCheatReinforcementBonusErrorResponse.kt
@@ -22,16 +22,22 @@ import kotlinx.serialization.encoding.Encoder
 enum class ClaimCheatReinforcementBonusErrorCode {
     /** Die Connection gehört nicht zu dem Spieler, für den der Request gestellt wurde. */
     REQUESTER_MISMATCH,
+
     /** Der Spieler ist gerade nicht am Zug. */
     NOT_ACTIVE_PLAYER,
+
     /** Das Spiel wartet gerade auf einen getrennten Spieler. */
     GAME_PAUSED,
+
     /** Der Bonus ist nur in der Reinforcements-Phase erlaubt. */
     PHASE_MISMATCH,
+
     /** Die angefragte Lobby existiert serverseitig nicht. */
     GAME_NOT_FOUND,
+
     /** Der Spieler hat seinen einmaligen Bonus bereits verbraucht. */
     ALREADY_USED,
+
     /** Vor weiteren Verstärkungen muss wegen zu vieler Karten ein Trade-In passieren. */
     FORCED_TRADE_REQUIRED,
 }

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/error/ReportCheatErrorResponse.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/error/ReportCheatErrorResponse.kt
@@ -15,14 +15,19 @@ import kotlinx.serialization.Serializable
 enum class ReportCheatErrorCode {
     /** Die angefragte Lobby existiert serverseitig nicht. */
     GAME_NOT_FOUND,
+
     /** Die Connection passt nicht zum Reporter im Payload. */
     REQUESTER_MISMATCH,
+
     /** Vor Spielstart darf noch niemand gemeldet werden. */
     GAME_NOT_RUNNING,
+
     /** Reporter oder beschuldigter Spieler ist nicht Teil der Lobby. */
     UNKNOWN_PLAYER,
+
     /** Spieler dürfen sich nicht selbst melden. */
     SELF_REPORT,
+
     /** Derselbe Spieler hat denselben offenen Cheat bereits gemeldet. */
     ALREADY_REPORTED,
 }

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/error/ReportCheatErrorResponse.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/lobby/response/error/ReportCheatErrorResponse.kt
@@ -4,20 +4,34 @@ import at.aau.pulverfass.shared.message.protocol.NetworkMessagePayload
 import kotlinx.serialization.Serializable
 
 /**
- * Typisierte Fehlercodes fuer fehlgeschlagene Cheat-Meldungen.
+ * Typisierte Fehlercodes für fehlgeschlagene Cheat-Meldungen.
+ *
+ * Diese Fälle sind keine "falschen Verdächtigungen". Eine falsche Verdächtigung
+ * ist ein gültiger Report und wird mit [ReportCheatResponse.correct] = false
+ * beantwortet. Ein Fehlercode bedeutet dagegen, dass der Report selbst nicht
+ * erlaubt oder technisch nicht auswertbar war.
  */
 @Serializable
 enum class ReportCheatErrorCode {
+    /** Die angefragte Lobby existiert serverseitig nicht. */
     GAME_NOT_FOUND,
+    /** Die Connection passt nicht zum Reporter im Payload. */
     REQUESTER_MISMATCH,
+    /** Vor Spielstart darf noch niemand gemeldet werden. */
     GAME_NOT_RUNNING,
+    /** Reporter oder beschuldigter Spieler ist nicht Teil der Lobby. */
     UNKNOWN_PLAYER,
+    /** Spieler dürfen sich nicht selbst melden. */
     SELF_REPORT,
+    /** Derselbe Spieler hat denselben offenen Cheat bereits gemeldet. */
     ALREADY_REPORTED,
 }
 
 /**
  * Fehlantwort des Servers auf eine nicht erfolgreiche Cheat-Meldung.
+ *
+ * Auch hier gilt: `code` ist der stabile technische Teil, `reason` ist die
+ * erklärende Nachricht für Logs und UI.
  */
 @Serializable
 data class ReportCheatErrorResponse(

--- a/shared/src/main/kotlin/at/aau/pulverfass/shared/message/protocol/MessageType.kt
+++ b/shared/src/main/kotlin/at/aau/pulverfass/shared/message/protocol/MessageType.kt
@@ -124,7 +124,12 @@ enum class MessageType(val id: Int) {
     /** Broadcast, dass ein Spieler einen Charakter gewählt hat. */
     LOBBY_CHARACTER_SELECTED_BROADCAST(84),
 
-    /** Anfrage zum Beanspruchen des einmaligen Schummel-Verstärkungsbonus. */
+    /**
+     * Anfrage zum Beanspruchen des einmaligen Schummel-Verstärkungsbonus.
+     *
+     * Diese IDs müssen stabil bleiben, weil sie im Paket-Header über das
+     * Netzwerk gehen. App und Server müssen also dieselbe Zahl gleich deuten.
+     */
     LOBBY_CHEAT_REINFORCEMENT_BONUS_REQUEST(85),
 
     /** Erfolgsantwort auf das Beanspruchen des einmaligen Schummel-Verstärkungsbonus. */
@@ -136,7 +141,13 @@ enum class MessageType(val id: Int) {
     /** Broadcast des aktuellen Verbindungsstatus eines Lobby-Spielers. */
     LOBBY_CONNECTION_STATUS_UPDATE_BROADCAST(88),
 
-    /** Anfrage, einen mutmasslichen Cheat eines anderen Spielers zu melden. */
+    /**
+     * Anfrage, einen mutmaßlichen Cheat eines anderen Spielers zu melden.
+     *
+     * Der Report ist ein eigener Nachrichtentyp und nicht Teil des
+     * Cheatbonus-Requests, weil er von einem anderen Spieler und zu einem
+     * späteren Zeitpunkt abgeschickt wird.
+     */
     LOBBY_REPORT_CHEAT_REQUEST(89),
 
     /** Erfolgsantwort auf eine Cheat-Meldung. */

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/event/LobbyEventTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/event/LobbyEventTest.kt
@@ -10,6 +10,14 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 
+/**
+ * Smoke-Test für die wichtigsten LobbyEvent-Datenklassen.
+ *
+ * Der Test prüft keine Spiellogik, sondern stellt sicher, dass die Events mit
+ * realistischen Beispielwerten gebaut werden können. Das ist besonders für neue
+ * Events wie CheatReinforcementBonusUsedEvent nützlich, weil sie später im
+ * Reducer und in der Persistenz wiederverwendet werden.
+ */
 class LobbyEventTest {
     @Test
     fun `should instantiate sample lobby events consistently`() {

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/reducer/DefaultLobbyEventReducerTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/reducer/DefaultLobbyEventReducerTest.kt
@@ -55,6 +55,15 @@ import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import kotlin.random.Random
 
+/**
+ * Tests für den Domain-Reducer.
+ *
+ * Der Reducer ist die Stelle, an der aus einem gültigen LobbyEvent ein neuer
+ * GameState entsteht. Für die Prüfung ist die Grundidee wichtig: Regeln wie
+ * "darf der Spieler den Request senden?" liegen im Routing, aber ein bereits
+ * akzeptiertes Event muss hier deterministisch und reproduzierbar angewendet
+ * werden.
+ */
 class DefaultLobbyEventReducerTest {
     private val reducer = DefaultLobbyEventReducer()
 
@@ -1750,6 +1759,10 @@ class DefaultLobbyEventReducerTest {
                 CheatReinforcementBonusUsedEvent(lobbyCode, playerOne),
             )
 
+        /*
+         * Der Reducer trägt den Spieler in das Set der bereits verwendeten
+         * Cheatboni ein. Genau dieses Set verhindert später eine zweite Nutzung.
+         */
         assertEquals(
             setOf(playerOne),
             updated.usedCheatReinforcementBonusByPlayer,
@@ -1773,6 +1786,11 @@ class DefaultLobbyEventReducerTest {
                 CheatReinforcementBonusUsedEvent(lobbyCode, playerOne),
             )
 
+        /*
+         * Auch wenn die Hauptprüfung im Server-Routing sitzt, schützt der Reducer
+         * den State zusätzlich davor, dass dasselbe Event fachlich zweimal
+         * angewendet wird.
+         */
         val exception =
             assertThrows(InvalidLobbyEventException::class.java) {
                 reducer.apply(

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/state/GameStateTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/state/GameStateTest.kt
@@ -21,6 +21,14 @@ import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
+/**
+ * Tests für die Invarianten des zentralen GameState.
+ *
+ * Diese Tests sind wichtig, weil GameState von Server, Reducer und Clients als
+ * gemeinsame Wahrheit gelesen wird. Wenn hier ungültige Kombinationen erlaubt
+ * wären, würden Fehler später an ganz anderen Stellen im Netzwerk- oder UI-Code
+ * auftauchen.
+ */
 class GameStateTest {
     @Test
     fun `should expose consistent initial state`() {

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/state/TerritoryStateTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/lobby/state/TerritoryStateTest.kt
@@ -7,6 +7,14 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 
+/**
+ * Basistests für den Zustand eines einzelnen Territoriums.
+ *
+ * TerritoryState ist klein, aber sehr zentral: Angriffe, Verstärkungen und
+ * Kartenlogik hängen davon ab, wem ein Gebiet gehört und wie viele Truppen dort
+ * stehen. Darum werden auch einfache Randfälle wie "Besitzer mit 0 Truppen"
+ * explizit abgesichert.
+ */
 class TerritoryStateTest {
     @Test
     fun `should expose default territory state`() {

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/ClaimCheatReinforcementBonusMessageTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/ClaimCheatReinforcementBonusMessageTest.kt
@@ -11,6 +11,13 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
+/**
+ * Prüft den reinen Netzwerkvertrag des Schummel-Verstärkungsbonus.
+ *
+ * Diese Tests laufen ohne Server und ohne App-UI. Sie stellen nur sicher, dass
+ * Request, Erfolgsantwort und Fehlerantwort verlustfrei zu JSON serialisiert
+ * und wieder zurückgelesen werden können.
+ */
 class ClaimCheatReinforcementBonusMessageTest {
     private val json = Json
 

--- a/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/ReportCheatMessageTest.kt
+++ b/shared/src/test/kotlin/at/aau/pulverfass/shared/network/message/ReportCheatMessageTest.kt
@@ -11,6 +11,13 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
+/**
+ * Prüft den Netzwerkvertrag für Cheat-Meldungen.
+ *
+ * Besonders wichtig sind hier reporterPlayerId und accusedPlayerId: Beide IDs
+ * müssen über das Netzwerk erhalten bleiben, weil der Server daraus ableitet,
+ * wer meldet und wer beschuldigt wird.
+ */
 class ReportCheatMessageTest {
     private val json = Json
 


### PR DESCRIPTION
## Was wurde geändert?

- Ergänzt ausführliche Kommentare zur Schummelfunktion und zum Melden von Schummeln.
- Erklärt den Ablauf zwischen App, Shared-Protokoll, Server-Routing, Domain-State und Tests.
- Kommentiert zentrale Prüfungsstellen wie:
  - Lichtsensor-Trigger für den Schummelbonus
  - serverseitige Prüfung des einmaligen Bonus
  - Cheat-Meldefenster
  - Bonus/Malus/0-Verstärkungen nach einer Meldung
  - Persistenz und Recovery des verbrauchten Schummelbonus
  - relevante Tests für GameState, Reducer, App, Server und Netzwerkpayloads

## Warum?

Die Kommentare sollen helfen, den Code in der Abgabe und Prüfung besser erklären zu können. 
Es wurde keine Fachlogik verändert.